### PR TITLE
Meta Loss to combine losses for learning rate scheduling

### DIFF
--- a/LearningRateControl.py
+++ b/LearningRateControl.py
@@ -236,6 +236,8 @@ class LearningRateControl(object):
       relative_error = (new_error - old_error) / abs(old_error)
     else:
       relative_error = (new_error - old_error) / abs(new_error)
+    import math
+    assert not math.isnan(relative_error)
     if self.relative_error_also_relative_to_learning_rate:
       learning_rate = self.get_most_recent_learning_rate(new_epoch, exclude_current=False)
       # If the learning rate is lower than the initial learning rate,

--- a/docs/configuration_reference/optimizer_settings.rst
+++ b/docs/configuration_reference/optimizer_settings.rst
@@ -61,7 +61,10 @@ optimizer_epsilon
 
 user_learning_rate_control_always
 
-
+meta_losses
+    A list of (name, formula) tuples that define arbitrary meta losses.
+    Every meta loss may combine any number of other losses. The formula is a string, which will be eval'ed.
+    This can be used in combination with learning_rate_control_error_measure to make the LR scheduling dependant on multiple losses.
 
 
 


### PR DESCRIPTION
This introduces a `MetaLoss`. It can be configured by the `meta_loss` setting in the config file. It may be any mathematical operation, using all defined losses, eg: `5 * decoder_src_output_prob_src + decoder_trg_output_prob_trg` (here, I have two recursive layers, `decoder_src` and `decoder_trg`, each containing `output_prob_src` and `output_prob_trg`, respectively.

This is meant to be used to control the learning rate scheduling if there are multiple outputs given, see #195.
The logic to actually choose the meta loss still needs to be implemented.