### PR TITLE
UTF-8 compatibility for bliss-to-ogg-zip tool

### DIFF
--- a/tools/bliss-to-ogg-zip.py
+++ b/tools/bliss-to-ogg-zip.py
@@ -59,7 +59,8 @@ def iter_bliss(filename):
   if filename.endswith(".gz"):
     corpus_file = gzip.GzipFile(fileobj=corpus_file)
 
-  context = iter(ElementTree.iterparse(corpus_file, events=('start', 'end')))
+  parser = ElementTree.XMLParser(target=ElementTree.TreeBuilder(), encoding="utf-8")
+  context = iter(ElementTree.iterparse(corpus_file, parser=parser, events=('start', 'end')))
   _, root = next(context)  # get root element
   name_tree = [root.attrib["name"]]
   elem_tree = [root]


### PR DESCRIPTION
I switched recently from my own custom tool for ogg zip creation to the official one, and found that it crashes when I have non-ASCII characters in the "orth" segments. I could fix the problem by adding a custom parser that runs with UTF-8 encoding. I am just not sure if this creates any unwanted side-effects.