### PR TITLE
batch_norm, new flags, faster implementation, save/load bug fixed

### DIFF
--- a/TFUtil.py
+++ b/TFUtil.py
@@ -1736,8 +1736,12 @@ class Data(object):
       dyn_axes = [(i if (i < removed_axis) else (i - 1))
                   for i in dyn_axes]
       ndim -= 1
+    shape = tf.shape(x)
+    dyn_axes.sort()
+    # Transpose remaining dyn_axes, s.t. they are together before merge
+    perm = dyn_axes + [i for i in range(self.ndim) if i not in dyn_axes]
+    x = tf.transpose(x, perm=perm)
     if len(dyn_axes) > 1:
-      shape = tf.shape(x)
       x = tf.reshape(
         x,
         [tf.reduce_prod([shape[i] for i in dyn_axes])] +

--- a/tests/test_TFUtil.py
+++ b/tests/test_TFUtil.py
@@ -2783,6 +2783,34 @@ def test_same_context_loop():
   print("magic (totally arbitrary) res:", session.run(x))
 
 
+def test_flatten_with_seq_len_mask():
+  import numpy as np
+  import numpy.testing as npt
+  batch_dim_axis = 0
+  time_dim_axis = 2
+  x = tf.constant(np.random.rand(10, 16, 11, 16))
+  seq_lens = tf.constant([11, 11, 11, 11, 11, 11, 11, 11, 11, 11])
+
+  x_flat = flatten_with_seq_len_mask(x, seq_lens, batch_dim_axis, time_dim_axis)
+
+  x, x_flat = session.run([x, x_flat])
+  npt.assert_array_almost_equal(x[0, :, 1, :], x_flat[1])
+
+
+def test_flatten_with_unequal_seq_len_mask():
+  import numpy as np
+  import numpy.testing as npt
+  batch_dim_axis = 0
+  time_dim_axis = 2
+  x = tf.constant(np.random.rand(10, 16, 11, 16))
+  seq_lens = tf.constant([11, 11, 5, 11, 11, 11, 11, 11, 11, 11])
+
+  x_flat = flatten_with_seq_len_mask(x, seq_lens, batch_dim_axis, time_dim_axis)
+
+  x, x_flat = session.run([x, x_flat])
+  npt.assert_array_almost_equal(x[4, :, 1, :], x_flat[11 + 11 + 11 + 5 + 1])
+
+
 def test_softmax_cross_entropy_over_size_batch1():
   energy_np = numpy.array([
     [0.00060279], [0.00106305], [0.00139351], [0.0016565], [0.00179641], [0.00188511], [0.00197855],

--- a/tests/test_TFUtil.py
+++ b/tests/test_TFUtil.py
@@ -385,6 +385,33 @@ def test_4D_Data_get_placeholder_flattened():
   assert res.shape[0] == 7 * 9 * 13
   assert len(res.shape) == 2
 
+
+def test_4D_nhwc_Data_get_placeholder_flattened():
+  import numpy as np
+  import numpy.testing as npt
+  size_placeholder = tf.constant(np.full((7,), 9), dtype=tf.int32)
+  d = Data(name='test_data', shape=(13, None, 17), dtype='float32',
+           size_placeholder={1: size_placeholder}, batch_dim_axis=0,
+           time_dim_axis=2, feature_dim_axis=1)
+  placeholder = tf.placeholder(shape=(None, 13, None, 17), dtype=tf.float32)
+  d.placeholder = placeholder
+  feed_data = np.random.rand(7, 13, 9, 17)
+  res = session.run(d.placeholder, feed_dict={placeholder: feed_data})
+  print(res.shape)
+  flat_placeholder = d.get_placeholder_flattened(keep_dims=True)
+  res = session.run(flat_placeholder, feed_dict={placeholder: feed_data})
+  print(res.shape)
+  assert res.shape[0] == 7 * 9 * 17
+  assert len(res.shape) == 4
+  npt.assert_array_almost_equal(res[0, :, 0, 0], feed_data[0, :, 0, 0])
+  flat_placeholder = d.get_placeholder_flattened(keep_dims=False)
+  res = session.run(flat_placeholder, feed_dict={placeholder: feed_data})
+  print(res.shape)
+  assert res.shape[0] == 7 * 9 * 17
+  assert len(res.shape) == 2
+  npt.assert_array_almost_equal(res[0, :], feed_data[0, :, 0, 0])
+
+
 def test_2D_Data_get_placeholder_flattened():
   import numpy as np
   d = Data(name='test_data', shape=(17,), dtype='float32',


### PR DESCRIPTION
For conv nets it's beneficial to use both channel and frequency dims to gather the statistics in batch normalization. Added `use_frequency` flag. 
Also conv nets are trained faster in NCHW format, however when eval on cpu only NHWC format is available. => train in NCHW and recog in NHWC. But an error occurs: shape mismatch when saving in NCHW after training and loading in NHWC for recog. => perform all bn operations in one format (NHWC) . In case of input is in NCHW transpose to NHWC, perform operations, transpose back to NCHW.