### PR TITLE
TF model paths are allowed to have .meta postfix

### DIFF
--- a/EngineBase.py
+++ b/EngineBase.py
@@ -73,10 +73,14 @@ class EngineBase(object):
       assert start_epoch >= 1
 
     load_model_epoch_filename = config.value('load', '')
+    if load_model_epoch_filename.endswith(".meta"):
+      load_model_epoch_filename = load_model_epoch_filename[:-len(".meta")]
     if load_model_epoch_filename:
       assert os.path.exists(load_model_epoch_filename + get_model_filename_postfix())
 
     import_model_train_epoch1 = config.value('import_model_train_epoch1', '')
+    if import_model_train_epoch1.endswith(".meta"):
+      import_model_train_epoch1 = import_model_train_epoch1[:-len(".meta")]
     if import_model_train_epoch1:
       assert os.path.exists(import_model_train_epoch1 + get_model_filename_postfix())
 


### PR DESCRIPTION
Sisyphus can only handle existing paths, so .meta has to be part of the path.