### PR TITLE
test_TFEngine, test_init_network_from_config_preload_from_files_eval

### DIFF
--- a/tests/test_TFEngine.py
+++ b/tests/test_TFEngine.py
@@ -2579,6 +2579,64 @@ def test_preload_from_files_ignore_missing():
   engine.finalize()
 
 
+# Test `init_network_from_config` for eval when both `model_epoch_filename` and `preload_from_files` are not None.
+def test_init_network_from_config_preload_from_files_eval():
+  import tempfile
+  model_tmp_dir = tempfile.mkdtemp("-tmp-checkpoint")
+  # Name ending with ".042" for `save_params_to_file` to generate a model checkpoint for epoch 42.
+  # The same files are also used for pre-loading.
+  preload_model_filename = model_tmp_dir + "/model.042"
+  with make_scope() as session:
+    config = Config()
+    n_in, n_hidden, n_out = 2, 5, 3
+    config.update({
+      "num_outputs": n_out,
+      "num_inputs": n_in,
+      "network": {
+        "l1": {"class": "linear", "activation": None, "n_out": n_hidden},
+        "output": {"class": "linear", "activation": None, "n_out": n_out, "from": ["l1"]}
+      }
+    })
+    network = TFNetwork(config=config, train_flag=True)
+    network.construct_from_dict(config.typed_dict["network"])
+    network.initialize_params(session)
+    network.save_params_to_file(filename=preload_model_filename, session=session)
+
+  config = Config()
+  config.update({
+    "num_outputs": n_out,
+    "num_inputs": n_in,
+    "network": {
+      "l1": {"class": "linear", "activation": None, "n_out": n_hidden},
+      "main_l1": {"class": "linear", "activation": None, "n_out": n_hidden},
+      "add": {"class": "eval", "eval": "source(0) + source(1)", "n_out": n_hidden, "from": ["l1", "main_l1"]},
+      "output": {"is_output_layer": True, "class": "linear", "activation": None, "n_out": n_out, "from": ["add"]},
+    },
+    "preload_from_files": {
+      'train_base': {
+        'filename': preload_model_filename,  # Pre-load from an arbitrary file.
+        'prefix': 'main_',
+      }
+    },
+    "task": "eval",
+    "load_epoch": 42,  # Load from a checkpoint.
+    "device": "cpu",
+    "batch_size": 50,
+    "model": model_tmp_dir + "/model",
+  })
+
+  from GeneratingDataset import DummyDataset
+  from TFEngine import Engine
+  seq_len = 5
+  n_data_dim = n_in
+  n_classes_dim = n_out
+  cv_data = DummyDataset(input_dim=n_data_dim, output_dim=n_classes_dim, num_seqs=2, seq_len=seq_len)
+  cv_data.init_seq_order(epoch=1)
+  engine = Engine(config=config)
+  engine.init_train_from_config(config=config, train_data=None, dev_data=cv_data, eval_data=None)
+  engine.finalize()
+
+
 def test_TikhonovRegularizationLayer():
   """
   Tests :class:`TikhonovRegularizationLayer`.


### PR DESCRIPTION
One more test for `preload_from_files` which covers the typical eval case.

This test fails with 85b3d6aad972b7c592b380cf1b416ebd923f7835 and passes after the fix 083cf37ac75fea98f2a0596c0e2f35f116d40429.
