### PR TITLE
change dtype of ActivationLayer output according to placeholder

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -2314,6 +2314,7 @@ class ActivationLayer(CopyLayer):
     else:
       self.output_before_activation = OutputWithActivation(x)
     self.output.placeholder = self.output_before_activation.y
+    self.output.dtype = self.output_before_activation.y.dtype.base_dtype.name
 
 
 class BatchNormLayer(CopyLayer):


### PR DESCRIPTION
Some activation functions have a different `dtype` at the output compared to the input.
E.g. `tf.abs` converts `tf.complex64` to `tf.float32`.

Thus the `ActivationLayer` should change the `dtype` of the `self.output` accordingly