### PR TITLE
Respect trainable=False for RecLayer subnetwork layers

### DIFF
--- a/TFNetwork.py
+++ b/TFNetwork.py
@@ -798,8 +798,6 @@ class TFNetwork(object):
     for layer_name in sorted(self._selected_train_layers):
       layer = self.layers[layer_name]
       assert isinstance(layer, LayerBase)
-      if not layer.trainable:
-        continue
       for param_name, param in sorted(layer.params.items()):
         assert isinstance(param, tf.Variable)
         if param in trainable_vars_col:

--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -614,6 +614,11 @@ class LayerBase(object):
     :return: param
     :rtype tf.Variable
     """
+    if not self.trainable:
+      trainable_collection_ref = param.graph.get_collection_ref(tf.GraphKeys.TRAINABLE_VARIABLES)
+      if param in trainable_collection_ref:
+        trainable_collection_ref.remove(param)
+
     if isinstance(param, tf.Tensor):
       # This can happen with a custom_getter in tf.get_variable(), e.g. via self.reuse_params.
       # In that case, don't treat it like a param, i.e. don't save a reference in self.params,

--- a/TFNetworkRecLayer.py
+++ b/TFNetworkRecLayer.py
@@ -209,6 +209,13 @@ class RecLayer(_ConcatInputLayer):
       assert p.name.startswith(scope_name_prefix) and p.name.endswith(":0")
       self.add_param(p)
 
+      # Sublayers do not know whether the RecLayer is trainable. If it is not, we need to mark all defined parameters
+      # as untrainable
+      if not self.trainable:
+        trainable_collection_ref = p.graph.get_collection_ref(tf.GraphKeys.TRAINABLE_VARIABLES)
+        if p in trainable_collection_ref:
+          trainable_collection_ref.remove(p)
+
   def get_dep_layers(self):
     l = super(RecLayer, self).get_dep_layers()
     l += self._initial_state_deps

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -708,6 +708,25 @@ def test_ConvLayer_get_valid_out_dim():
   assert_equal(ConvLayer.calc_out_dim(in_dim=2, stride=1, filter_size=3, padding="valid"), 0)
 
 
+def test_untrainable_params():
+  with make_scope() as session:
+    config = Config()
+    n_in, n_out = 2, 3
+    config.update({
+      "num_outputs": n_out,
+      "num_inputs": n_in,
+      "network": {
+        "l1": {"class": "linear", "activation": None, "n_out": n_out},
+        "output": {"class": "linear", "activation": None, "from": ["l1"], "n_out": n_out, "trainable": False}
+      }
+    })
+    network = TFNetwork(config=config, train_flag=True)
+    network.construct_from_dict(config.typed_dict["network"])
+    l1 = network.layers["l1"]
+    l2 = network.layers["output"]
+    assert_equal(set(network.get_trainable_params()), {l1.params["W"], l1.params["b"]})
+
+
 def test_reuse_params():
   with make_scope() as session:
     config = Config()


### PR DESCRIPTION
This PR:
 - allows to set `trainable=False` to layers that are part of a `RecLayer` 
 - adds test cases to ensure that both trainable and untrainable layers are handled correctly, whether they were optimized out of the loop or not

This fixes #117 