### PR TITLE
WarpRNNT wrapper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = extern/ParseOggVorbis
 	url = https://github.com/albertz/ParseOggVorbis.git
 	branch = master
+[submodule "extern/HawkAaronWarpTransducer/warp-transducer"]
+	path = extern/HawkAaronWarpTransducer/warp-transducer
+	url = https://github.com/HawkAaron/warp-transducer.git

--- a/extern/HawkAaronWarpTransducer/__init__.py
+++ b/extern/HawkAaronWarpTransducer/__init__.py
@@ -1,0 +1,107 @@
+"""
+Provides a RETURNN wrapper around `warp-transducer`:
+  https://github.com/HawkAaron/warp-transducer
+
+Other references:
+  https://github.com/awni/transducer (reference implementation)
+  https://github.com/1ytic/warp-rnnt (CUDA-Warp RNN-Transducer, with pytorch binding)
+  https://github.com/ZhengkunTian/rnn-transducer (pytorch implementation)
+Importing this module immediately compiles the library and TF module.
+"""
+
+import tensorflow as tf
+from tensorflow.python.framework import ops
+import os
+from TFUtil import OpCodeCompiler
+
+
+warprnnt_dir = os.path.dirname(os.path.abspath(__file__))
+submodule_dir = os.path.join(warprnnt_dir, "warp-transducer")
+_tf_mod = None
+
+
+def is_checked_out():
+  """Checks if the git submodule is checkout out."""
+  return os.path.isfile("%s/src/rnnt_entrypoint.cpp" % submodule_dir)
+
+
+def init_warprnnt(verbose=False):
+  """
+  Initialiazes and compiles the library. Caches the TF module.
+  :param bool verbose:
+  """
+  global _tf_mod
+  assert is_checked_out(), "submodule not checked out? Run `git submodule update --init --recursive`"
+
+  # References:
+  # https://github.com/HawkAaron/warp-transducer/blob/master/tensorflow_binding/setup.py
+
+  src_files = ['%s/src/rnnt_entrypoint.cpp' % submodule_dir,
+               '%s/tensorflow_binding/src/warprnnt_op.cc' % submodule_dir]
+  assert all([os.path.isfile(f) for f in src_files]), "submodule in %r not checked out?" % warprnnt_dir
+  src_code = ""
+  for fn in src_files:
+    f_code = open(fn).read()
+    src_code += "\n// ------------ %s : BEGIN { ------------\n" % os.path.basename(fn)
+    # https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html#Line-Control
+    src_code += "#line 1 \"%s\"\n" % os.path.basename(fn)
+    src_code += f_code
+    src_code += "\n// ------------ %s : END } --------------\n\n" % os.path.basename(fn)
+
+  compiler = OpCodeCompiler(
+    base_name="warprnnt_kernels", code_version=1, code=src_code,
+    include_paths=(submodule_dir + "/include",),
+    c_macro_defines={"WITH_OMP": 1},
+    ld_flags=["-Xcompiler", "-fopenmp"],
+    is_cpp=True, use_cuda_if_available=True,
+    verbose=verbose)
+  tf_mod = compiler.load_tf_module()
+  assert hasattr(tf_mod, "WarpRNNT"), "content of mod: %r" % (dir(tf_mod),)
+  _tf_mod = tf_mod
+  return tf_mod
+
+
+def rnnt_loss(acts, labels, input_lengths, label_lengths, blank_label=0):
+  """Computes the RNNT loss between a sequence of activations and a
+  ground truth labeling.
+  Args:
+      acts: A 4-D Tensor of floats.  The dimensions
+                   should be (B, T, U, V), where B is the minibatch index,
+                   T is the time index, U is the prediction network sequence
+                   length, and V indexes over activations for each
+                   symbol in the alphabet.
+      labels: A 2-D Tensor of ints, a padded label sequences to make sure
+                   labels for the minibatch are same length.
+      input_lengths: A 1-D Tensor of ints, the number of time steps
+                     for each sequence in the minibatch.
+      label_lengths: A 1-D Tensor of ints, the length of each label
+                     for each example in the minibatch.
+      blank_label: int, the label value/index that the RNNT
+                   calculation should use as the blank label
+  Returns:
+      1-D float Tensor, the cost of each example in the minibatch
+      (as negative log probabilities).
+  * This class performs the softmax operation internally.
+  * The label reserved for the blank symbol should be label 0.
+  """
+  loss, _ = _tf_mod.warp_rnnt(acts, labels, input_lengths,
+                              label_lengths, blank_label)
+  return loss
+
+
+@ops.RegisterGradient("WarpRNNT")
+def _RNNTLossGrad(op, grad_loss, _):
+  grad = op.outputs[1]
+  # NOTE since here we are batch first, cannot use _BroadcastMul
+  grad_loss = tf.reshape(grad_loss, (-1, 1, 1, 1))
+  return [grad_loss * grad, None, None, None]
+
+
+@ops.RegisterShape("WarpRNNT")
+def _RNNTLossShape(op):
+  inputs_shape = op.inputs[0].get_shape().with_rank(4)
+  batch_size = inputs_shape[0]
+  return [batch_size, inputs_shape]
+
+
+init_warprnnt()

--- a/tests/test_TFNativeOp.py
+++ b/tests/test_TFNativeOp.py
@@ -3033,6 +3033,95 @@ def test_blocksparse_simple_feature_axis1():
   assert_allclose(result, y_test)
 
 
+def _run_rnnt(acts, labels, input_lengths, label_lengths,
+              expected_costs, expected_grads, blank):
+  from extern.HawkAaronWarpTransducer import rnnt_loss
+  assert_equal(acts.shape, expected_grads.shape)
+  acts_t = tf.constant(acts)
+  labels_t = tf.constant(labels)
+  input_lengths_t = tf.constant(input_lengths)
+  label_lengths_t = tf.constant(label_lengths)
+
+  logits = tf.nn.log_softmax(acts_t)
+  costs = rnnt_loss(logits, labels_t, input_lengths_t, label_lengths_t, blank)
+
+  grads = tf.gradients(costs, [acts_t])[0]
+
+  (tf_costs, tf_grad) = session.run([costs, grads])
+  # Max absolute difference: 2.861023e-06
+  # Max relative difference: 7.264356e-07
+  assert_allclose(tf_costs, expected_costs, atol=1e-6, rtol=1e-6)
+  assert_allclose(tf_grad, expected_grads, atol=1e-6, rtol=1e-6)
+
+
+@unittest.skipIf(not is_gpu_available(), "no gpu on this system")
+def test_warprnnt_forward():
+  from extern.HawkAaronWarpTransducer import rnnt_loss
+  # Softmax activations for the following inputs:
+  import numpy as np
+  acts = np.array([0.1, 0.6, 0.1, 0.1, 0.1, 0.1,
+                   0.1, 0.6, 0.1, 0.1, 0.1, 0.1,
+                   0.2, 0.8, 0.1, 0.1, 0.6, 0.1,
+                   0.1, 0.1, 0.1, 0.1, 0.2, 0.1,
+                   0.1, 0.7, 0.1, 0.2, 0.1, 0.1], dtype=np.float32).reshape(1, 2, 3, 5)
+
+  labels = np.array([[1, 2]], dtype=np.int32)
+  input_lengths = np.array([2], dtype=np.int32)
+  label_lengths = np.array([2], dtype=np.int32)
+
+  acts_t = tf.constant(acts)
+  labels_t = tf.constant(labels)
+  input_lengths_t = tf.constant(input_lengths)
+  label_lengths_t = tf.constant(label_lengths)
+  acts_t = tf.nn.log_softmax(acts_t)  # NOTE cpu
+  costs = rnnt_loss(acts_t, labels_t, input_lengths_t, label_lengths_t)
+  print(costs.eval())
+
+
+@unittest.skipIf(not is_gpu_available(), "no gpu on this system")
+def test_warprnnt_multiple_batches():
+  import numpy as np
+  n_batch = 2
+  n_time = 4
+  n_target = 3
+  n_vocab = 3
+
+  acts = np.array([0.065357, 0.787530, 0.081592, 0.529716, 0.750675, 0.754135,
+                   0.609764, 0.868140, 0.622532, 0.668522, 0.858039, 0.164539,
+                   0.989780, 0.944298, 0.603168, 0.946783, 0.666203, 0.286882,
+                   0.094184, 0.366674, 0.736168, 0.166680, 0.714154, 0.399400,
+                   0.535982, 0.291821, 0.612642, 0.324241, 0.800764, 0.524106,
+                   0.779195, 0.183314, 0.113745, 0.240222, 0.339470, 0.134160,
+                   0.505562, 0.051597, 0.640290, 0.430733, 0.829473, 0.177467,
+                   0.320700, 0.042883, 0.302803, 0.675178, 0.569537, 0.558474,
+                   0.083132, 0.060165, 0.107958, 0.748615, 0.943918, 0.486356,
+                   0.418199, 0.652408, 0.024243, 0.134582, 0.366342, 0.295830,
+                   0.923670, 0.689929, 0.741898, 0.250005, 0.603430, 0.987289,
+                   0.592606, 0.884672, 0.543450, 0.660770, 0.377128, 0.358021], dtype=np.float32)
+  acts = np.reshape(acts, (n_batch, n_time, n_target, n_vocab))
+
+  expected_costs = np.array([4.28065, 3.93844], dtype=np.float32)
+  expected_grads = np.array([-0.186844, -0.062555, 0.249399, -0.203377, 0.202399, 0.000977,
+                             -0.141016, 0.079123, 0.061893, -0.011552, -0.081280, 0.092832,
+                             -0.154257, 0.229433, -0.075176, -0.246593, 0.146405, 0.100188,
+                             -0.012918, -0.061593, 0.074512, -0.055986, 0.219831, -0.163845,
+                             -0.497627, 0.209240, 0.288387, 0.013605, -0.030220, 0.016615,
+                             0.113925, 0.062781, -0.176706, -0.667078, 0.367659, 0.299419,
+                             -0.356344, -0.055347, 0.411691, -0.096922, 0.029459, 0.067463,
+                             -0.063518, 0.027654, 0.035863, -0.154499, -0.073942, 0.228441,
+                             -0.166790, -0.000088, 0.166878, -0.172370, 0.105565, 0.066804,
+                             0.023875, -0.118256, 0.094381, -0.104707, -0.108934, 0.213642,
+                             -0.369844, 0.180118, 0.189726, 0.025714, -0.079462, 0.053748,
+                             0.122328, -0.238789, 0.116460, -0.598687, 0.302203, 0.296484], dtype=np.float32)
+  expected_grads = np.reshape(expected_grads, (n_batch, n_time, n_target, n_vocab))
+
+  labels = np.array([[1, 2], [1, 1]], dtype=np.int32)
+  input_lengths = np.array([4, 4], dtype=np.int32)
+  label_lengths = np.array([2, 2], dtype=np.int32)
+
+  _run_rnnt(acts, labels, input_lengths, label_lengths, expected_costs, expected_grads, 0)
+
+
 if __name__ == "__main__":
   try:
     better_exchook.install()


### PR DESCRIPTION
Hi,

This PR implements the wrapper around [warp-transducer](https://github.com/HawkAaron/warp-transducer).

The loss can then be used like this:
`from extern.warprnnt import rnnt_loss`

with the definition `rnnt_loss(acts, labels, input_lengths, label_lengths, blank_label=0)`, defined in `extern/warprnnt/__init__.py`
