### PR TITLE
Fix output.size_placeholder of SliceLayer and ConvLayer

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -1731,7 +1731,8 @@ class SliceLayer(_ConcatInputLayer):
             tf.shape(self.input_data.placeholder)[self.input_data.time_dim_axis] - slice_end,
             self.output.size_placeholder[self.input_data.time_dim_axis_excluding_batch])
       if slice_step:
-        self.output.size_placeholder[self.input_data.time_dim_axis_excluding_batch] //= slice_step
+        self.output.size_placeholder[self.input_data.time_dim_axis_excluding_batch] = \
+          tf.ceil(tf.divide(self.output.size_placeholder[self.input_data.time_dim_axis_excluding_batch], slice_step))
     elif axis_wo_batch is not None:
       assert axis_wo_batch not in self.output.size_placeholder
     self.output.placeholder = self.input_data.placeholder[slices]

--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -2869,7 +2869,8 @@ class ConvLayer(_ConcatInputLayer):
     if padding == "SAME":
       return ceildiv(in_dim, stride)
     elif padding == "VALID":
-      return ceildiv((in_dim - (filter_size - 1) * dilation_rate), stride)
+      max_func = tf.maximum if isinstance(in_dim, tf.Tensor) else max
+      return max_func(ceildiv((in_dim - (filter_size - 1) * dilation_rate), stride), 0)
     else:
       raise Exception("invalid padding %r" % padding)
 


### PR DESCRIPTION
Fixes two errors in the calculation of the output size in the Slice and Conv Layer.