### PR TITLE
Reduced memory consumption of HDFDataset

### DIFF
--- a/CachedDataset.py
+++ b/CachedDataset.py
@@ -41,7 +41,6 @@ class CachedDataset(Dataset):
     self._seq_index_inv = {}; """ :type: dict[int,int] """  # Via init_seq_order(). hdf seq idx -> seq_index idx
     self._index_map = range(len(self._seq_index))  # sorted seq idx -> seq_index idx
     self._seq_lengths = numpy.zeros((0, 0))  # real seq idx -> tuple of len of data and all targets
-    self._tags = []; """ :type: list[str|bytes] """  # uses real seq idx. access via _get_tag_by_real_idx
     self._tag_idx = {}; ":type: dict[str,int] "  # map of tag -> real-seq-idx. call _update_tag_idx
     self.targets = {}
     self.target_keys = []
@@ -103,7 +102,7 @@ class CachedDataset(Dataset):
     return True
 
   def _get_tag_by_real_idx(self, real_idx):
-    return self._tags[real_idx]
+    raise NotImplementedError
 
   def _update_tag_idx(self):
     if self._tag_idx:


### PR DESCRIPTION
We had trouble using the HDFDataset on large amounts of sequences as experiments needed too much RAM. (The most extreme was >60 GB on 500M sequences.)

This is because the dataset stores many data structures of O(total number of sequences): sequence lengths, sequence tags, file index for each sequence, and start index for each sequence within the file. Note, that we don't use the cache, so the memory is consumed by this "meta data" only.

With the provided changes I managed to reduce that substantially. I realize that some of the changes might be controversial in terms of design decisions and speed performance, so let's discuss.


...by the way, you could even go one step further and remove the last O(total number of sequences) object `self.file_seq_start` by storing this information in the HDF file instead of the sequence lengths. Then, theoretically, the number of sequences would be unlimited (while sacrificing more speed).