### PR TITLE
Added option to rename layers using preload_from_files

### DIFF
--- a/TFEngine.py
+++ b/TFEngine.py
@@ -921,7 +921,7 @@ class Engine(EngineBase):
         else:  # default: init for recog
           if is_training:
             continue
-        model_filename = opts['filename']
+        model_filename = opts.get('filename', model_epoch_filename)
         print("loading weights from", model_filename, file=log.v2)
         self_prefix = self.network.get_absolute_name_scope_prefix()  # "" if root, otherwise with "/" at end
         load_if_prefix = opts.get('prefix', '')  # prefix to identify the variables to be restored from the file
@@ -930,7 +930,8 @@ class Engine(EngineBase):
           filename=model_filename,
           saveable_params=self.network.get_params_list(),
           params_prefix=self_prefix, load_if_prefix=load_if_prefix,
-          ignore_missing=opts.get("ignore_missing", False))
+          ignore_missing=opts.get("ignore_missing", False),
+          layer_mapping=opts.get('layer_mapping', {}))
         loader.set_as_custom_init()
       self.network.initialize_params(session=self.tf_session)
 


### PR DESCRIPTION
This PR allows to rename a layer using the preload_from_files option. The correct syntax is:

    "preload_from_files": {
      'train_base': {
        'filename': model_filename,
        'prefix': 'swap_',
        'init_for_train': True,
        'layer_mapping': {
          'l1': 'l2',
          'l2': 'l1'
        }
      }
    },

if the layer `swap_l1` should be initialized using the trained weights of layer `l2`, and `swap_l2` should be initialized using layer `l1`.
If you don't specify the filename, the current checkpoint will be used. This is useful during inference, when one config file may be used for the evaluation of multiple checkpoints.

This should solve issue #166 