### PR TITLE
fix feature_dim_axis in MergeDimsLayer and WindowLayer

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -2220,6 +2220,8 @@ class WindowLayer(_ConcatInputLayer):
     else:
       axis = data.get_axis_from_description(axis)
     data.shape = data.shape[:axis] + (window_size,) + data.shape[axis:]  # add new axis right after
+    if axis <= data.feature_dim_axis:
+      data.feature_dim_axis += 1
     return data
 
   @classmethod
@@ -2485,6 +2487,8 @@ class MergeDimsLayer(_ConcatInputLayer):
       input_data=input_data, merge_axes=axes, old_axis=input_data.batch_dim_axis)
     data.time_dim_axis = cls._old_axis_to_new_axis(
       input_data=input_data, merge_axes=axes, old_axis=input_data.time_dim_axis)
+    data.feature_dim_axis = cls._old_axis_to_new_axis(
+      input_data=input_data, merge_axes=axes, old_axis=input_data.feature_dim_axis)
     return data
 
 


### PR DESCRIPTION
I think that this is generally needed fix, but I'm not sure if it is the right way to do it (Especially in the WindowLayer)

It seems like in both cases some inconsistencies with the feature_dim_axis occur in the current implementation

@albertz could you take a look?