### PR TITLE
TFUtil: np array initialization

### DIFF
--- a/TFUtil.py
+++ b/TFUtil.py
@@ -3924,6 +3924,8 @@ def get_initializer(s, seed=None, eval_local_ns=None, dtype=tf.float32):
       if f == 1:
         return TFCompat.v1.ones_initializer(dtype=dtype)
       return TFCompat.v1.constant_initializer(f, dtype=dtype)
+    elif isinstance(f, numpy.ndarray):
+      return TFCompat.v1.constant_initializer(f, dtype=dtype, verify_shape=True)
     if not f:
       raise Exception("invalid initializer: %r" % s)
     if seed is not None:


### PR DESCRIPTION
I added another case in `get_initializer()` that allows passing strings which result in a numpy array when passed to `eval()`. Example for a possible usage: `'forward_weights_init': 'numpy.hanning(400).reshape((400, 1, 1, 1))'`