### PR TITLE
Easier configuration of MetaDataset

### DIFF
--- a/CachedDataset2.py
+++ b/CachedDataset2.py
@@ -151,6 +151,9 @@ class CachedDataset2(Dataset):
     return self._get_seq(sorted_seq_idx).ctc_targets
 
   def get_tag(self, sorted_seq_idx):
+    # get_tag() can be called before the seq is loaded via load_seqs().
+    # Thus, we just call load_seqs() ourselves here.
+    self.load_seqs(self.expected_load_seq_start, sorted_seq_idx + 1)
     return self._get_seq(sorted_seq_idx).seq_tag
 
   def get_data_keys(self):


### PR DESCRIPTION
1. Get data dims from the sub-datasets instead of explicitly giving it in the config. This is straight forward and I don't know why it hasn't been this way all along 😄 

2. When we combine datasets of the same (or similar) type, it might be straight forward to see which sequences correspond. For example when combining two TranslationDatasets most likely "line-n" of dataset A belongs to "line-n" of dataset B.
For this purpose, I implemented reading the list of sequence tags from one dataset (the one containing the "data" feature) and applying it to all others. In this case a sequence list created by the user is no longer necessary.