### PR TITLE
Disable 2DLSTM code for TF <= 1.4

### DIFF
--- a/NativeOp.cpp
+++ b/NativeOp.cpp
@@ -95,8 +95,10 @@ Ndarray* Ndarray_Copy(const Ndarray* self) {
 
 #if (TF_MAJOR_VERSION == 1 && TF_MINOR_VERSION >= 5) || (TF_MAJOR_VERSION > 1)
 #define TF_issue_6602_workaround 0
+#define TWOD_LSTM_SUPPORT 1
 #else
 #define TF_issue_6602_workaround 1
+#define TWOD_LSTM_SUPPORT 0
 #endif
 
 #if TF_issue_6602_workaround
@@ -208,6 +210,7 @@ static void tf_cuda_sgemm_batched(
     T beta = *beta_;
 // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/rnn/kernels/blas_gemm.cc
 #if GOOGLE_CUDA
+#if TWOD_LSTM_SUPPORT
     typedef perftools::gputools::DeviceMemory<float> DeviceMemoryType;
     std::vector<DeviceMemoryType> a_device_memory;
     std::vector<DeviceMemoryType> b_device_memory;
@@ -258,6 +261,9 @@ static void tf_cuda_sgemm_batched(
                 .ok();
         OP_REQUIRES(context, blas_launch_status, errors::Aborted("BlockHostUntilDone failed!"));
     }
+#else  // TWOD_LSTM_SUPPORT
+    context->SetStatus(errors::InvalidArgument("For 2D-LSTMs, TensorFlow 1.5 or later is required"));
+#endif
 #else  // GOOGLE_CUDA
     context->SetStatus(errors::InvalidArgument("CuBlasGemm needs CUDA."));
 #endif  // GOOGLE_CUDA


### PR DESCRIPTION
TensorFlow 1.4 does not provide the necessary functions to run the 2D-LSTM code. This PR disables the relevant code and displays an error message if the TF version is not supported.

Fixes #115 