### PR TITLE
add all layer targets to used_data_keys in SubnetworkRecCell

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -437,6 +437,13 @@ class LayerBase(object):
           # Not resolving this in the dict as target, but call get_layer to make it available.
           if target.startswith("layer:"):
             target_layers[target] = get_layer(target[len("layer:"):])
+          else:
+            # Note: This is a workaround for cases where we need to know about used data keys before the layer
+            # itself is constructed (e.g. in _SubnetworkRecCell.get_output).
+            # A nicer solution would be to not modify this here,
+            # but instead lazily handle it in TFNetwork.get_extern_data,
+            # such that we do not need to know in advance which data keys we need.
+            network.used_data_keys.add(target)
     if "n_out" not in d and targets and network.eval_flag:
       # Must be done here now because loss might be set to None later.
       target = targets[0]  # guess using first target

--- a/TFNetworkRecLayer.py
+++ b/TFNetworkRecLayer.py
@@ -3612,13 +3612,11 @@ class ChoiceLayer(LayerBase):
     """
     if isinstance(d["target"], str):
       d["target"] = [d["target"]]
-    if not network.search_flag:
-      network.used_data_keys.update(d["target"])
-      if not d.get("scheduled_sampling"):
-        # In the dependency graph, we don't want it.
-        # This can enable some optimizations in the RecLayer.
-        # We do it here because we should know about the deps early in the template creation in RecLayer.
-        d["from"] = []
+    if not network.search_flag and not d.get("scheduled_sampling"):
+      # In the dependency graph, we don't want it.
+      # This can enable some optimizations in the RecLayer.
+      # We do it here because we should know about the deps early in the template creation in RecLayer.
+      d["from"] = []
     if d.get("explicit_search_source"):
       d["explicit_search_source"] = get_layer(d["explicit_search_source"]) if network.search_flag else None
     super(ChoiceLayer, cls).transform_config_dict(d, network=network, get_layer=get_layer)


### PR DESCRIPTION
Used keys is currently lacking any target that was specified in layers of the subnetwork. The subnetwork copies all targets from the parent network, and adds the defined target, but no additional targets.