### PR TITLE
PositionalEncodingLayer, changes to support offset

### DIFF
--- a/TFNetworkRecLayer.py
+++ b/TFNetworkRecLayer.py
@@ -5293,15 +5293,14 @@ class SelfAttentionLayer(_ConcatInputLayer):
 
 class PositionalEncodingLayer(_ConcatInputLayer):
   """
-  Provides positional encoding in the form of (batch, time, n_out),
-  where n_out is the number of channels,
-  if it is run outside a :class:`RecLayer`,
-  or (batch, n_out)
+  Provides positional encoding in the form of (batch, time, n_out) or (time, batch, n_out) same as the source
+  where n_out is the number of channels, if it is run outside a :class:`RecLayer`,
+  and (batch, n_out) or (n_out, batch) same as the source
   if run inside a :class:`RecLayer`, where it will depend on the current time frame.
 
   Assumes one source input with a time dimension if outside a :class:`RecLayer`.
-  By default ("from" key not provided), it would either use "data", or ":i".
   With `add_to_input`, it will calculate `x + input`.
+  The output shape is the same as the input in all cases.
 
   The positional encoding is the same as in Tensor2Tensor.
   See :func:`TFUtil.get_positional_encoding`.
@@ -5309,33 +5308,54 @@ class PositionalEncodingLayer(_ConcatInputLayer):
   layer_class = "positional_encoding"
   recurrent = True
 
-  def __init__(self, add_to_input=False, constant=-1, **kwargs):
+  def __init__(self, add_to_input=False, constant=-1, offset=None, **kwargs):
     """
     :param bool add_to_input: will add the signal to the input
     :param int constant: if positive, always output the corresponding positional encoding.
+    :param None|LayerBase offset: Specify the offset to be added to positions. Expect shape (batch, time) or (batch,).
     """
     super(PositionalEncodingLayer, self).__init__(**kwargs)
     assert len(self.sources) == 1, "%s: expect a single source" % self
     source = self.input_data
+    assert source.feature_dim_axis == source.batch_ndim - 1  # Must be last
     if add_to_input:
       assert source.dim == self.output.dim
+    output_templ_wo_feat = self.output.copy_template_excluding_axis(self.output.feature_dim_axis)
+    offset_data = None
+    if offset:
+      offset_data = offset.output.copy_compatible_to(output_templ_wo_feat, check_dtype=False)
     from TFUtil import get_positional_encoding
     if source.have_time_axis():
-      length = tf.shape(source.placeholder)[source.time_dim_axis]
       if constant > -1:
-        position = constant * tf.ones([length], tf.int32)
-        signal = get_positional_encoding(num_channels=self.output.dim, position=position)  # (len,n_out)
+        position = constant * tf.ones([1] * output_templ_wo_feat.batch_ndim, tf.int32)
+        if offset_data:
+          position += offset_data.placeholder  # (batch, len)
+        # signal has shape (1, len) or (batch, len) or (1, 1) or more ones
+        signal = get_positional_encoding(num_channels=self.output.dim, position=position)
+        if not add_to_input and not offset_data:  # Need to tile the time dimension
+          tiles = [1] * self.output.batch_ndim
+          tiles[self.output.time_dim_axis] = tf.shape(source.placeholder)[source.time_dim_axis]
+          signal = tf.tile(signal, tiles)
       else:
-        signal = get_positional_encoding(num_channels=self.output.dim, length=length)  # (len,n_out)
+        length = tf.shape(source.placeholder)[source.time_dim_axis]
+        position = tf.range(length)  # (len,)
+        # Expand dims e.g. (1, len)
+        position = tf.reshape(
+          position,
+          [length if i == output_templ_wo_feat.time_dim_axis else 1 for i in range(output_templ_wo_feat.batch_ndim)])
+        if offset_data:
+          position += offset_data.placeholder
+        # signal has shape (1,len,n_out) or (batch,len,n_out)
+        signal = get_positional_encoding(num_channels=self.output.dim, position=position)
     else:
       if constant > -1:
         position = tf.convert_to_tensor([constant])
       else:
         position = tf.convert_to_tensor([self.network.get_rec_step_index()])
-      signal = get_positional_encoding(num_channels=self.output.dim, position=position)  # (1,n_out)
-      signal = tf.squeeze(signal, axis=0)  # (n_out,)
-    if self.output.batch_dim_axis is not None:
-      signal = tf.expand_dims(signal, axis=self.output.batch_dim_axis)  # e.g. (len,batch,n_out)
+      if offset_data:
+        position += offset_data.placeholder  # (batch,)
+      signal = get_positional_encoding(num_channels=self.output.dim, position=position)  # (1,n_out) or (batch,n_out)
+
     if add_to_input:
       signal += source.placeholder
     else:
@@ -5358,6 +5378,8 @@ class PositionalEncodingLayer(_ConcatInputLayer):
       else:
         d["from"] = ["data"]
     super(PositionalEncodingLayer, cls).transform_config_dict(d, network=network, get_layer=get_layer)
+    if d.get("offset", None):
+      d["offset"] = get_layer(d["offset"])
 
   @classmethod
   def get_out_data_from_opts(cls, name, network, add_to_input=False, sources=(), **kwargs):

--- a/TFUtil.py
+++ b/TFUtil.py
@@ -8625,7 +8625,7 @@ def get_positional_encoding(num_channels, length=None, position=None, min_timesc
   memory inputs to attention.
 
   The use of relative position is possible because sin(x+y) and cos(x+y) can be
-  experessed in terms of y, sin(x) and cos(x).
+  expressed in terms of y, sin(x) and cos(x).
 
   In particular, we use a geometric sequence of timescales starting with
   min_timescale and ending with max_timescale.  The number of different
@@ -8638,11 +8638,11 @@ def get_positional_encoding(num_channels, length=None, position=None, min_timesc
 
   :param int num_channels: scalar, size of timing embeddings to create. The number of
     different timescales is equal to channels / 2.
-  :param tf.Tensor|None length: scalar, length of timing signal sequence. if not given, is shape(position)[0]
-  :param tf.Tensor|None position: could be provided directly. int32, shape (length,)
-  :param float min_timescale: a float
-  :param float max_timescale: a float
-  :return: a Tensor of timing signals (length, channels)
+  :param tf.Tensor|None length: scalar, length of timing signal sequence.
+  :param tf.Tensor|None position: could be provided directly. int32. Can have any shape.
+  :param float min_timescale: a float.
+  :param float max_timescale: a float.
+  :return: a Tensor of timing signals of shape (length, channels) or (batch, length, channels).
   :rtype: tf.Tensor
   """
   import math
@@ -8651,16 +8651,17 @@ def get_positional_encoding(num_channels, length=None, position=None, min_timesc
     position = tf.range(length)
   else:
     assert length is None
-    position.set_shape((None,))
   position = tf.to_float(position)
   num_timescales = num_channels // 2
   log_timescale_increment = (
     math.log(float(max_timescale) / float(min_timescale)) / (float(num_timescales - 1)))
   inv_timescales = min_timescale * tf.exp(
     tf.to_float(tf.range(num_timescales)) * -log_timescale_increment)
-  scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)
-  signal = tf.concat([tf.sin(scaled_time), tf.cos(scaled_time)], axis=1)
-  signal = tf.pad(signal, [[0, 0], [0, num_channels % 2]])  # (length, channels)
+  scale = tf.reshape(inv_timescales, [1] * len(position.shape) + [num_timescales])  # Usually (1, D//2) or (1, 1, D//2).
+  scaled_time = tf.expand_dims(position, -1) * scale
+  signal = tf.concat([tf.sin(scaled_time), tf.cos(scaled_time)], axis=-1)
+  # (length, channels) or (batch, length, channels).
+  signal = tf.pad(signal, [[0, 0]] * len(position.shape) + [[0, num_channels % 2]])
   return signal
 
 

--- a/tests/test_TFUtil.py
+++ b/tests/test_TFUtil.py
@@ -3186,6 +3186,30 @@ def test_FetchHelper_loop_invalid_vars_switch():
     assert fetch_helper.callback_count >= 1
 
 
+def test_get_positional_encoding_batch_position():
+  # Test `get_positional_encoding` with `position` with a batch dimension.
+  num_channels = 8
+  position0 = tf.range(5)
+  position1 = tf.range(5, 10)
+  position2 = tf.range(5)
+  position = tf.stack([position0, position1, position2])  # (3, 5).
+  signal = get_positional_encoding(num_channels=num_channels, position=position)  # (3, 5, 8).
+  signal1 = get_positional_encoding(num_channels=num_channels, position=position1)  # (5, 8).
+  signal_np, signal1_np = session.run([signal, signal1])
+  assert signal_np.shape == (3, 5, 8)
+  numpy.array_equal(signal1_np, signal_np[1])
+
+
+def test_get_position_encoding():
+  y = get_positional_encoding(num_channels=4, position=tf.range(3))
+  values = session.run(y)
+  numpy.testing.assert_almost_equal(
+    values,
+    [[0.0, 0.0, 1.0, 1.0],
+     [0.8414709568023682, 9.99999901978299e-05, 0.5403022766113281, 1.0],
+     [0.9092974066734314, 0.0001999999803956598, -0.416146844625473, 1.0]])
+
+
 if __name__ == "__main__":
   try:
     better_exchook.install()

--- a/tests/test_TFUtil.py
+++ b/tests/test_TFUtil.py
@@ -305,6 +305,16 @@ def test_Data_copy_template_excluding_spatial_dim():
   assert rem_enc_time.shape == (None, 1) and rem_enc_time.batch_dim_axis == 1
 
 
+def test_Data_copy_template_excluding_axis():
+  data = Data(name="data", shape=(None, 8), batch_dim_axis=0, time_dim_axis=1, feature_dim_axis=2)
+  data_wo_batch = data.copy_template_excluding_axis(data.batch_dim_axis)
+  assert data_wo_batch.shape == (None, 8) and data_wo_batch.feature_dim_axis == 1 and data_wo_batch.time_dim_axis == 0
+  data_wo_time = data.copy_template_excluding_axis(data.time_dim_axis)
+  assert data_wo_time.shape == (8,) and data_wo_time.feature_dim_axis == 1 and data_wo_time.batch_dim_axis == 0
+  data_wo_feature = data.copy_template_excluding_axis(data.feature_dim_axis)
+  assert data_wo_feature.shape == (None,) and data_wo_feature.time_dim_axis == 1 and data_wo_feature.batch_dim_axis == 0
+
+
 def test_Data_copy_squeeze_axes():
   weights = Data(name='att_weights_output', shape=(1, None), time_dim_axis=2, auto_create_placeholders=True)
   squeezed = weights.copy_squeeze_axes([1])


### PR DESCRIPTION
Changes to support `offset` option in `PositionalEncodingLayer`.

This enables using another layer as offsets to shift positions.

In addition, this removes the previously available option to specify `batch_dim_axis` independently of the input when `add_to_input` is `False`. The output shape is now always set to be the same as the input shape. Please let me know if anyone is against this change.