### PR TITLE
Add option to avoid loading train_data

### DIFF
--- a/rnn.py
+++ b/rnn.py
@@ -233,7 +233,8 @@ def initData():
   if train_cache_bytes >= 0:
     # Maybe we have left over cache from dev/eval if dev/eval have cached everything.
     train_cache_bytes += extra_cache_bytes_dev + extra_cache_bytes_eval
-  train_data, extra_train = load_data(config, train_cache_bytes, 'train')
+  if not config.bool('ignore_train_data', False):
+    train_data, extra_train = load_data(config, train_cache_bytes, 'train')
 
 
 def printTaskProperties(devices=None):


### PR DESCRIPTION
Does this make sense @albertz, @jan-rosendahl-rwth ?
We should have an option to avoid loading the training data, for example for eval tasks.
@albertz, please suggest if you have a better solution or naming. Thanks!