### PR TITLE
Fix unexpected type in _get_control_flow_ops

### DIFF
--- a/TFUtil.py
+++ b/TFUtil.py
@@ -5848,12 +5848,13 @@ def nested_get_shapes(x):
 
 
 def _get_control_flow_ops(v):
+  import numpy
   if isinstance(v, (list, tuple)):
     for elem in v:
       for t in _get_control_flow_ops(elem):
         yield t
     return
-  if isinstance(v, (int, float, type(None))):
+  if isinstance(v, (int, float, numpy.integer, type(None))):
     return
   if isinstance(v, tf.Tensor):
     v = v.op


### PR DESCRIPTION
I got an `unexpected type <class 'numpy.int64'>` when using MergeDimLayer inside the recurrent unit.
The numpy type comes from line 2614 in TFNetworkLayer:
`res_dim = numpy.prod([data.batch_shape[i] for i in axes])`
An alternative fix would be to convert to int here right away.