### PR TITLE
RecLayer template construction: allow loop exception if get_layer safe

### DIFF
--- a/TFNetwork.py
+++ b/TFNetwork.py
@@ -380,7 +380,7 @@ class TFNetwork(object):
         return self.get_layer(name)
       except LayerNotFound:
         pass  # ok, we will try to construct it then
-    if name in self._constructing_layers:
+    if name in self._constructing_layers and not (get_layer and hasattr(get_layer, "safe") and get_layer.safe):
       raise NetworkConstructionDependencyLoopException(
         layer_name=name, constructing_layers=self._constructing_layers, net_dict=net_dict, network=self)
     if name not in net_dict:


### PR DESCRIPTION
This fixes the invalid shape issue in #102. However, I'm not 100% sure if this is what we want...

The goal of this change is that we can infer the output data shape of layers in the recurrent subnetwork that depend on the "output" layer (usually a target embedding for label feedback). What happens at the moment is, that construction starts at output, recursively we go backwards through the recurrent cell until we end at output again and cannot construct it, because a loop exception is thrown. The first layer that is constructed is then the one that directly depends on the output, which (in most cases, I guess) can only be constructed uninitialized, because the input ("output") is not constructed yet. Therefore the shape is set to the default (None,). For target embeddings, more or less by chance, this works out, but for other layers it leads to shape mismatches.

By not throwing a loop exception for the case of get_layer.safe, we allow constructing the output layer when visiting it again, while at the same time avoiding an infinite loop. 

I am not sure if get_layer.once has to be included. What is it actually doing?