### PR TITLE
Changed CustomCheckpointLoader call to look for all params (not only trainable)

### DIFF
--- a/TFEngine.py
+++ b/TFEngine.py
@@ -955,7 +955,8 @@ class Engine(object):
         load_if_prefix = opts.get('prefix', '')  # prefix to identify the variables to be restored from the file
         from TFNetwork import CustomCheckpointLoader
         loader = CustomCheckpointLoader(
-          filename=model_filename, saveable_params=self.network.get_trainable_params(),
+          filename=model_filename,
+          saveable_params=self.network.get_params_list(),
           params_prefix=self_prefix, load_if_prefix=load_if_prefix,
           ignore_missing=opts.get("ignore_missing", False))
         loader.set_as_custom_init()

--- a/TFNetwork.py
+++ b/TFNetwork.py
@@ -394,7 +394,7 @@ class TFNetwork(object):
       layer_desc = net_dict[name]
     if not get_layer:
       def get_layer(src_name):
-        return self.construct_layer(net_dict=net_dict, name=src_name)
+        return self.construct_layer(net_dict=net_dict, name=src_name)  # set get_layer to wrap construct_layer
     if not add_layer:
       add_layer = self.add_layer
     self.layers_desc[name] = layer_desc


### PR DESCRIPTION
This change is necessary in order to use the trainable option for freezing certain layers
while still being able to load the corresponding parameters in the checkpoint.

I don't see any problems occurring due to this change. Please let me know if there are. Then I have to find another solution. 

