### PR TITLE
removed unused get_seq_length/get_seq_length_nd bodies

### DIFF
--- a/Dataset.py
+++ b/Dataset.py
@@ -251,33 +251,13 @@ class Dataset(object):
     assert start < end
     return False
 
-  def get_seq_length_nd(self, sorted_seq_idx):
-    """
-    :type sorted_seq_idx: int
-    :rtype: numpy.ndarray
-    :returns the len of the input features and the len of each target sequence.
-    Note: This is deprecated, better use get_seq_length().
-    Attention: Either this method or get_seq_length() needs to be redefined
-    in any subclass of Dataset! However, in new code, just override get_seq_length().
-    """
-    ls = self.get_seq_length(sorted_seq_idx)
-    targets = self.get_target_list()
-    if targets:
-      return numpy.array([ls[key] for key in (["data"] + targets)])
-    else:
-      return numpy.array([ls["data"], 0])
-
   def get_seq_length(self, seq_idx):
     """
     :param int seq_idx:
     :rtype: NumbersDict
     :returns the len of the input features and the len of the target sequence.
     """
-    assert self.__class__.get_seq_length_nd is not Dataset.get_seq_length_nd, "Override get_seq_length."
-    input_len, output_len = self.get_seq_length_nd(seq_idx)
-    d = {"data": input_len}
-    d.update({k: output_len for k in self.get_target_list()})
-    return NumbersDict(d)
+    raise NotImplementedError
 
   def get_num_timesteps(self):
     """


### PR DESCRIPTION
As discussed in #294, I think the function bodies can be removed/replaced by a NotImplementedException

I ran the dataset tests locally, but made a PR to make sure all tests are fine.