### PR TITLE
fix in TFCompat

### DIFF
--- a/TFCompat.py
+++ b/TFCompat.py
@@ -12,7 +12,7 @@ https://github.com/tensorflow/lingvo/blob/master/lingvo/compat.py
 
 import tensorflow as tf
 
-if not getattr(tf, "compat", None) or not getattr(tf.compat, "v1", None):
+if not getattr(tf, "compat", None) or not getattr(tf.compat, "v2", None):
   v1 = tf
   v2 = None
 else:


### PR DESCRIPTION
Shouldn't this check against v2? So that v2 is none if it does not exist? Because my current TF1.13 versions are now crashing with:

```
File "/work/asr4/rossenbach/sisyphus_work_folders/librispeech_tts_work/returnn/helpers/rossenbach/checkout/CheckoutRETURNN.xxswwSAwc3ZC/output/crnn/5aabe210ca167ee83ff38786a109406a63e8a6bb/TFCompat.py", line 22, in <module>
    line: v2 = tf.compat.v2
    locals:
      v2 = <not found>
      tf = <local> <module 'tensorflow' from '/work/asr4/rossenbach/env/python37_tf_1.13/lib/python3.7/site-packages/tensorflow/__init__.py'>
      tf.compat = <local> <module 'tensorflow._api.v1.compat' from '/work/asr4/rossenbach/env/python37_tf_1.13/lib/python3.7/site-packages/tensorflow/_api/v1/compat/__init__.py'>
      tf.compat.v2 = <local> !AttributeError: module 'tensorflow._api.v1.compat' has no attribute 'v2'
AttributeError: module 'tensorflow._api.v1.compat' has no attribute 'v2'
```