### PR TITLE
TemplateLayer: don't normalize to real layer

### DIFF
--- a/TFNetworkRecLayer.py
+++ b/TFNetworkRecLayer.py
@@ -3070,6 +3070,8 @@ class _TemplateLayer(LayerBase):
       # All refs to this subnet are other _TemplateLayer, no matter if prev-frame or not.
       # Otherwise, refs to the base network are given as-is.
       dependencies = list(self.cur_frame_dependencies)
+      # If real layer already constructed, use it.
+      dependencies = [d.get_normalized_layer() for d in dependencies]
       if self.prev_frame_dependencies:
         cell = self._get_cell()
         for layer in self.prev_frame_dependencies:


### PR DESCRIPTION
This is more an issue than a solution.
I get the following error when using two dependent choice layers in the recurrent unit (called 'output_lemma' and 'output_casing', in this order):

```
Exception: get_search_choices src=<ReduceOutLayer 'readout' out_type=Data(shape=(100,), time_dim_axis=None, beam=SearchBeam(name='output/prev:output_casing', beam_size=13), batch_shape_meta=[B,F|100])> base_search_choice=None sources=None.
Search choices cannot be compared.
Layer 1
  <_TemplateLayer(ChoiceLayer)(:template:choice) 'output_casing' out_type=Data(shape=(), dtype='int32', sparse=True, dim=5, time_dim_axis=None, beam=SearchBeam(name='output/output_casing', beam_size=13, dependency=SearchBeam(name='output/output_lemma', beam_size=12)), batch_shape_meta=[B]) (construction stack 'output')>
choice trace
[<_TemplateLayer(ChoiceLayer)(:template:choice) 'output_casing' out_type=Data(shape=(), dtype='int32', sparse=True, dim=5, time_dim_axis=None, beam=SearchBeam(name='output/output_casing', beam_size=13, dependency=SearchBeam(name='output/output_lemma', beam_size=12)), batch_shape_meta=[B]) (construction stack 'output')>,
 <_TemplateLayer(ChoiceLayer)(:prev:choice) 'prev:output_lemma' out_type=Data(shape=(), dtype='int32', sparse=True, dim=2192, time_dim_axis=None, beam=SearchBeam(name='output/prev:output_lemma', beam_size=12), batch_shape_meta=[B]) (construction stack None)>,
 <_TemplateLayer(ChoiceLayer)(:prev:choice) 'prev:output_casing' out_type=Data(shape=(), dtype='int32', sparse=True, dim=5, time_dim_axis=None, beam=SearchBeam(name='output/prev:output_casing', beam_size=13), batch_shape_meta=[B]) (construction stack None)>,
 <_TemplateLayer(ChoiceLayer)(:template:choice) 'output_lemma' out_type=Data(shape=(), dtype='int32', sparse=True, dim=2192, time_dim_axis=None, beam=SearchBeam(name='output/output_lemma', beam_size=12), batch_shape_meta=[B]) (construction stack 'target_embed_lemma')>]
vs layer 2
  <ChoiceLayer 'output_lemma' out_type=Data(shape=(), dtype='int32', sparse=True, dim=2192, time_dim_axis=None, beam=SearchBeam(name='output/output_lemma', beam_size=12, dependency=SearchBeam(name='output/prev:output_casing', beam_size=13)), batch_shape_meta=[B])>
choice trace
[<ChoiceLayer 'output_lemma' out_type=Data(shape=(), dtype='int32', sparse=True, dim=2192, time_dim_axis=None, beam=SearchBeam(name='output/output_lemma', beam_size=12, dependency=SearchBeam(name='output/prev:output_casing', beam_size=13)), batch_shape_meta=[B])>,
 <_TemplateLayer(ChoiceLayer)(:prev:choice) 'prev:output_lemma' out_type=Data(shape=(), dtype='int32', sparse=True, dim=2192, time_dim_axis=None, beam=SearchBeam(name='output/prev:output_lemma', beam_size=12), batch_shape_meta=[B]) (construction stack None)>,
 <_TemplateLayer(ChoiceLayer)(:prev:choice) 'prev:output_casing' out_type=Data(shape=(), dtype='int32', sparse=True, dim=5, time_dim_axis=None, beam=SearchBeam(name='output/prev:output_casing', beam_size=13), batch_shape_meta=[B]) (construction stack None)>].
```

The issue is that the 'prev:output_lemma ' layer got normalized to the ChoiceLayer 'output_lemma' (which is already constructed), but the trace contains only the Template for 'output_lemma', and real layer and template don't compare equal.

I don't see a nice way to solve this if normalization means going from prev to current time step **and** going from template to real layer.

This is the related code in `TFNetwork.get_search_choices().compare_layer()`:
```
      l1n = l1.get_normalized_layer()
      l2n = l2.get_normalized_layer()
      if l1 != l1n and l2 != l2n:  # only in the case that we get normalized variants for both
        l1, l2 = l1n, l2n
      if l1 is l2:
        return 0
      l1trace_ = full_trace_for_layer(l1)
      l2trace_ = full_trace_for_layer(l2)
      if l1 in l2trace_ and l2 not in l1trace_:
        return -1
      if l2 in l1trace_ and l1 not in l2trace_:
        return 1
```

Either we would have to normalize the trace to real layers but not to current time frame, or we would have to normalize l1 and l2 in time but not to real layers.
Related, I think line 3 and 4 are problematic because e.g. `l1 = TemplateLayer prev:output` and `l2 = TemplateLayer output` would both be normalized to `ChoiceLayer output`, but clearly l1 < l2.

Right now, we use normalization only to handle search choices and this should be possible without real layers, so this commit should indeed be a solution. Also, I find it confusing that the return value of`TemplateLayer.get_dep_layers()` depends on the order of layer initializations. But maybe one of the solutions above is better. Or maybe make template and real layer compare equal?