### PR TITLE
Support for attention energies without encoder dependencies

### DIFF
--- a/TFNetworkLayer.py
+++ b/TFNetworkLayer.py
@@ -4812,7 +4812,7 @@ class ConvLayer(_ConcatInputLayer):
             filter_size=filter_size[i], stride=strides[i], dilation_rate=dilation_rate[i], padding=padding)
     feature_dim_axis = NotSpecified
     # Swap the dims if the input dim order doesn't fit the flag auto_use_channel_first.
-    if (TFUtil.is_gpu_available() and auto_use_channel_first) or data.is_batch_feature_major:
+    if TFUtil.is_gpu_available() and (auto_use_channel_first or data.is_batch_feature_major):
       feature_dim_axis = 1
       shape = shape[-1:] + shape[:-1]
     return {


### PR DESCRIPTION
This PR adds an additional test case to enable the construction of specific attention methods that do not require an explicit encoder context. This added test case uses an explicit DimensionTag for correct template construction and an `initial_output` for the weight-feedback based on the encoder for correct tensor shapes.

Two fixes were needed for this to run:
- the deepcopy function does not try to copy tensors and dimension tags
- the `declare_same_as` function to adopt to external DimensionTags is now aware of a possible beam search and adjusts the batch axis accordingly