### PR TITLE
Mark time dimension and store sequence length

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -3345,12 +3345,14 @@ class ExpandDimsLayer(_ConcatInputLayer):
     data = self.input_data
     if isinstance(axis, int):
       data = data.copy_as_batch_major()
-    axis = self._get_axis(data=data, axis=axis)
+    axis_index = self._get_axis(data=data, axis=axis)
     from TFUtil import expand_dims_unbroadcast
-    self.output.placeholder = expand_dims_unbroadcast(data.placeholder, axis=axis, dim=dim)
+    self.output.placeholder = expand_dims_unbroadcast(data.placeholder, axis=axis_index, dim=dim)
     self.output.size_placeholder = {
-      (i if (data.get_batch_axis(i) < axis) else i + 1): v
+      (i if (data.get_batch_axis(i) < axis_index) else i + 1): v
       for (i, v) in data.size_placeholder.items()}
+    if axis.lower() in ["spatial", "time", "t"] and self.output.time_dim_axis is None:
+      self.output.time_dim_axis = axis_index
 
   @classmethod
   def _get_axis(cls, data, axis):


### PR DESCRIPTION
If the `ExpandDimsLayer` is used to add a time dimension, the time axis index is now stored as the new `output.time_dim_axis` and an entry in the `output.size_placeholder` dictionary is added.

This is needed, because some layers (at least the `HDFDumpLayer`) expect the time dimension to be variable and to be listed in the `output.size_placeholder`. If `HDFDumpLayer` is the only layer with this behavior, it could also be a bug over there.