### PR TITLE
Fix for static time-axis in generic_att

### DIFF
--- a/TFNetworkRecLayer.py
+++ b/TFNetworkRecLayer.py
@@ -4056,6 +4056,9 @@ class GenericAttentionLayer(AttentionBaseLayer):
     # SoftmaxOverSpatialLayer by default uses time_dim_axis.
     # We also should maybe check that this matches the base time dim axis.
     dyn_axes = weights.get_dynamic_axes()
+    # for static time-dim
+    if weights.time_dim_axis not in dyn_axes:
+      return weights.time_dim_axis
     assert dyn_axes, "no dynamic axes in %r" % weights
     # Simple case: Only one dynamic axis.
     # Do not do any further checks in this case. The runtime will crash if non-matching and this is simple to identify.

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -3323,6 +3323,28 @@ def test_GenericAttentionLayer_weights_auto_squeeze_time_end():
   assert layer.output.shape == (2048,) and not layer.output.have_time_axis()
 
 
+def test_GenericAttentionLayer_weights_static_time_axis():
+  # Example: weights (B,1,W), base (B,W,V), where W: window_size (static)
+  window_size = 10
+  from TFNetworkLayer import InternalLayer
+  net = TFNetwork(extern_data=ExternData(), config=Config({"debug_print_layer_output_template": True}))
+  kwargs = dict(
+    name="att", network=net,
+    weights=InternalLayer(
+      name="att_weights", network=net,
+      output=Data(
+        name='att_weights_output', shape=(1, 10), time_dim_axis=2, auto_create_placeholders=True)),
+    base=InternalLayer(
+      name="enc_value", network=net,
+      output=Data(name='enc_value_output', shape=(10, 2048), time_dim_axis=1, auto_create_placeholders=True)))
+  print("GenericAttentionLayer kwargs:")
+  pprint(kwargs)
+  kwargs["output"] = GenericAttentionLayer.get_out_data_from_opts(**kwargs)
+  layer = GenericAttentionLayer(**kwargs)
+  layer.output.sanity_check()
+  assert layer.output.shape == (2048,) and not layer.output.have_time_axis()
+
+
 def test_GenericAttentionLayer_weights_heads_time_end():
   # Example: weights (B,H,T), base (B,T,H,V)
   from TFNetworkLayer import InternalLayer


### PR DESCRIPTION
Support for static time axis in the `GenericAttentionLayer`.

See https://github.com/rwth-i6/returnn/commit/2da3644#r33196068 and further discussion.

