### PR TITLE
fix: partition_epoch in TranslationDataset

### DIFF
--- a/Dataset.py
+++ b/Dataset.py
@@ -252,7 +252,7 @@ class Dataset(object):
     :return: the order for the given epoch. such that seq_idx -> underlying idx
     :rtype: list[int]
     """
-    partition_epoch = self.partition_epoch
+    partition_epoch = self.partition_epoch or 1
     if not epoch:
       epoch = 1
     full_epoch = epoch


### PR DESCRIPTION
The index offset due to partition_epoch was still added in _get_line_nr(). This is wrong, as partition_epoch is now handled by get_sequence_order_for_epoch() and thus self._seq_order contains only elements for the current sub-epoch.