### PR TITLE
ActivationLayer output dtype

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -33,7 +33,7 @@ class LayerBase(object):
               " docstring, document the args! "
               super(YourOwnLayer, self).__init__(**kwargs)
               # Now we need to set self.output, which must be of type :class:`Data`.
-              # It is set at this point to whatever we got from `selfget_out_data_from_opts()`,
+              # It is set at this point to whatever we got from `self.get_out_data_from_opts()`,
               # so it is enough if we set self.output.placeholder and self.output.size_placeholder,
               # but we could also reset self.output.
               self.output.placeholder = self.input_data.placeholder + 42  # whatever you want to do

--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -2375,6 +2375,20 @@ class ActivationLayer(CopyLayer):
     else:
       self.output_before_activation = OutputWithActivation(x)
     self.output.placeholder = self.output_before_activation.y
+    self.output.dtype = self.get_out_data_from_opts(activation=activation, **kwargs).dtype
+
+  @classmethod
+  def get_out_data_from_opts(cls, activation, **kwargs):
+    """
+    :param str activation:
+    :rtype: Data
+    """
+    # Get dtype based on inputs
+    out = super(ActivationLayer, cls).get_out_data_from_opts(**kwargs)
+    # Modify if needed based on activation function
+    if activation == "abs" and out.dtype == "complex64":
+      out.dtype = "float32"
+    return out
 
 
 class BatchNormLayer(CopyLayer):

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -2096,7 +2096,10 @@ def test_Loss_NCHW():
       src_nchw.output.size_placeholder = {1: TFCompat.v1.placeholder(shape=(None,), dtype=tf.int32)}
 
     with TFCompat.v1.variable_scope("activation"):
-      activation = ActivationLayer(name="activation", activation="softmax", network=net, sources=[src_nchw])
+      activation = ActivationLayer(
+        name="activation", activation="softmax", network=net, sources=[src_nchw],
+        output=ActivationLayer.get_out_data_from_opts(name="activation", activation="softmax", network=net,
+                                                      sources=[src_nchw]))
 
     target_placeholder = TFCompat.v1.placeholder(shape=(None, None, 16), dtype=tf.float32)
     target_size_placeholder = TFCompat.v1.placeholder(shape=(None,), dtype=tf.int32)


### PR DESCRIPTION
I added `get_out_data_from_opts()` for the `ActivationLayer` and added the case of the abs activation on complex values, in which case the output `dtype` should change from `complex64` to `float32`.