### PR TITLE
some more misc. fixes

### DIFF
--- a/LmDataset.py
+++ b/LmDataset.py
@@ -877,7 +877,7 @@ class TranslationDataset(CachedDataset2):
       target.vocab.pkl
   """
 
-  MapToDataKeys = {"target": "classes"}  # just by our convention
+  MapToDataKeys = {"source": "data", "target": "classes"}  # just by our convention
   _main_data_key = None
   _main_classes_key = None
 
@@ -909,8 +909,6 @@ class TranslationDataset(CachedDataset2):
       self._main_data_key = "data"
     if self._main_classes_key is None:
       self._main_classes_key = "classes"
-    if "source" not in self.MapToDataKeys.keys():
-      self.MapToDataKeys["source"] = "data"
     self._add_postfix = {self._main_data_key: source_postfix, self._main_classes_key: target_postfix}
     self._keys_to_read = [self._main_data_key, self._main_classes_key]
     self._use_cache_manager = use_cache_manager
@@ -1175,6 +1173,8 @@ class ConfusionNetworkDataset(TranslationDataset):
   can e.g. be used to repeat the confusion net part of the training data without loading it several times.
   """
 
+  MapToDataKeys = {"source": "sparse_inputs", "target": "classes"}
+
   def __init__(self, max_density=20, **kwargs):
     """
     :param str path: the directory containing the files
@@ -1187,7 +1187,6 @@ class ConfusionNetworkDataset(TranslationDataset):
     :param str|None unknown_label: "UNK" or so. if not given, then will not replace unknowns but throw an error
     :param int|12 max_density: the density of the confusion network: max number of arcs per slot
     """
-    self.MapToDataKeys["source"] = "sparse_inputs"
     self._main_data_key = "sparse_inputs"
     self._keys_to_read = ["sparse_inputs", "classes"]
     self.density = max_density
@@ -1209,7 +1208,7 @@ class ConfusionNetworkDataset(TranslationDataset):
     return "int32"  # sparse -> label idx
 
   def get_data_shape(self, key):
-    if key != "classes":
+    if key in ["sparse_inputs", "sparse_weights"]:
       return [self.density]
     return []
 

--- a/MetaDataset.py
+++ b/MetaDataset.py
@@ -165,6 +165,10 @@ class MetaDataset(CachedDataset2):
   def get_target_list(self):
     return self.target_list
 
+  def get_data_shape(self, data_key):
+    dataset_key, dataset_data_key = self.data_map[data_key]
+    return self.datasets[dataset_key].get_data_shape(dataset_data_key)
+
   def get_data_dtype(self, key):
     dtype = self.data_dtypes[key]
     if self.added_data:

--- a/TFEngine.py
+++ b/TFEngine.py
@@ -1792,12 +1792,16 @@ class Engine(object):
       else:
         print("Dataset have_corpus_seq_idx == False, i.e. it will not be sorted for optimal performance.", file=log.v3)
         dataset.seq_ordering = "default"  # enforce order as-is, so that the order in the written file corresponds
+
+    max_seq_length=self.config.typed_value('max_seq_length', None) or self.config.float('max_seq_length', 0)
+    assert not max_seq_length, "Set max_seq_length = 0 for search (i.e. no maximal length). We want to keep all source sentences."
+
     dataset.init_seq_order(epoch=self.epoch)
     batches = dataset.generate_batches(
       recurrent_net=self.network.recurrent,
       batch_size=self.config.int('batch_size', 1),
       max_seqs=self.config.int('max_seqs', -1),
-      max_seq_length=self.config.typed_value('max_seq_length', None) or self.config.float('max_seq_length', 0),
+      max_seq_length=max_seq_length,
       used_data_keys=self.network.used_data_keys)
 
     output_layer = self.network.layers[output_layer_name]

--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -4161,6 +4161,10 @@ class SwitchLayer(LayerBase):
     """
     super(SwitchLayer, self).__init__(**kwargs)
 
+    self.condition = condition
+    self.true_from = true_from
+    self.false_from = false_from
+
     assert condition.output.dtype == "bool"
     assert true_from.output.shape == false_from.output.shape
 
@@ -4182,8 +4186,11 @@ class SwitchLayer(LayerBase):
     d["false_from"] = get_layer(d["false_from"])
 
   @classmethod
-  def get_out_data_from_opts(cls, true_from, **kwargs):
-      return true_from.output.copy(name="%s_output" % kwargs["name"])
+  def get_out_data_from_opts(cls, true_from, name, **kwargs):
+      return true_from.output.copy(name="%s_output" % name)
+
+  def get_dep_layers(self):
+    return [self.condition, self.true_from, self.false_from]
 
 
 class SubnetworkLayer(LayerBase):


### PR DESCRIPTION
Should rather be 3 separate PRs...

I forgot some last changes to the CN dataset that were necessary for the ensembling experiments, this is the first commit.

Then I solved a crash occurring when max_seq_length is set in search. Translations for the filtered sentences were expected, causing a key error in out_cache. With this solution the filtered sentences do not appear in the output at all. Maybe we should add some line or enforce max_seq_length=0 instead? You might want to check this (although I have), an error here would be critical ;) 

Finally, get_dep_layers had to be implemented for the SwitchLayer to be able to use it in a recurrent unit.