### PR TITLE
Layer Reference in Documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ User guide
     tech_overview
     tf_lstm_benchmark
     deterministic_training
+    layer_reference/index.rst
 
 
 API Reference

--- a/docs/layer_reference/attention.rst
+++ b/docs/layer_reference/attention.rst
@@ -1,0 +1,47 @@
+.. _attention_layers:
+
+================
+Attention Layers
+================
+
+Generic Attention Layer
+-----------------------
+
+.. autoclass:: TFNetworkRecLayer.GenericAttentionLayer
+	:members:
+	:undoc-members:
+
+Dot-Product Attention Layer
+---------------------------
+
+.. autoclass:: TFNetworkRecLayer.DotAttentionLayer
+	:members:
+	:undoc-members:
+
+Concatenative Attention Layer
+-----------------------------
+
+.. autoclass:: TFNetworkRecLayer.ConcatAttentionLayer
+	:members:
+	:undoc-members:
+
+Self-Attention Layer
+--------------------
+
+.. autoclass:: TFNetworkRecLayer.SelfAttentionLayer
+	:members:
+	:undoc-members:
+
+Generic Window Attention Layer
+------------------------------
+
+.. autoclass:: TFNetworkRecLayer.GenericWindowAttentionLayer
+	:members:
+	:undoc-members:
+
+Gauss Window Attention Layer
+----------------------------
+
+.. autoclass:: TFNetworkRecLayer.GaussWindowAttentionLayer
+	:members:
+	:undoc-members:

--- a/docs/layer_reference/basic.rst
+++ b/docs/layer_reference/basic.rst
@@ -1,0 +1,147 @@
+.. _basic_layers:
+
+============
+Basic Layers
+============
+
+
+Linear Layer
+------------
+
+.. autoclass:: TFNetworkLayer.LinearLayer
+	:members:
+	:undoc-members:
+
+Copy Layer
+----------
+
+.. autoclass:: TFNetworkLayer.CopyLayer
+	:members:
+	:undoc-members:
+
+Combine Layer
+-------------
+
+.. autoclass:: TFNetworkLayer.CombineLayer
+	:members:
+	:undoc-members:
+
+Convolution Layer
+-----------------
+
+.. autoclass:: TFNetworkLayer.ConvLayer
+	:members:
+	:undoc-members:
+
+
+Pooling Layer
+-------------
+
+.. autoclass:: TFNetworkLayer.PoolLayer
+	:members:
+	:undoc-members:
+
+Reduce Layer
+------------
+
+.. autoclass:: TFNetworkLayer.ReduceLayer
+	:members:
+	:undoc-members:
+
+Reduce-Out Layer
+----------------
+
+.. autoclass:: TFNetworkLayer.ReduceOutLayer
+	:members:
+	:undoc-members:
+
+Dot Layer
+---------
+
+.. autoclass:: TFNetworkLayer.DotLayer
+	:members:
+	:undoc-members:
+
+Constant Layer
+--------------
+
+.. autoclass:: TFNetworkLayer.ConstantLayer
+	:members:
+	:undoc-members:
+
+Variable Layer
+--------------
+
+.. autoclass:: TFNetworkLayer.VariableLayer
+	:members:
+	:undoc-members:
+
+Activation Layer
+----------------
+
+.. autoclass:: TFNetworkLayer.ActivationLayer
+	:members:
+	:undoc-members:
+
+Gating Layer
+------------
+
+.. autoclass:: TFNetworkLayer.GatingLayer
+	:members:
+	:undoc-members:
+
+Window Layer
+------------
+
+.. autoclass:: TFNetworkLayer.WindowLayer
+	:members:
+	:undoc-members:
+
+Length Layer
+-----------
+
+.. autoclass:: TFNetworkLayer.LengthLayer
+	:members:
+	:undoc-members:
+
+Weighted Sum Layer
+------------------
+
+.. autoclass:: TFNetworkLayer.WeightedSumLayer
+	:members:
+	:undoc-members:
+
+Cumulative Sum Layer
+--------------------
+
+.. autoclass:: TFNetworkLayer.CumsumLayer
+	:members:
+	:undoc-members:
+
+Elementwise Product Layer
+-------------------------
+
+.. autoclass:: TFNetworkLayer.ElemwiseProdLayer
+	:members:
+	:undoc-members:
+
+Accumulate Mean Layer
+---------------------
+
+.. autoclass:: TFNetworkLayer.AccumulateMeanLayer
+	:members:
+	:undoc-members:
+
+Switch Layer
+------------
+
+.. autoclass:: TFNetworkLayer.SwitchLayer
+	:members:
+	:undoc-members:
+
+Compare Layer
+-------------
+
+.. autoclass:: TFNetworkLayer.CompareLayer
+	:members:
+	:undoc-members:

--- a/docs/layer_reference/custom.rst
+++ b/docs/layer_reference/custom.rst
@@ -1,0 +1,19 @@
+.. _custom_layers:
+
+=============
+Custom Layers
+=============
+
+Eval Layer
+----------
+
+.. autoclass:: TFNetworkLayer.EvalLayer
+	:members:
+	:undoc-members:
+
+Subnetwork Layer
+----------------
+
+.. autoclass:: TFNetworkLayer.SubnetworkLayer
+	:members:
+	:undoc-members:

--- a/docs/layer_reference/index.rst
+++ b/docs/layer_reference/index.rst
@@ -1,0 +1,76 @@
+.. _layer_reference:
+
+==========================
+Tensorflow Layer Reference
+==========================
+
+
+General Information
+-------------------
+
+Every usable layer with the tensorflow backend inherits from :class:`TFNetworkLayer.LayerBase`.
+This class provides most of the parameters that can be set for each layer.
+
+Every layer accepts the following dictionary entries:
+
+**class** [:class:`str`] specifies the type of the layer. Each layer class defines a ``layer_class`` attribute which
+defines the layer name.
+
+**from** [:class:`list[str]`] specifies the inputs of a layer, usually refering to the layer name. Many layers automatically concatenate their inputs, as provided by
+:class:`TFNetworkLayer._ConcatInputLayer`. For more details on how to connect layers, see :ref:`connecting`.
+
+**n_out** [:class:`int`] specifies the output feature dimension, and is usually set for every layer, but the argument is not strictly required.
+If ``n_out`` is not specified or set to :class:`None`, it will try to determine the output size by a provided ``target``.
+If a loss is given, it will set ``n_out`` to the value provided by :func:`TFNetworkLayer.Loss.get_auto_output_layer_dim`.
+
+**out_type** [:class:`dict[str]`] specifies the output shape in more details. The keys are ``dim`` and ``shape``.
+If ``output`` is specified, the values are used to check if the output matches the given dimension and shape. Otherwise, it
+is passed to :func:TFNetworkLayer.LayerBase.get_out_data_from_opts`.
+
+**loss** [:class:`str`] every layer can have its output connected to a loss function. For available loss functions,
+see :ref:`loss`. When specifying a loss, also ``target`` has to be set (see below). In addition, ``loss_scale`` (defaults to 1)
+and ``loss_opts`` can be specified.
+
+**target** [:class:`str`] specifies the loss target in the dataset.
+
+**loss_scale** [:class:`float`] specifies a loss scale. Before adding all losses, this factor will be used as scaling.
+
+**loss_opts** [:class:`dict`] specifies additional loss arguments. For details, see the documentation of the loss functions :ref:`loss`
+
+**trainable** [:class:`bool`] (default ``True``) if set to ``False``, the layer parameters will not be updated during training (parameter freezing).
+
+**L2** [:class:`float`] if specified, add the L2 norm of the parameters with the given factor to the total constraints.
+
+**darc1** [:class:`float`] if specified, add darc1 loss of the parameters with the given factor to the total constraints.
+
+**spatial_smoothing** [:class:`float`] if specified, add spatial-smoothing loss of the layer output with the given factor to the total constraints.
+
+.. _connecting:
+
+Connecting Layers
+-----------------
+
+In most cases it is sufficient to just specify a list of layer names for the **from** attribute. When no input is specified,
+it will automatically fallback to ``"data"``, which is the default input-data of the provided dataset. Depending on the
+definition of the ``feature`` and ``target`` keys (see :class:`Dataset.DatasetSeq`), the data can be accessed
+via ``from["data:DATA_KEY"]``. When specifying layers inside a recurrent unit (see :ref:`recurrent_layers`), two additional
+input prefixes are available, ``base`` and ``prev``. When trying to access layers from outside the recurrent unit, the prefix
+``base`` as to be used. Otherwise, only other layers inside the recurrent unit are recognised. ``prev`` can be used to access
+the layer output from the previous recurrent step (e.g. for target embedding feedback).
+
+Layer Types
+-----------
+
+.. toctree::
+    :maxdepth: 2
+
+    basic.rst
+    shape.rst
+    recurrent.rst
+    attention.rst
+    norm.rst
+    custom.rst
+    utility.rst
+    loss.rst
+
+

--- a/docs/layer_reference/loss.rst
+++ b/docs/layer_reference/loss.rst
@@ -1,0 +1,105 @@
+.. _loss:
+
+==============
+Loss Functions
+==============
+
+
+Cross-Entropy Loss
+------------------
+
+.. autoclass:: TFNetworkLayer.CrossEntropyLoss
+	:members:
+	:undoc-members:
+
+Binary Cross-Entropy Loss
+-------------------------
+
+.. autoclass:: TFNetworkLayer.BinaryCrossEntropyLoss
+	:members:
+	:undoc-members:
+
+Generic Cross-Entropy Loss
+--------------------------
+
+.. autoclass:: TFNetworkLayer.GenericCELoss
+	:members:
+	:undoc-members:
+
+Mean-Squared-Error Loss
+-----------------------
+
+.. autoclass:: TFNetworkLayer.MeanSquaredError
+	:members:
+	:undoc-members:
+
+L1 Loss
+-------
+
+.. autoclass:: TFNetworkLayer.L1Loss
+	:members:
+	:undoc-members:
+
+CTC Loss
+--------
+
+.. autoclass:: TFNetworkLayer.CtcLoss
+	:members:
+	:undoc-members:
+
+Edit Distance Loss
+------------------
+
+.. autoclass:: TFNetworkLayer.EditDistanceLoss
+	:members:
+	:undoc-members:
+
+Bleu Loss
+---------
+
+.. autoclass:: TFNetworkLayer.BleuLoss
+	:members:
+	:undoc-members:
+
+Expected Loss
+-------------
+
+.. autoclass:: TFNetworkLayer.ExpectedLoss
+	:members:
+	:undoc-members:
+
+Extern Sprint Loss
+------------------
+
+.. autoclass:: TFNetworkLayer.ExternSprintLoss
+	:members:
+	:undoc-members:
+
+Deep Clustering Loss
+--------------------
+
+.. autoclass:: TFNetworkLayer.DeepClusteringLoss
+	:members:
+	:undoc-members:
+
+Fast Baum Welch Loss
+--------------------
+
+.. autoclass:: TFNetworkLayer.FastBaumWelchLoss
+	:members:
+	:undoc-members:
+
+Via Layer Loss
+--------------
+
+.. autoclass:: TFNetworkLayer.ViaLayerLoss
+	:members:
+	:undoc-members:
+
+Sampled Softmax Loss
+--------------------
+
+.. autoclass:: TFNetworkLayer.SampledSoftmaxLoss
+	:members:
+	:undoc-members:
+

--- a/docs/layer_reference/norm.rst
+++ b/docs/layer_reference/norm.rst
@@ -1,0 +1,21 @@
+.. _norm_layers:
+
+===========
+Norm Layers
+===========
+
+
+Batch-Normalization Layer
+-------------------------
+
+.. autoclass:: TFNetworkLayer.BatchNormLayer
+	:members:
+	:undoc-members:
+
+
+Layer-Normalization Layer
+-------------------------
+
+.. autoclass:: TFNetworkLayer.LayerNormLayer
+	:members:
+	:undoc-members:

--- a/docs/layer_reference/recurrent.rst
+++ b/docs/layer_reference/recurrent.rst
@@ -1,0 +1,58 @@
+.. _recurrent_layers:
+
+================
+Recurrent Layers
+================
+
+
+Recurrent Layer
+---------------
+
+.. autoclass:: TFNetworkRecLayer.RecLayer
+	:members:
+	:undoc-members:
+
+RNN Cell Layer
+--------------
+
+.. autoclass:: TFNetworkRecLayer.RnnCellLayer
+	:members:
+	:undoc-members:
+
+Get Last Hidden State Layer
+---------------------------
+
+.. autoclass:: TFNetworkRecLayer.GetLastHiddenStateLayer
+	:members:
+	:undoc-members:
+
+Get Accumulated Output Layer
+----------------------------
+
+.. autoclass:: TFNetworkRecLayer.GetRecAccumulatedOutputLayer
+	:members:
+	:undoc-members:
+
+Positional Encoding Layer
+-------------------------
+
+.. autoclass:: TFNetworkRecLayer.PositionalEncodingLayer
+	:members:
+	:undoc-members:
+
+Choice Layer
+------------
+
+.. autoclass:: TFNetworkRecLayer.ChoiceLayer
+	:members:
+	:undoc-members:
+
+Decision Layer
+--------------
+
+.. autoclass:: TFNetworkRecLayer.DecideLayer
+	:members:
+	:undoc-members:
+
+
+

--- a/docs/layer_reference/shape.rst
+++ b/docs/layer_reference/shape.rst
@@ -1,0 +1,92 @@
+.. _shape_layers:
+
+===========================
+Shape and Type Modification
+===========================
+
+Swap Axes Layer
+---------------
+
+.. autoclass:: TFNetworkLayer.SwapAxesLayer
+	:members:
+	:undoc-members:
+
+Resize Layer
+------------
+
+.. autoclass:: TFNetworkLayer.ResizeLayer
+	:members:
+	:undoc-members:
+
+Squeeze Layer
+-------------
+
+.. autoclass:: TFNetworkLayer.SqueezeLayer
+	:members:
+	:undoc-members:
+
+Reinterpret Data Layer
+----------------------
+
+.. autoclass:: TFNetworkLayer.ReinterpretDataLayer
+	:members:
+	:undoc-members:
+
+Expand Dimensions Layer
+-----------------------
+
+.. autoclass:: TFNetworkLayer.ExpandDimsLayer
+	:members:
+	:undoc-members:
+
+Split Dimensions Layer
+----------------------
+
+.. autoclass:: TFNetworkLayer.SplitDimsLayer
+	:members:
+	:undoc-members:
+
+Merge Dimensions Layer
+----------------------
+
+.. autoclass:: TFNetworkLayer.MergeDimsLayer
+	:members:
+	:undoc-members:
+
+Pad Layer
+---------
+
+.. autoclass:: TFNetworkLayer.PadLayer
+	:members:
+	:undoc-members:
+
+Slice Layer
+-----------
+
+.. autoclass:: TFNetworkLayer.SliceLayer
+	:members:
+	:undoc-members:
+
+Slice n-dim Layer
+-----------------
+
+.. autoclass:: TFNetworkLayer.SlideNdLayer
+	:members:
+	:undoc-members:
+
+Split Batch Time Layer
+----------------------
+
+.. autoclass:: TFNetworkLayer.SplitBatchTimeLayer
+	:members:
+	:undoc-members:
+
+Length Layer
+------------
+
+.. autoclass:: TFNetworkLayer.LengthLayer
+	:members:
+	:undoc-members:
+
+
+

--- a/docs/layer_reference/softmax.rst
+++ b/docs/layer_reference/softmax.rst
@@ -1,0 +1,26 @@
+.. _softmax_layers:
+
+==============
+Softmax Layers
+==============
+
+Softmax Layer
+-------------
+
+.. autoclass:: TFNetworkLayer.SoftmaxLayer
+	:members:
+	:undoc-members:
+
+Batched Softmax Layer
+---------------------
+
+.. autoclass:: TFNetworkLayer.BatchSoftmaxLayer
+	:members:
+	:undoc-members:
+
+Softmax-Over-Spatial Layer
+--------------------------
+
+.. autoclass:: TFNetworkLayer.SoftmaxOverSpatialLayer
+	:members:
+	:undoc-members:

--- a/docs/layer_reference/utility.rst
+++ b/docs/layer_reference/utility.rst
@@ -1,0 +1,42 @@
+.. _utility:
+
+==============
+Utility Layers
+==============
+
+Print Layer
+-----------
+
+.. autoclass:: TFNetworkLayer.PrintLayer
+	:members:
+	:undoc-members:
+
+Framewise Statistics Layer
+--------------------------
+
+.. autoclass:: TFNetworkLayer.FramewiseStatisticsLayer
+	:members:
+	:undoc-members:
+
+Dropout Layer
+-------------
+
+.. autoclass:: TFNetworkLayer.DropoutLayer
+	:members:
+	:undoc-members:
+
+Image Summary Layer
+-------------------
+
+.. autoclass:: TFNetworkLayer.ImageSummaryLayer
+	:members:
+	:undoc-members:
+
+Synthetic Gradient Layer
+------------------------
+
+.. autoclass:: TFNetworkLayer.SyntheticGradientLayer
+	:members:
+	:undoc-members:
+
+


### PR DESCRIPTION
For a better overview, i added the layer API docstrings sorted into layer categories, and added some general information that seemed helpful.