### PR TITLE
CombinedDataset: recovery of general sorting support

### DIFF
--- a/Dataset.py
+++ b/Dataset.py
@@ -259,6 +259,20 @@ class Dataset(object):
     """
     raise NotImplementedError
 
+  def get_estimated_seq_length(self, seq_idx):
+    """
+    In contrast to self.get_seq_length(), this method is designed to work for sequences that have not been loaded yet
+    via self.load_seqs().
+    Used by meta-datasets for sequence ordering. Currently we only provide one number, i.e. do not give different
+    estimates for the different data keys (as in get_seq_length()). It is up to the dataset what this number represents
+    and how it is computed.
+
+    :param int seq_idx: for current epoch, not the corpus seq idx
+    :rtype: int
+    :returns sequence length estimate (for sorting)
+    """
+    raise OptionalNotImplementedError
+
   def get_num_timesteps(self):
     """
     :rtype: int

--- a/HDFDataset.py
+++ b/HDFDataset.py
@@ -300,6 +300,15 @@ class HDFDataset(CachedDataset):
       return super(HDFDataset, self).get_targets(target, sorted_seq_idx)
     return self.get_data(sorted_seq_idx, target)
 
+  def get_estimated_seq_length(self, seq_idx):
+    """
+    :param int seq_idx: for current epoch, not the corpus seq idx
+    :rtype: int
+    :returns sequence length of "data", used for sequence sorting
+    """
+    real_seq_idx = self._seq_index[self._index_map[seq_idx]]
+    return int(self._get_seq_length_by_real_idx(real_seq_idx)[0])
+
   def _get_seq_length_by_real_idx(self, real_seq_idx):
     """
     :param int real_seq_idx:

--- a/LmDataset.py
+++ b/LmDataset.py
@@ -1382,6 +1382,17 @@ class TranslationDataset(CachedDataset2):
     self._num_seqs = len(self._seq_order)
     return True
 
+  def get_estimated_seq_length(self, seq_idx):
+    """
+    :param int seq_idx: for current epoch, not the corpus seq idx
+    :rtype: int
+    :returns sequence length of main source data key ("data"), used for sequence sorting
+    """
+    corpus_seq_idx = self.get_corpus_seq_idx(seq_idx)
+    assert corpus_seq_idx is not None
+
+    return len(self._get_data(key=self.main_source_data_key, line_nr=corpus_seq_idx))
+
   def _collect_single_seq(self, seq_idx):
     if seq_idx >= self._num_seqs:
       return None

--- a/LmDataset.py
+++ b/LmDataset.py
@@ -1334,6 +1334,12 @@ class TranslationDataset(CachedDataset2):
     """
     return True
 
+  def get_all_tags(self):
+    """
+    :rtype: list[str]
+    """
+    return [self._tag_prefix + str(line_nr) for line_nr in range(len(self._data[self.main_source_data_key]))]
+
   def get_corpus_seq_idx(self, seq_idx):
     """
     :param int seq_idx:


### PR DESCRIPTION
Let's follow up on the discussion in 761062b. This commit removed support for the sorting options available via `Dataset.get_seq_order_for_epoch()` in CombinedDataset.

I just boldly put our code here, but it's secondary. Let's discuss the principles first :)

What I want to achieve is to combine several datasets such that they behave exactly as if a dataset would have been created from the merged input files. Our use case is that we already have TranslationDatasets setups (possibly dumped to HDF) on disk for several language pairs and now want to train a multilingual system using those datasets without creating new merged corpora for each new language pair combination. Our bilingual systems use "laplace" sequence ordering and we want to keep that for multilingual systems.

For this, CombinedDataset itself has to call `get_seq_order_for_epoch()`, which requires the total number of sequences and a function to get the sequence lengths as input. The discussion was about how to correctly get those from the subdatasets.

**About num_seqs:**
The check for `know_num_seqs_beforehand` was removed in 761062b because `num_seqs` "is not reliable". However, many dataset types internally are able to provide `num_seqs` to `get_seq_order_for_epoch()`, I just want to do the same from outside the class, so it should be possible in principle. Also, I don't see many cases where it is not reliable. I looked through the code of a lot of datasets and I only found two that don't provide `num_seqs`: ExternSprintDataset only provides it as soon as the reading thread finishes. LMDataset does not provide it at all (because of unknown filtering, I guess). All other datasets that I looked at seem to provide the correct number of sequences. And if they don't they should. Or not provide `num_seqs` at all.
Also, we discussed at which point in time `num_seqs` becomes valid. When initialising a dataset we always call `init_seq_order()` for the first epoch (`init_dataset()`-> `Dataset.initialize()`). And after `init_seq_order()` we should know whether the number of sequences is known, so I claim the `know_num_seqs_beforehand` check was correct. It is clear that if the number of sequences is not known in advance you cannot do a global sort. But I think this was handled correctly before by checking the `seq_ordering` in `_expand_dataset_sec_idxs()`.

**About get_seq_length:**
We discussed that a sequence has to be loaded via `load_seqs` to know its length. Again, internally the subdatasets are able to provide lengths when calling `get_seq_order_for_epoch()`, I just want to do the same from outside the class, so I don't think this is true. Most of the classes use a `get_seq_len` that is different from `CachedDataset2.get_seq_length()` and doesn't load the sequence. So actually, I would have to expose those and use them. However, I found two cases where `get_seq_order_for_epoch()` is called using `CachedDataset2.get_seq_length()`: RawWavDataset and MetaDataset (via `_get_dataset_seq_length`). Are those "wrong" too? Is loading the sequences in `CachedDataset2.get_seq_length()` a hack that should not be used?

Imho, overall, a good design would be:

- `_seq_order` should be a property of the base class Dataset (updated for each epoch)
- all datasets that know the total number of sequences in advance should use `get_seq_order_for_epoch()` to compute `_seq_order` (almost the case I guess)
- `num_seq`should be `len(_seq_order)` **by definition**
- if total number of sequences unknown, `_seq_order` and `num_seq` should be None, or raise
- filtering must be done before creating `_seq_order`, i.e. all sequences in it are really used (confer LMDataset...)
- the `get_seq_len` used for `get_seq_order_for_epoch()` in the different datasets should be exposed like `CachedDataset._get_seq_length_by_real_idx()` to make them available for MetaDatasets


Somewhat unrelated:
In the code we added a `sampling_sizes` parameter such that you can take a fixed amount of sequences from the subdatasets per epoch, still supporting generic sorting of that chunk.
Also, giving a sequence list (list of strings) to the subdatasets was slow and memory intensive for huge datasets, so I introduced this `reinit_indices` parameter to do it by indices. We can discuss those things separately.



