### PR TITLE
TFNetworkLayer.py added flag masked_time to BatchNorm layer

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -818,7 +818,8 @@ class LayerBase(object):
                  use_shift=True, use_std=True, use_sample=0.0, force_sample=False,
                  momentum=0.99, epsilon=1e-3,
                  sample_mean=None, sample_variance=None,
-                 gamma=None, beta=None):
+                 gamma=None, beta=None,
+                 masked_time=True):
     """
     :param Data data:
     :param bool use_shift:
@@ -831,6 +832,7 @@ class LayerBase(object):
     :param tf.Tensor sample_variance:
     :param tf.Tensor gamma:
     :param tf.Tensor beta:
+    :param bool masked_time: flatten and mask input tensor
     :rtype: tf.Tensor
 
     http://arxiv.org/abs/1502.03167
@@ -840,8 +842,12 @@ class LayerBase(object):
       https://github.com/deepmind/sonnet/blob/master/sonnet/python/modules/batch_norm.py
     """
     with tf.variable_scope("batch_norm"):
-      x = data.get_placeholder_flattened(keep_dims=True)  # shape (time',...)
-      mean, variance = tf.nn.moments(x, axes=[0], keep_dims=True)
+      if masked_time:
+        x = data.get_placeholder_flattened(keep_dims=True)
+        mean, variance = tf.nn.moments(x, axes=[0], keep_dims=True)
+      else:
+        x = data.placeholder
+        mean, variance = tf.nn.moments(x, axes=data.get_axes(exclude_feature=True), keep_dims=True)
       if sample_mean is None:
         with self.var_creation_scope():
           sample_mean = self.add_param(tf.Variable(

--- a/TFUtil.py
+++ b/TFUtil.py
@@ -1026,10 +1026,11 @@ class Data(object):
       x.set_shape([None] * self.batch_ndim)
     return x
 
-  def get_axes(self, exclude_time=False, exclude_batch=False):
+  def get_axes(self, exclude_time=False, exclude_batch=False, exclude_feature=False):
     """
     :param bool exclude_time: will filter out the time-axis
     :param bool exclude_batch: will filter out the batch-axis
+    :param bool exclude_feature: will filter out the feature-axis
     :return: list of axes, like `range(len(self.shape))`, calculated with batch dim.
     :rtype: list[int]
     """
@@ -1038,6 +1039,8 @@ class Data(object):
       axes.pop(axes.index(self.time_dim_axis))
     if exclude_batch and self.batch_dim_axis is not None:
       axes.pop(axes.index(self.batch_dim_axis))
+    if exclude_feature and self.feature_dim_axis is not None:
+      axes.pop(axes.index(self.feature_dim_axis))
     return axes
 
   def get_axes_from_description(self, axes):


### PR DESCRIPTION
When possible (only standard set of parameters is given) use tf.layers.batch_normalization with fused ops. Works faster.