### PR TITLE
CachedDataset2, get_data_dtype return as string

### DIFF
--- a/CachedDataset2.py
+++ b/CachedDataset2.py
@@ -265,7 +265,7 @@ class CachedDataset2(Dataset):
     :rtype: str
     """
     self._load_something()
-    return self.added_data[0].get_data(key).dtype
+    return str(self.added_data[0].get_data(key).dtype)
 
 
 class SingleStreamPipeDataset(CachedDataset2):


### PR DESCRIPTION
I think the return value should be of type `str`. It is also mentioned like that in the docstring.