### PR TITLE
LearningRateControl, alternative relative error

### DIFF
--- a/LearningRateControl.py
+++ b/LearningRateControl.py
@@ -40,6 +40,7 @@ class LearningRateControl(object):
                          or config.value('learning_rate_control_error_measure', None),
       "relativeErrorAlsoRelativeToLearningRate": config.bool('learning_rate_control_relative_error_relative_lr', False),
       "minNumEpochsPerNewLearningRate": config.int("learning_rate_control_min_num_epochs_per_new_lr", 0),
+      "relativeErrorDivByOld": config.bool('newbob_relative_error_div_by_old', False),
       "filename": config.value('learning_rate_file', None),
     }
 
@@ -56,12 +57,14 @@ class LearningRateControl(object):
                errorMeasureKey=None,
                relativeErrorAlsoRelativeToLearningRate=False,
                minNumEpochsPerNewLearningRate=0,
+               relativeErrorDivByOld=False,
                filename=None):
     """
     :param float defaultLearningRate: default learning rate. usually for epoch 1
     :param list[float] | dict[int,float] defaultLearningRates: learning rates
     :param str|list[str]|None errorMeasureKey: for getEpochErrorValue() the selector for EpochData.error which is a dict
     :param int minNumEpochsPerNewLearningRate: if the lr was recently updated, use it for at least N epochs
+    :param bool relativeErrorDivByOld: if True, compute relative error as (new - old) / old.
     :param str filename: load from and save to file
     """
     self.epochData = {}  # type: dict[int,LearningRateControl.EpochData]
@@ -79,6 +82,7 @@ class LearningRateControl(object):
     self.errorMeasureKey = errorMeasureKey
     self.relativeErrorAlsoRelativeToLearningRate = relativeErrorAlsoRelativeToLearningRate
     self.minNumEpochsPerNewLearningRate = minNumEpochsPerNewLearningRate
+    self.relativeErrorDivByOld = relativeErrorDivByOld
     self.filename = filename
     if filename:
       if os.path.exists(filename):
@@ -166,7 +170,10 @@ class LearningRateControl(object):
       return None
     if oldKey != newKey:
       return None
-    relativeError = (newError - oldError) / abs(newError)
+    if self.relativeErrorDivByOld:
+      relativeError = (newError - oldError) / abs(oldError)
+    else:
+      relativeError = (newError - oldError) / abs(newError)
     if self.relativeErrorAlsoRelativeToLearningRate:
       learningRate = self.getMostRecentLearningRate(newEpoch, excludeCurrent=False)
       # If the learning rate is lower than the initial learning rate,


### PR DESCRIPTION
Add 'newbob_relative_error_old_minus_new' option.
If 'newbob_relative_error_old_minus_new' is set to True, compute
relative error as (old - new) / old.
Otherwise (by default), (new - old) / new is used as before.

I would like to have an option to compute the relative change in this
direction and use positive valued lower-bound threshold (isn't this more natural?).
What do you think @albertz ?
This behavior can not be reproduced by the default code, even if you
try to fit the threshold.

Also, in line 176, 
```relativeError = (newError - oldError) / abs(newError)```
I think it is not correct to have "abs" in the denominator in the general case.