### PR TITLE
a minor bug related to TFUtil was fixed.

### DIFF
--- a/TFUtil.py
+++ b/TFUtil.py
@@ -4773,7 +4773,7 @@ def smoothing_cross_entropy(logits,
   :return: Tensor of the same shape as `labels` and of the same dtype as `logits`.
   :rtype: tf.Tensor
   """
-  with tf.name_scope("smoothing_cross_entropy", [logits, labels]):
+  with tf.name_scope("smoothing_cross_entropy", values=[logits, labels]):
     if vocab_size is None:
       vocab_size = get_shape_dim(logits, -1, name="vocab_size")
     confidence = 1.0 - label_smoothing


### PR DESCRIPTION
Command: ${returnn-experiments}/2018-asr-attention/librispeech/full-setup-attention/22_train.sh
I've got this log message.

" default_name type (<class 'list'>) is not a string type. You likely meant to pass this into the values kwarg."

I simply modified "returnn/TFUtil.py".