### PR TITLE
SprintControl.py: convert segment name from bytes to string

### DIFF
--- a/SprintControl.py
+++ b/SprintControl.py
@@ -443,7 +443,7 @@ class PythonControl:
     with self.cond:
       self.control_thread__have_new_seg = True
       self.control_thread__have_new_error_signal = False
-      if isinstance(segment_name, bytes):
+      if isinstance(seg_name, bytes):
         self.seg_name = seg_name.decode('ascii')
       else:
         self.seg_name = seg_name

--- a/SprintControl.py
+++ b/SprintControl.py
@@ -122,7 +122,10 @@ def getSegmentList(corpusName, segmentList, config, **kwargs):
   init(name="CRNN.PythonSegmentOrder", reference=corpusName, config=config)
   PythonControl.instance.check_control_loop_running()
   for segment_name in PythonControl.instance.segment_list_iterator():
-    yield segment_name
+    if isinstance(segment_name, bytes):
+      yield segment_name.decode('ascii')
+    else:
+      yield segment_name
 
 # End Sprint PythonSegmentOrder interface. }
 
@@ -440,7 +443,10 @@ class PythonControl:
     with self.cond:
       self.control_thread__have_new_seg = True
       self.control_thread__have_new_error_signal = False
-      self.seg_name = seg_name
+      if isinstance(segment_name, bytes):
+        self.seg_name = seg_name.decode('ascii')
+      else:
+        self.seg_name = seg_name
       self.seg_len = seg_len
       self.posteriors = posteriors
       self.error_signal = None

--- a/SprintControl.py
+++ b/SprintControl.py
@@ -123,7 +123,7 @@ def getSegmentList(corpusName, segmentList, config, **kwargs):
   PythonControl.instance.check_control_loop_running()
   for segment_name in PythonControl.instance.segment_list_iterator():
     if isinstance(segment_name, bytes):
-      yield segment_name.decode('ascii')
+      yield segment_name.decode('utf-8')
     else:
       yield segment_name
 
@@ -444,7 +444,7 @@ class PythonControl:
       self.control_thread__have_new_seg = True
       self.control_thread__have_new_error_signal = False
       if isinstance(seg_name, bytes):
-        self.seg_name = seg_name.decode('ascii')
+        self.seg_name = seg_name.decode('utf-8')
       else:
         self.seg_name = seg_name
       self.seg_len = seg_len


### PR DESCRIPTION
When building RASR with Python 3, the segment name is encoded as bytes, so we need to decode it into string. It is not guaranteed, but in 100% of corpus files I've worked with, the segment name is pure ascii.

This PR should allow to keep using RASR binaries built with Python 2 as well as to switch to Python 3.