### PR TITLE
adding flag to tools/compile_native_op.py to better control linker param

### DIFF
--- a/TFNativeOp.py
+++ b/TFNativeOp.py
@@ -420,7 +420,7 @@ class OpMaker(object):
           # Prefer Numpy; move to front.
           libs = numpy_libs + [fn for fn in libs if fn not in numpy_libs]
         if self.blas_lib is not None:
-          libs = filter(lambda l: self.blas_lib in l, libs)
+          libs = [l for l in libs if self.blas_lib in l]
         for fn in libs:
           ld_flags += ["-L%s" % os.path.dirname(fn), "-l:%s" % os.path.basename(fn)]
           have_blas_lib = True

--- a/tools/compile_native_op.py
+++ b/tools/compile_native_op.py
@@ -66,6 +66,8 @@ def main(argv):
   argparser = argparse.ArgumentParser(description='Compile some op')
   argparser.add_argument('--config', help="filename to config-file")
   argparser.add_argument('--native_op', help="op name. e.g. 'LstmGenericBase'")
+  argparser.add_argument('--blas_lib', default=None,
+                         help="specify which blas lib to use (path to .so or file name to search for)")
   argparser.add_argument('--search_for_numpy_blas', dest='search_for_numpy_blas', action='store_true',
                          help="search for blas inside numpys .libs folder")
   argparser.add_argument('--no_search_for_numpy_blas', dest='search_for_numpy_blas', action='store_false',
@@ -80,7 +82,7 @@ def main(argv):
   if args.native_op:
     print("Loading native op %r" % args.native_op)
     make_op(getattr(NativeOp, args.native_op), compiler_opts={"verbose": True},
-            search_for_numpy_blas=args.search_for_numpy_blas)
+            search_for_numpy_blas=args.search_for_numpy_blas, blas_lib=args.blas_lib)
 
   libs = []
   if OpMaker.with_cuda and OpMaker.tf_blas_gemm_workaround:


### PR DESCRIPTION
When we use TF with Intel MKL (built with `--config=mkl`) and build native ops, OpMaker retrieves both OpenBLAS and MKL from the run-time environment, such that libopenblas has a higher priority.

With `--blas_lib` we can specify either
 * `/path/to/libmyblas.so` -> link with `-L/path/to -lmyblas`, or
 * `libmyblas.so` -> perform search and add `-L... -l...` for library that contains `libmyblas.so` in file name