### PR TITLE
Add linter to the Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ dist: trusty
 # quiet (-qq) to keep log smaller
 # |cat to avoid interactive banner (which blows up the log)
 install:
+  - pip install flake8
   - pip2 install -qq --user --upgrade pip setuptools wheel six | cat  # Python2<->Python3
   - pip2 install --user -r requirements.txt | cat  # need for Python2<->Python3 communication tests
   - pip install -qq --upgrade pip setuptools wheel
@@ -73,6 +74,12 @@ env:
   - TEST=TaskSystem_SharedMem
   - TEST=TheanoUtil
   - TEST=Util
+
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=32 --max-line-length=127 --statistics
 
 # command to run tests
 script:


### PR DESCRIPTION
It's necessary to keep all the code in the same and proper style that satisfy PEP8.