### PR TITLE
ChoiceLayer: support for more than two targets

### DIFF
--- a/TFNetworkRecLayer.py
+++ b/TFNetworkRecLayer.py
@@ -4055,6 +4055,15 @@ class ChoiceLayer(BaseChoiceLayer):
   Assume that each batch is already a choice via search.
   In search with a beam size of N, we would output
   sparse (batch=N,) and scores for each.
+
+  In case of multiple sources, this layer computes the top-k combinations of choices. The score of such a combination
+  is determined by adding up the (log-space) scores of the choices for the individual sources. In this case, the
+  'target' parameter of the layer has to be set to a list of targets corresponding to the sources respectively. Because
+  computing all possible combinations of source scores is costly, the sources are pruned beforehand using the beam
+  sizes set by the 'source_beam_sizes' parameter. The choices made for the different sources can be accessed via the
+  sublayers '<choice layer name>/out_0', '<choice layer name>/out_1' and so on.
+  Note, that the way scores are combined assumes the sources to be independent. If you want to model a dependency,
+  use separate ChoiceLayers and let the input of one depend on the output of the other.
   """
   layer_class = "choice"
 


### PR DESCRIPTION
I generalised the implementation of target factors in the ChoiceLayer to an arbitrary number of targets.

Also I changed the tests to 3 instead of 2 targets. A single choice layer with 3 targets works, however the other test, where there are 3 separate ChoiceLayers depending on each other, fails. Something seems to go wrong in `get_search_choices`, I will try to look into this, but help is appreciated.

The two things are only somewhat related, I could also make separate PRs...