### PR TITLE
Fix 1Dto2D layer to MDLSTM layer sizes layout issue

### DIFF
--- a/NetworkTwoDLayer.py
+++ b/NetworkTwoDLayer.py
@@ -222,6 +222,9 @@ class TwoDLSTMLayer(TwoDBaseLayer):
     X = source.output
     assert X.ndim == 4
     sizes = source.output_sizes
+    if source.layer_class == "1Dto2D":
+      #sizes has the wrong layout if coming directly from a 1Dto2D layer
+      sizes = sizes.reshape((2, sizes.size // 2)).dimshuffle(1, 0)
     self.output_sizes = sizes
     assert directions in [1,2,4], "only 1, 2 or 4 directions are supported"
     assert projection in ['average', 'concat'], "invalid projection"


### PR DESCRIPTION
If coming from a conv2 layer then sizes is in the right format for the mdlstm layer [[h1,w1],[h2,w2],...] but if coming from s 1Dto2D layer then the sizes are laid out as [[h1,h2,...],[w1,w2,...]] which will results in corrupted output and gradients from the mdlstm layer.