### PR TITLE
fixed size_placeholder bug in MergeDimsLayer, added test case

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -3849,7 +3849,7 @@ class MergeDimsLayer(_ConcatInputLayer):
         d[j] = v
     for axis in merge_axes:
       if self.output.get_batch_axis_excluding_batch(axis) in self.input_data.size_placeholder.keys():
-        continue # is already covered in the first loop, so skip
+        continue  # is already covered in the first loop, so skip
       new_axis = self._old_axis_to_new_axis(input_data=self.input_data, merge_axes=merge_axes, old_axis=axis)
       if new_axis == self.output.batch_dim_axis:
         continue

--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -3847,6 +3847,15 @@ class MergeDimsLayer(_ConcatInputLayer):
         d[j] *= v
       else:
         d[j] = v
+    for axis in merge_axes:
+      if self.output.get_batch_axis_excluding_batch(axis) in self.input_data.size_placeholder.keys():
+        continue # is already covered in the first loop, so skip
+      new_axis = self._old_axis_to_new_axis(input_data=self.input_data, merge_axes=merge_axes, old_axis=axis)
+      if new_axis == self.output.batch_dim_axis:
+        continue
+      j = self.output.get_batch_axis_excluding_batch(new_axis)
+      if j in d:
+        d[j] *= self.input_data.get_dim(axis)
     if self.input_data.batch_dim_axis in merge_axes:
       # The batch axis got multiplied.
       in_shape = tf.shape(self.input_data.placeholder)

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1002,15 +1002,10 @@ def _check_MergeDimsLayer(session, in_data_opts, in_static_shape, opts, out_data
 
   if out_size_placeholder:
     n_batch = in_static_shape[src.output.batch_dim_axis]
-    for axis, dim in enumerate(in_data_opts['shape']):
+    for axis, dim in enumerate(src.output.batch_shape):
+      axis_wo_b = src.output.get_batch_axis_excluding_batch(axis)
       if dim is None:
-        n_time = in_static_shape[src.output.get_batch_axis(axis)]
-        dyn_size_v = numpy.array([n_time, max(n_time - 2, 1), max(n_time - 3, 1)])
-        if dyn_size_v.shape[0] > n_batch:
-          dyn_size_v = dyn_size_v[:n_batch]
-        elif dyn_size_v.shape[0] < n_batch:
-          assert False, "batch_size > 3 not available for testing size_placeholder"
-        src.output.size_placeholder[axis] = tf.constant(dyn_size_v)
+        src.output.size_placeholder[axis_wo_b] = tf.fill([n_batch], in_static_shape[axis])
 
   opts = opts.copy()
   print("opts:", opts)

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -990,7 +990,7 @@ def _check_MergeDimsLayer(session, in_data_opts, in_static_shape, opts, out_data
   :param dict[str] opts: for MergeDimsLayer
   :param tuple[int|None] out_data_shape:
   :param tuple[int] out_static_shape:
-  :param dict[int, tuple[int]] out_size_placeholder:
+  :param dict[int,tuple[int]]|None out_size_placeholder:
   :rtype: MergeDimsLayer
   """
   net = TFNetwork(extern_data=ExternData())

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1032,6 +1032,7 @@ def test_MergeDimsLayer_basic():
     _check_MergeDimsLayer(session, {"shape": (4, None, 7), "time_dim_axis": 2}, (2, 4, 3, 7), {"axes": "static"}, (None, 4 * 7), (2, 3, 4 * 7))
     _check_MergeDimsLayer(session, {"shape": (1, None), "time_dim_axis": 2, "feature_dim_axis": 1}, (2, 1, 4), {"axes": "except_batch"}, (None,), (2, 4))
 
+
 def test_MergeDimsLayer_size_placeholder():
   with make_scope() as session:
     _check_MergeDimsLayer(session, {"shape": (None, 2), "time_dim_axis": 1, "feature_dim_axis": 2}, (3, 4, 2), {"axes": "except_batch"}, (None,), (3, 8),

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1000,12 +1000,11 @@ def _check_MergeDimsLayer(session, in_data_opts, in_static_shape, opts, out_data
   src.output.placeholder = tf.constant(rnd.normal(size=in_static_shape).astype("float32"), dtype=tf.float32)
   src.output.size_placeholder = {}
 
-  if out_size_placeholder:
-    n_batch = in_static_shape[src.output.batch_dim_axis]
-    for axis, dim in enumerate(src.output.batch_shape):
-      axis_wo_b = src.output.get_batch_axis_excluding_batch(axis)
-      if dim is None:
-        src.output.size_placeholder[axis_wo_b] = tf.fill([n_batch], in_static_shape[axis])
+  n_batch = in_static_shape[src.output.batch_dim_axis]
+  for axis, dim in enumerate(src.output.batch_shape):
+    axis_wo_b = src.output.get_batch_axis_excluding_batch(axis)
+    if dim is None:
+      src.output.size_placeholder[axis_wo_b] = tf.fill([n_batch], in_static_shape[axis])
 
   opts = opts.copy()
   print("opts:", opts)


### PR DESCRIPTION
The MergeDimsLayer did not consider any static axes when updating the size placeholder. So if e.g. a dynamic time axis was merged with a fixed sized spatial axis, the resulting dynamic axis would be equal to the original time axis, and not be multiplied.