### PR TITLE
problem with CombineLayer after ConvLayer

### DIFF
--- a/TFUtil.py
+++ b/TFUtil.py
@@ -2173,7 +2173,7 @@ class Data(object):
       common = common.copy()
       # Note: we don't use copy_extend_with_beam because we don't want to create any ops in the TF graph at this point.
       common.beam_size = max([s.beam_size or 0 for s in sources])
-    is_equal_opts = dict(ignore_feature_dim=True)
+    is_equal_opts = dict(ignore_feature_dim=True, allow_same_spatial_dim=True)
     all_dim_tags, tags_dict = DimensionTag.get_all_dimension_tags(sources, is_equal_opts=is_equal_opts)
     # Note: We cannot compare len(all_dims_tags) to len(shape) as e.g. shape (B,1,1,D) would have only 3 dim tags.
     largest_dim_tags, _ = DimensionTag.get_all_dimension_tags([common], is_equal_opts=is_equal_opts)

--- a/tests/test_TFUtil.py
+++ b/tests/test_TFUtil.py
@@ -469,6 +469,22 @@ def test_Data_copy_compatible_to_batch_feature_is_dynamic():
   assert_equal(t.get_size_dim_tag(0), dec.get_time_dim_tag())
 
 
+def test_Data_get_common_data_extra_static_spatial():
+  d1 = Data(name='t', shape=(None, 32, 128), dtype='float32', auto_create_placeholders=True)
+  d2 = Data(name='r', shape=(None, 32, 128), dtype='float32', auto_create_placeholders=True)
+  d2.get_size_dim_tag(0).declare_same_as(d1.get_size_dim_tag(0))
+  common = Data.get_common_data([d1, d2], warnings_out=sys.stdout)
+  assert d1.shape == common.shape
+
+
+def test_Data_get_common_data_extra2_static_spatial():
+  d1 = Data(name='t', shape=(None, 32, 32, 128), dtype='float32', auto_create_placeholders=True)
+  d2 = Data(name='r', shape=(None, 32, 32, 128), dtype='float32', auto_create_placeholders=True)
+  d2.get_size_dim_tag(0).declare_same_as(d1.get_size_dim_tag(0))
+  common = Data.get_common_data([d1, d2], warnings_out=sys.stdout)
+  assert d1.shape == common.shape
+
+
 def test_Data_copy_compatible_to_get_common_data_auto_feature_non_sparse():
   d1 = Data(name='t', shape=(None,), dtype='int32', batch_dim_axis=None, feature_dim_axis=None,
             auto_create_placeholders=True)  # placeholder for specific spatial dim-tag


### PR DESCRIPTION
test Data.get_common_data for two sources with equal shape. Expecting to get the same shape. 
The behavior is required by CombineLayer with param `kind=add`. Common shape has to be the same as the shape of two inputs to do addition.   