### PR TITLE
hdf-dump, fix bug: converting dataset with 'data' as target key

### DIFF
--- a/LmDataset.py
+++ b/LmDataset.py
@@ -159,6 +159,7 @@ class LmDataset(CachedDataset2):
     self.delayed_seq_data_start_symbol = delayed_seq_data_start_symbol
     if add_delayed_seq_data:
       self.num_outputs["delayed"] = self.num_outputs["data"]
+      self.labels["delayed"] = self.labels["data"]
 
     self.orths = read_corpus(corpus_file)
     # It's only estimated because we might filter some out or so.


### PR DESCRIPTION
Set "classes" to be the target key after conversion, when the
original dataset uses 'data' as the target key (which is reserved
to be the input key for the HDFDataset).

Add 'labels["delayed"]' in LmDataset.

These fix bug for converting LmDataset to HDFDataset.