### PR TITLE
ChoiceLayer: multiple targets (factors)

### DIFF
--- a/TFNetwork.py
+++ b/TFNetwork.py
@@ -387,6 +387,7 @@ class TFNetwork(object):
       def get_layer(src_name):
         return self.construct_layer(net_dict=net_dict, name=src_name)  # set get_layer to wrap construct_layer
     if name not in net_dict:
+      layer_desc = None
       if name == "data":
         layer_desc = {"class": "source", "from": []}
       elif name.startswith("data:"):
@@ -394,12 +395,11 @@ class TFNetwork(object):
       elif '/' in name:
         # it may be a hierarchical path to a sub-layer, which should have been found by get_layer()
         # but maybe it's not constructed yet, so try constructing the root layer
-        get_layer(name.split('/')[0])
-        assert name.split('/')[0] in self.layers, ("Root %r layer was not constructed! "
-                                                   "Unable to get layer %r." % (name.split('/')[0], name))
-        # constructing the root layer should have constructed all its children
-        return self.get_layer(name)  # ...so try again now
-      else:
+        root_layer = get_layer(name.split('/')[0])
+        sub_layer = root_layer.get_sub_layer('/'.join(name.split('/')[1:]))  # get the sub-layer from the root-layer
+        if sub_layer:
+          return sub_layer
+      if not layer_desc:
         raise LayerNotFound("layer %r not found in %r" % (name, self))
     else:
       layer_desc = net_dict[name]

--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -479,9 +479,24 @@ class LayerBase(object):
   def get_sub_layer(self, layer_name):
     """
     The default behavior for any layer is to return None.
-    :param str layer_name:  The sub_layer addressed by '/' separated path.
-    :return: The sub_layer addressed in layer_name or None if no sub_layer exists
+
+    :param str layer_name: name of the sub_layer (right part of '/' separated path)
+    :return: the sub_layer addressed in layer_name or None if no sub_layer exists
     :rtype: LayerBase|None
+    """
+    return None
+
+  @classmethod
+  def get_sub_layer_out_data_from_opts(cls, layer_name, parent_layer_kwargs):
+    """
+    Called by _TemplateLayer.get_sub_layer(). Gets a Data template for the sub-layer with name 'layer_name'.
+    Also returns the network the sub-layer is in and the class type of the sub-layer. There is no good default
+    behaviour here, as this heavily depends on how the current layer uses sub-layers.
+
+    :param str layer_name: name of the sub_layer (right part of '/' separated path)
+    :param dict[str] parent_layer_kwargs: kwargs for the parent layer (as kwargs in cls.get_out_data_from_opts())
+    :return: Data template, network and the class type of the sub-layer
+    :rtype: (Data, TFNetwork, type)|None
     """
     return None
 

--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -366,16 +366,23 @@ class LayerBase(object):
       d["reuse_params"] = ReuseParams.from_config_dict(d["reuse_params"], network=network, get_layer=get_layer)
     if d.get("loss", None) and "target" not in d:
       d["target"] = network.extern_data.default_target
+    targets = None
     if d.get("target"):
+      targets = d["target"]
+      # we might have multiple targets, e.g. in choice layer, so convert to list
+      if isinstance(targets, str):
+          targets = [targets]
       if network.eval_flag:
-        # Not resolving this in the dict, but call get_layer to make it available.
-        assert isinstance(d["target"], str)
-        if d["target"].startswith("layer:"):
-          get_layer(d["target"][len("layer:"):])
-    if "n_out" not in d and d.get("target", None) and network.eval_flag:
+        for target in targets:
+          assert isinstance(target, str)
+          # Not resolving this in the dict, but call get_layer to make it available.
+          if target.startswith("layer:"):
+            get_layer(target[len("layer:"):])
+    if "n_out" not in d and targets and network.eval_flag:
       # Must be done here now because loss might be set to None later.
+      target = targets[0]  # guess using first target
       d["n_out"] = cls._guess_n_out_from_target_and_opt_loss(
-        network=network, target=d["target"], loss_class_name=d.get("loss", None), get_layer=get_layer)
+        network=network, target=target, loss_class_name=d.get("loss", None), get_layer=get_layer)
     if d.pop("loss_only_on_non_search", None) and network.search_flag:
       d.pop("loss", None)
       d.pop("loss_scale", None)

--- a/TFNetworkRecLayer.py
+++ b/TFNetworkRecLayer.py
@@ -2943,34 +2943,41 @@ class ChoiceLayer(LayerBase):
   _debug_out = None  # type: None|list
 
   def __init__(self, beam_size, input_type="prob", explicit_search_source=None, length_normalization=True,
-               scheduled_sampling=False,
-               cheating=False,
-               **kwargs):
+               source_beam_sizes=None, scheduled_sampling=False, cheating=False, **kwargs):
     """
     :param int beam_size: the outgoing beam size. i.e. our output will be (batch * beam_size, ...)
     :param str input_type: "prob" or "log_prob", whether the input is in probability space, log-space, etc.
-      or "regression", if it is a prediction of the data as-is.
+      or "regression", if it is a prediction of the data as-is. If there are several inputs, same format
+      for all is assumed.
     :param LayerBase|None explicit_search_source: will mark it as an additional dependency
-    :param dict|None scheduled_sampling:
     :param bool length_normalization: evaluates score_t/len in search
+    :param list[int]|None source_beam_sizes: If there are several sources, they are pruned with these beam sizes
+       before combination. If None, 'beam_size' is used for all sources. Has to have same length as number of sources.
+    :param dict|None scheduled_sampling:
     :param bool cheating: if True, will always add the true target in the beam
     """
     super(ChoiceLayer, self).__init__(**kwargs)
     from Util import CollectionReadCheckCovered
+    self.input_type = input_type
     self.explicit_search_source = explicit_search_source
     self.scheduled_sampling = CollectionReadCheckCovered.from_bool_or_dict(scheduled_sampling)
     # We assume log-softmax here, inside the rec layer.
     assert self.target
+
     if self.network.search_flag:
-      assert len(self.sources) == 1
-      assert not self.sources[0].output.sparse
+      if isinstance(self.target, list):
+        assert len(self.target) == len(self.sources), "Provide a target for each of the sources."
+      for source in self.sources:
+        assert not source.output.sparse
       assert self.sources[0].output.dim == self.output.dim
       assert self.sources[0].output.shape == (self.output.dim,)
+
       # We are doing the search.
       self.search_choices = SearchChoices(
         owner=self,
         beam_size=beam_size)
       if input_type == "regression":
+        assert len(self.sources) == 1
         # It's not a probability distribution, so there is no search here.
         net_batch_dim = self.network.get_data_batch_dim()
         assert self.search_choices.beam_size == 1
@@ -2979,7 +2986,25 @@ class ChoiceLayer(LayerBase):
         self.search_choices.src_beams = tf.zeros((net_batch_dim, 1), dtype=tf.int32)
         self.search_choices.set_beam_scores(self.search_choices.src_layer.search_choices.beam_scores)
       else:
+        assert len(self.sources) <= 2, "Combining more than two sources not implemented yet."
         net_batch_dim = self.network.get_data_batch_dim()
+        if len(self.sources) > 1:
+          # If no separate beam sizes for the sources are given, use the final beam size also for pruning
+          # the incoming sources. Note, that it makes no sense to set it higher than that, as the best
+          # k=beam_size scores are always included if all source_beam_sizes >= beam_size.
+          if not source_beam_sizes:
+            source_beam_sizes = [beam_size] * len(self.sources)
+          assert len(source_beam_sizes) == len(self.sources), "Provide exactly one beam size per source."
+
+          # Combine the incoming scores by adding them up for all possible combinations of target labels. To reduce
+          # the number of combinations, we separately apply beam pruning to the sources beforehand.
+          scores_in, scores_in_dim, pruned_labels = \
+              self._prune_and_combine_sources(self.sources, source_beam_sizes, net_batch_dim * beam_size)
+          # scores_in has size (batch * beam_size, source_beam_sizes[0] * source_beam_sizes[1])
+        else:
+          scores_in = self._get_scores(self.sources[0])  # (batch * beam_size, dim)
+          scores_in_dim = self.sources[0].output.dim
+
         assert self.search_choices.src_layer, (
           self.network.debug_search_choices(base_search_choice=self),
           "Not implemented yet. In rec-layer, we would always have our prev-frame as one previous search choice. "
@@ -2987,7 +3012,7 @@ class ChoiceLayer(LayerBase):
         scores_base = self.search_choices.src_layer.search_choices.beam_scores  # (batch, beam_in)
         assert scores_base.get_shape().ndims == 2, "%r invalid" % self.search_choices.src_layer.search_choices
         base_beam_in = tf.shape(scores_base)[1]  # 1 in first frame, then beam_in (beam_size)
-        scores_beam_in = tf.shape(self.sources[0].output.placeholder)[0] // net_batch_dim
+        scores_beam_in = tf.shape(scores_in)[0] // net_batch_dim
         beam_size = self.sources[0].output.beam_size
         # About incoming beam size:
         #   base_beam_in  - 1 in first frame, then beam_in
@@ -3014,20 +3039,7 @@ class ChoiceLayer(LayerBase):
               tf.ones(tf.shape(end_flags)) * (tf.to_float(t + 1) / tf.to_float(t)),
               tf.ones(tf.shape(end_flags)))
         scores_base = tf.expand_dims(scores_base, axis=-1)  # (batch, beam_in, dim)
-        scores_in = self.sources[0].output.placeholder  # (batch * beam_in, dim)
-        # We present the scores in +log space, and we will add them up along the path.
-        if input_type == "prob":
-          if self.sources[0].output_before_activation:
-            scores_in = self.sources[0].output_before_activation.get_log_output()
-          else:
-            from TFUtil import safe_log
-            scores_in = safe_log(scores_in)
-        elif input_type == "log_prob":
-          pass
-        else:
-          raise Exception("%r: invalid input type %r" % (self, input_type))
         from TFUtil import filter_ended_scores
-        scores_in_dim = self.sources[0].output.dim
         if self.network.have_rec_step_info():
           scores_in = filter_ended_scores(
             scores_in, end_flags=self.network.get_rec_step_info().get_end_flag(),
@@ -3054,6 +3066,7 @@ class ChoiceLayer(LayerBase):
         # We get scores/labels of shape (batch, beam) with indices in [0..beam_in*dim-1].
         scores, labels = tf.nn.top_k(scores_comb_flat, k=beam_size)
         if cheating:
+          assert len(self.sources) == 1, "Cheating not yet implemented for multiple sources."
           # It assumes that sorted=True in top_k, and the last entries in scores/labels are the worst.
           # We replace them by the true labels.
           gold_targets = self._static_get_target_value(
@@ -3074,11 +3087,20 @@ class ChoiceLayer(LayerBase):
         labels = labels % scores_in_dim  # (batch, beam) -> dim idx
         labels = tf.reshape(labels, [net_batch_dim * beam_size])  # (batch * beam)
         labels = tf.cast(labels, self.output.dtype)
+
+        if len(self.sources) > 1:
+          # 'labels' in this case do not refer to a target vocabulary, but just represent ids to the labels
+          # that survived pruning for each of the sources ('pruned_labels'). So as a last step, we get the final
+          # target labels by indexing pruned_labels with 'labels'.
+          labels = self._get_combined_labels(pruned_labels, source_beam_sizes, combined_ids=labels)
+        else:
+          labels = [labels]
+
         self.search_choices.set_beam_scores(scores)  # (batch, beam) -> log score
         if self._debug_out is not None:
           from TFUtil import identity_with_debug_log
-          labels = identity_with_debug_log(
-            out=self._debug_out, x=labels, args={
+          labels[0] = identity_with_debug_log(
+            out=self._debug_out, x=labels[0], args={
               "step": self.network.get_rec_step_index() if self.network.have_rec_step_info() else tf.constant(-1),
               "base_beam_in": base_beam_in,
               "scores_in_orig": self.sources[0].output.placeholder,
@@ -3087,18 +3109,27 @@ class ChoiceLayer(LayerBase):
               "scores_base": scores_base,
               "scores_combined": scores_comb,
               "src_beam_idxs": self.search_choices.src_beams,
-              "labels": tf.reshape(labels, [net_batch_dim, beam_size]),
+              "labels": tf.reshape(labels[0], [net_batch_dim, beam_size]),
               "scores": scores})
-        self.output = Data(
-          name="%s_choice_output" % self.name,
-          batch_dim_axis=0,
-          shape=self.output.shape,
-          sparse=True,
-          dim=self.output.dim,
-          dtype=self.output.dtype,
-          placeholder=labels,
-          available_for_inference=True,
-          beam_size=beam_size)
+
+        # Put labels for all targets in a list.
+        # They can be accessed by using the sublayers created in self.get_sub_layer().
+        self.output_list = []
+        for index, labels_ in enumerate(labels):
+          self.output_list.append(Data(
+            name="%s_choice_output" % self.name,
+            batch_dim_axis=0,
+            shape=self.output.shape,
+            sparse=True,
+            dim=self.sources[index].output.dim,
+            dtype=self.output.dtype,
+            placeholder=labels_,
+            available_for_inference=True,
+            beam_size=beam_size))
+
+        # We use the labels of the first target as "normal" output.
+        self.output = self.output_list[0]
+
     elif self.scheduled_sampling.truth_value:
       # Original paper: https://arxiv.org/abs/1506.03099
       # Currently, here: no scheduling, just always sample...
@@ -3141,10 +3172,102 @@ class ChoiceLayer(LayerBase):
       assert len(self.sources) == 0  # will be filtered out in transform_config_dict
       # Note: If you want to do forwarding, without having the reference,
       # that wont work. You must do search in that case.
-      self.output = self._static_get_target_value(
-        target=self.target, network=self.network,
-        mark_data_key_as_used=True).copy()
-      self.output.available_for_inference = True  # in inference, we should do search
+      targets = self.target
+      if isinstance(targets, str):
+        targets = [targets]
+      # Put all targets in a list.
+      # They can be accessed by using the sublayers created in self.get_sub_layer().
+      self.output_list = []
+      for target in targets:
+        target_out_data = self._static_get_target_value(
+            target=target, network=self.network, mark_data_key_as_used=True).copy()
+        target_out_data.available_for_inference = True  # in inference, we should do search
+        self.output_list.append(target_out_data)
+
+      # We use the labels of the first target as "normal" output.
+      self.output = self.output_list[0]
+
+  def _get_scores(self, source):
+    scores_in = source.output.placeholder
+    # We present the scores in +log space, and we will add them up along the path.
+    if self.input_type == "prob":
+      if source.output_before_activation:
+        return source.output_before_activation.get_log_output()
+      else:
+        from TFUtil import safe_log
+        return safe_log(scores_in)
+    elif self.input_type == "log_prob":
+      return scores_in
+    else:
+      raise Exception("%r: invalid input type %r" % (self, self.input_type))
+
+  def _prune_and_combine_sources(self, sources, beam_sizes, batch_dim):
+    """
+    Applies beam bruning to the sources and then calculates all possible sums of scores.
+    Returns the scores, the (static) number of targets after pruning and a list of
+    labels corresponding to the top scores.
+
+    :param list[LayerBase] sources: input layers providing the scores
+    :param list[int] beam_sizes: beam sizes used for pruning of the individual sources
+    :param tf.Tensor|int batch_dim: dim of batch axis (batch size * incoming beam)
+    :return: combined scores, dim of combined scores, labels that survived pruning
+    :rtype: (tf.Tensor, int, list[tf.Tensor])
+    """
+
+    # Calculate the product of beam_sizes. This will be the length (i.e. 'dim') of combined_pruned_scores.
+    combined_scores_dim = 1
+
+    pruned_scores = []
+    pruned_labels = []
+
+    with tf.name_scope("combine_sources"):
+      # prune incoming sources separately
+      for source, beam_size in zip(sources, beam_sizes):
+        scores_in = self._get_scores(source)
+
+        scores, labels = tf.nn.top_k(scores_in, k=beam_size)
+        pruned_scores.append(scores)
+        pruned_labels.append(labels)
+
+        combined_scores_dim *= beam_size
+
+      # all possible combinations of scores from source 0 and 1 via broadcasting
+      # TODO: generalize to more than two sources
+      scores_0 = tf.expand_dims(pruned_scores[0], -1)  # (batch, beam_sizes[0], 1)
+      scores_1 = tf.expand_dims(pruned_scores[1], -2)  # (batch, 1, beam_sizes[1])
+      combined_pruned_scores = scores_0 + scores_1  # (batch, beam_sizes[0], beam_sizes[1])
+
+      # We flatten over the beam dims of the sources, but not yet over the batch dim. This matches
+      # the shape of the input scores in case of a single source.
+      combined_pruned_scores_flat = tf.reshape(combined_pruned_scores, [batch_dim, combined_scores_dim])
+
+    return combined_pruned_scores_flat, combined_scores_dim, pruned_labels
+
+  def _get_combined_labels(self, pruned_labels, beam_sizes, combined_ids):
+    """
+    Gets output labels by converting 'combined_ids' (corresponding to the flattend shape created in
+    self._prune_and_combine_sources()) back to separate ids and then using those as indices to the labels
+    that survived pruning.
+
+    :param list[tf.Tensor] pruned_labels: labels before pruning, see self._prune_and_combine_sources()
+    :param list[int] beam_sizes: beam sizes used for pruning of the individual sources
+    :param tf.Tensor combined_ids: indices to the flattened scores, see self._prune_and_combine_sources()
+    :return: final labels for all sources
+    :rtype: list[tf.Tensor]
+    """
+    # TODO: generalize to more than two sources
+
+    # We can recover the ids for the unflattened shape by using integer division and modulo operations.
+    # (similar to numpy.unravel_index())
+    with tf.name_scope("get_combined_labels"):
+      ids_0 = tf.floordiv(combined_ids, beam_sizes[1])
+      ids_1 = tf.floormod(combined_ids, beam_sizes[1])
+
+      # Now get the final target labels by indexing the labels.
+      labels_0 = tf.squeeze(tf.batch_gather(pruned_labels[0], tf.expand_dims(ids_0, axis=-1)), axis=-1)
+      labels_1 = tf.squeeze(tf.batch_gather(pruned_labels[1], tf.expand_dims(ids_1, axis=-1)), axis=-1)
+
+      return [labels_0, labels_1]
 
   @classmethod
   def transform_config_dict(cls, d, network, get_layer):
@@ -3153,24 +3276,68 @@ class ChoiceLayer(LayerBase):
     :param TFNetwork.TFNetwork network:
     :param ((str) -> LayerBase) get_layer: function to get or construct another layer
     """
-    if not network.search_flag and not d.get("scheduled_sampling"):
-      # In the dependency graph, we don't want it.
-      # This can enable some optimizations in the RecLayer.
-      # We do it here because we should know about the deps early in the template creation in RecLayer.
-      d["from"] = []
+    if isinstance(d["target"], str):
+      d["target"] = [d["target"]]
+    if not network.search_flag:
+      network.used_data_keys.update(d["target"])
+      if not d.get("scheduled_sampling"):
+        # In the dependency graph, we don't want it.
+        # This can enable some optimizations in the RecLayer.
+        # We do it here because we should know about the deps early in the template creation in RecLayer.
+        d["from"] = []
     if d.get("explicit_search_source"):
       d["explicit_search_source"] = get_layer(d["explicit_search_source"]) if network.search_flag else None
     super(ChoiceLayer, cls).transform_config_dict(d, network=network, get_layer=get_layer)
 
   @classmethod
   def get_out_data_from_opts(cls, target, network, beam_size, **kwargs):
-    out = cls._static_get_target_value(
-      target=target, network=network,
-      mark_data_key_as_used=False).copy()
-    out.available_for_inference = True  # in inference, we would do search
+    first_target = target[0] if isinstance(target, list) else target
+    out_data = cls._static_get_target_value(target=first_target, network=network, mark_data_key_as_used=False).copy()
+
+    out_data.available_for_inference = True  # in inference, we would do search
     if network.search_flag:
-      out.beam_size = beam_size
-    return out
+      out_data.beam_size = beam_size
+
+    return out_data
+
+  def get_sub_layer(self, layer_name):
+    """
+    Used to get outputs in case of multiple targets. For all targets we create a sub-layer that can be referred to
+    by "self.name + '/out_' + index" (e.g. output/out_0). These sublayers can then be used as input to other layers,
+    e.g. "output_0": {"class": "copy", "from": ["output/out_0"].
+
+    :param str layer_name: name of the sub_layer (e.g. 'out_0')
+    :return: internal layer that outputs labels for the target corresponding to layer_name
+    :rtype: InternalLayer
+    """
+    assert layer_name.startswith("out_")
+    index = int(layer_name[len("out_"):])
+    full_layer_name = self.name + '/' + layer_name
+
+    from TFNetworkLayer import InternalLayer
+    sub_layer = InternalLayer(name=full_layer_name, network=self.network, output=self.output_list[index], sources=[self])
+    return sub_layer
+
+  @classmethod
+  def get_sub_layer_out_data_from_opts(cls, layer_name, parent_layer_kwargs):
+    """
+    :param str layer_name: name of the sub_layer (e.g. 'out_0'), see self.get_sub_layer()
+    :param dict[str] parent_layer_kwargs: kwargs for the parent layer, here we only need 'network' and 'beam_size'
+    :return: Data template, network and the class type of the sub-layer
+    :rtype: (Data, TFNetwork, type)|None
+    """
+    assert layer_name.startswith("out_")
+    index = int(layer_name[len("out_"):])
+
+    targets = parent_layer_kwargs["target"]
+    assert isinstance(targets, list), "Sub-layers for ChoiceLayer should only exist in case of multiple targets."
+
+    # The sub-layer with index n will output the n-th target. The out_data is taken directly
+    # from the target as it is done in self.get_out_data_from_opts().
+    sub_layer_out_data = cls.get_out_data_from_opts(target=targets[index], network=parent_layer_kwargs["network"],
+                                                    beam_size=parent_layer_kwargs["beam_size"])
+    from TFNetworkLayer import InternalLayer
+    return sub_layer_out_data, parent_layer_kwargs["network"], InternalLayer
 
   # noinspection PyMethodOverriding
   @classmethod


### PR DESCRIPTION
This is needed for [Factored NMT](https://arxiv.org/abs/1609.04621).
ChoiceLayer now accepts two sources and two corresponding targets (e.g. target factors) and does a joint decision for both. Criterion is the sum of the two incoming scores in log space. Beam pruning is applied to both sources to reduce the number of possible combinations.

As the layer has several outputs (labels for both targets), I used sub-layers to refer to them. For this I also needed sub-layer templates.
An example config can be found here: https://github.com/patrick-wilken/returnn-examples/blob/master/factored-nmt/config

