### PR TITLE
CombinedDataset: sequence ordering of subsets via indices

### DIFF
--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -540,10 +540,12 @@ class Dataset(object):
       full_epoch = (full_epoch - 1) // partition_epoch + 1
     return full_epoch + self.random_seed_offset
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :type epoch: int|None
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order. Only possible
+      if the dataset has such indices (see self.have_corpus_seq_idx()).
     :rtype: bool
     :returns whether the order changed (True is always safe to return)
 

--- a/returnn/datasets/cached.py
+++ b/returnn/datasets/cached.py
@@ -59,15 +59,18 @@ class CachedDataset(Dataset):
             max(temp_cache_size_bytes / float(1024 * 1024 * 1024), 0),
             file=log.v4)
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :type epoch: int|None
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     Initialize lists:
       self.seq_index  # sorted seq idx
     """
-    super(CachedDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
-    if seq_list is not None:
+    super(CachedDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
+    if seq_order is not None:
+      seq_index = seq_order
+    elif seq_list is not None:
       self._update_tag_idx()
       seq_index = [self._tag_idx[tag] for tag in seq_list]
     else:

--- a/returnn/datasets/cached2.py
+++ b/returnn/datasets/cached2.py
@@ -37,17 +37,19 @@ class CachedDataset2(Dataset):
     self.expected_load_seq_start = 0
     self._num_timesteps_accumulated = 0
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int|None epoch:
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order. Only possible
+      if the dataset has such indices (see self.have_corpus_seq_idx()).
     :rtype: bool
     :returns whether the order changed (True is always safe to return)
 
     This is called when we start a new epoch, or at initialization.
     Call this when you reset the seq list.
     """
-    super(CachedDataset2, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(CachedDataset2, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     if not epoch:
       epoch = 1
     self.expected_load_seq_start = 0
@@ -305,13 +307,14 @@ class SingleStreamPipeDataset(CachedDataset2):
     """
     return self.dtype
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int epoch:
     :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     :rtype: bool
     """
-    assert not seq_list
+    assert not seq_list and not seq_order
     super(SingleStreamPipeDataset, self).init_seq_order(epoch=epoch)
     with self.condition:
       self.producer_seq_idx = 0

--- a/returnn/datasets/generating.py
+++ b/returnn/datasets/generating.py
@@ -45,14 +45,15 @@ class GeneratingDataset(Dataset):
     self.reached_final_seq = False
     self.added_data = []  # type: typing.List[DatasetSeq]
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :type epoch: int|None
-    :param seq_list: predefined order. doesn't make sense here
+    :param list[str]|None seq_list: predefined order via tags, doesn't make sense here
+    :param list[int]|None seq_order: predefined order via indices, doesn't make sense here
     This is called when we start a new epoch, or at initialization.
     """
     super(GeneratingDataset, self).init_seq_order(epoch=epoch)
-    assert not seq_list, "predefined order doesn't make sense for %s" % self.__class__.__name__
+    assert not seq_list and not seq_order, "predefined order doesn't make sense for %s" % self.__class__.__name__
     self.random.seed(self.fixed_random_seed or self._get_random_seed_for_epoch(epoch=epoch))
     self._num_timesteps = 0
     self.reached_final_seq = False
@@ -1769,14 +1770,15 @@ class TimitDataset(CachedDataset2):
     stream.close()
     p.terminate()
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int epoch:
     :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     :rtype: bool
     """
-    assert seq_list is None
-    super(TimitDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    assert seq_list is None and seq_order is None
+    super(TimitDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     self._num_seqs = len(self._seq_tags)
     self._seq_order = self.get_seq_order_for_epoch(
       epoch=epoch, num_seqs=self._num_seqs, get_seq_len=lambda i: len(self._seq_tags[i][1]))
@@ -2377,14 +2379,15 @@ class BlissDataset(CachedDataset2):
         name_tree = name_tree[:-1]
     self._num_seqs = len(self._seqs)
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int|None epoch:
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: Predefined order via list of tags, not used here.
+    :param list[int]|None seq_order: Predefined order via list of indices, not used here.
     :rtype: bool
     :returns whether the order changed (True is always safe to return)
     """
-    super(BlissDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(BlissDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     self._num_seqs = len(self._seqs)
     return True
 
@@ -2542,18 +2545,19 @@ class LibriSpeechCorpus(CachedDataset2):
     assert transs
     return transs
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     If random_shuffle_epoch1, for epoch 1 with "random" ordering, we leave the given order as is.
     Otherwise, this is mostly the default behavior.
 
     :param int|None epoch:
-    :param list[str]|None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     :rtype: bool
     :returns whether the order changed (True is always safe to return)
     """
     import returnn.util.basic
-    super(LibriSpeechCorpus, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(LibriSpeechCorpus, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     if not epoch:
       epoch = 1
     self._audio_random.seed(self._fixed_random_seed or self._get_random_seed_for_epoch(epoch=epoch))
@@ -2565,18 +2569,19 @@ class LibriSpeechCorpus(CachedDataset2):
       """
       return len(self.transs[self._reference_seq_order[i]])
 
-    if seq_list is not None:
+    if seq_order is not None:
+      self._seq_order = seq_order
+    elif seq_list is not None:
       seqs = [i for i in range(len(self._reference_seq_order)) if self._get_tag(i) in seq_list]
       seqs = {self._get_tag(i): i for i in seqs}
       for seq_tag in seq_list:
         assert seq_tag in seqs, "did not found all requested seqs. we have eg: %s" % (self._get_tag(0),)
       self._seq_order = [seqs[seq_tag] for seq_tag in seq_list]
-      self._num_seqs = len(self._seq_order)
     else:
       num_seqs = len(self._reference_seq_order)
       self._seq_order = self.get_seq_order_for_epoch(
         epoch=epoch, num_seqs=num_seqs, get_seq_len=get_seq_len)
-      self._num_seqs = len(self._seq_order)
+    self._num_seqs = len(self._seq_order)
     if self.epoch_wise_filter:
       # Note: A more generic variant of this code is :class:`MetaDataset.EpochWiseFilter`.
       from .meta import EpochWiseFilter
@@ -2948,17 +2953,18 @@ class OggZipDataset(CachedDataset2):
     seqs = seqs[:fixed_random_subset]
     self._data = seqs
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     If random_shuffle_epoch1, for epoch 1 with "random" ordering, we leave the given order as is.
     Otherwise, this is mostly the default behavior.
 
     :param int|None epoch:
-    :param list[str]|None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     :rtype: bool
     :returns whether the order changed (True is always safe to return)
     """
-    super(OggZipDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(OggZipDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     if not epoch:
       epoch = 1
     self._audio_random.seed(self._fixed_random_seed or self._get_random_seed_for_epoch(epoch=epoch))
@@ -2973,7 +2979,9 @@ class OggZipDataset(CachedDataset2):
       """
       return int(self._data[i]["duration"] * 100)
 
-    if seq_list is not None:
+    if seq_order is not None:
+      self._seq_order = seq_order
+    elif seq_list is not None:
       seqs = {
         self._get_tag_from_info_dict(seq): i for i, seq in enumerate(self._data)
         if self._get_tag_from_info_dict(seq) in seq_list}
@@ -2981,7 +2989,6 @@ class OggZipDataset(CachedDataset2):
         assert seq_tag in seqs, ("did not found all requested seqs. we have eg: %s" % (
           self._get_tag_from_info_dict(self._data[0]),))
       self._seq_order = [seqs[seq_tag] for seq_tag in seq_list]
-      self._num_seqs = len(self._seq_order)
     else:
       num_seqs = len(self._data)
       self._seq_order = self.get_seq_order_for_epoch(
@@ -2989,7 +2996,7 @@ class OggZipDataset(CachedDataset2):
       if self.epoch_wise_filter:
         self.epoch_wise_filter.debug_msg_prefix = str(self)
         self._seq_order = self.epoch_wise_filter.filter(epoch=epoch, seq_order=self._seq_order, get_seq_len=get_seq_len)
-      self._num_seqs = len(self._seq_order)
+    self._num_seqs = len(self._seq_order)
 
     return True
 
@@ -3167,13 +3174,14 @@ class Enwik8Corpus(CachedDataset2):
     """
     return "uint8"
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int epoch:
     :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     :rtype: bool
     """
-    super(Enwik8Corpus, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(Enwik8Corpus, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     if not epoch:
       epoch = 1
     epoch_part = None

--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -568,14 +568,17 @@ class NextGenHDFDataset(CachedDataset2):
 
     super(NextGenHDFDataset, self).initialize()
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :type epoch: int|None
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     """
-    super(NextGenHDFDataset, self).init_seq_order(epoch, seq_list)
+    super(NextGenHDFDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
 
-    if seq_list is not None:
+    if seq_order is not None:
+      self.seq_order = seq_order
+    elif seq_list is not None:
       self.seq_order = [self.seq_name_to_idx[s] for s in seq_list]
     else:
       epoch = epoch or 1
@@ -745,14 +748,17 @@ class SiameseHDFDataset(CachedDataset2):
 
     super(SiameseHDFDataset, self).initialize()
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int|None epoch: current epoch id
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     """
-    super(SiameseHDFDataset, self).init_seq_order(epoch, seq_list)
+    super(SiameseHDFDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
 
-    if seq_list is not None:
+    if seq_order is not None:
+      self.seq_order = seq_order
+    elif seq_list is not None:
       self.seq_order = [self.seq_name_to_idx[s] for s in seq_list]
     else:
       epoch = epoch or 1

--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -237,13 +237,14 @@ class LmDataset(CachedDataset2):
     """
     return self.dtype
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     If random_shuffle_epoch1, for epoch 1 with "random" ordering, we leave the given order as is.
     Otherwise, this is mostly the default behavior.
 
     :param int|None epoch:
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     :rtype: bool
     :returns whether the order changed (True is always safe to return)
     """
@@ -252,11 +253,13 @@ class LmDataset(CachedDataset2):
             "Please activate auto_replace_unknown_symbol if you want to prevent invalid sequences!",
             file=log.v4)
       self.error_on_invalid_seq = True
-    super(LmDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(LmDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     if not epoch:
       epoch = 1
 
-    if seq_list is not None:
+    if seq_order is not None:
+      self.seq_order = seq_order
+    elif seq_list is not None:
       self.seq_order = [int(s[len(self._tag_prefix):]) for s in seq_list]
     else:
       self.seq_order = self.get_seq_order_for_epoch(
@@ -1363,23 +1366,26 @@ class TranslationDataset(CachedDataset2):
     """
     return "int32"  # sparse -> label idx
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     If random_shuffle_epoch1, for epoch 1 with "random" ordering, we leave the given order as is.
     Otherwise, this is mostly the default behavior.
 
     :param int|None epoch:
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     :rtype: bool
     :returns whether the order changed (True is always safe to return)
     """
-    super(TranslationDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(TranslationDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     if not epoch:
       epoch = 1
 
     if seq_list is None and self.seq_list:
       seq_list = self.seq_list
-    if seq_list is not None:
+    if seq_order:
+      self._seq_order = seq_order
+    elif seq_list is not None:
       self._seq_order = [int(s[len(self._tag_prefix):]) for s in seq_list]
     else:
       num_seqs = self._get_data_len()

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -326,21 +326,24 @@ class MetaDataset(CachedDataset2):
 
     return self.datasets[self.default_dataset_key].get_seq_length(seq_idx)["data"]
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int|None epoch:
-    :param list[str]|None seq_list:
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     :rtype: bool
     """
     need_reinit = self.epoch is None or self.epoch != epoch or seq_list
-    super(MetaDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(MetaDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
 
     if not need_reinit:
       self._num_seqs = len(self.seq_list_ordered[self.default_dataset_key])
       return False
 
     seq_order_dataset = None
-    if seq_list:
+    if seq_order:
+      seq_index = seq_order
+    elif seq_list:
       seq_index = [self.tag_idx[tag] for tag in seq_list]
     elif self.seq_order_control_dataset:
       seq_order_dataset = self.datasets[self.seq_order_control_dataset]
@@ -523,14 +526,15 @@ class ClusteringDataset(CachedDataset2):
       cluster_map[seq_name] = cluster_idx
     return cluster_map
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int epoch:
-    :param list[str]|int seq_list:
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     :rtype: bool
     """
-    self.dataset.init_seq_order(epoch=epoch, seq_list=seq_list)
-    return super(ClusteringDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    self.dataset.init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
+    return super(ClusteringDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
 
   def get_data_keys(self):
     """
@@ -656,17 +660,20 @@ class ConcatDataset(CachedDataset2):
       assert ds.num_outputs == self.num_outputs
     self.dataset_seq_idx_offsets = None  # type: typing.Optional[typing.List[int]]
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :type epoch: int|None
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     """
     need_reinit = self.epoch is None or self.epoch != epoch
-    super(ConcatDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(ConcatDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     self.dataset_seq_idx_offsets = [0]
     if not need_reinit:
       return False
 
+    if seq_order:
+      raise NotImplementedError("Predefined order via sequence indices for ConcatDataset")
     if seq_list:  # reference order
       seq_lists = []
       for dataset in self.datasets:
@@ -890,17 +897,18 @@ class CombinedDataset(CachedDataset2):
     self.dataset_sorted_seq_idx_list = None  # type: typing.Optional[typing.List[typing.Tuple[int,int]]]
     self.used_num_seqs_per_subset = None  # type: typing.Optional[typing.List[int]]
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int epoch:
     :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     :rtype: bool
     """
 
-    assert seq_list is None, "seq_list not supported for %s" % self.__class__
+    assert seq_list is None and seq_order is None, "seq_list and seq_order not supported for %s" % self.__class__
     need_reinit = self.epoch is None or self.epoch != epoch
     num_seqs_saved = self._num_seqs
-    super(CombinedDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)  # resets self._num_seqs
+    super(CombinedDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)  # resets num_seqs
 
     if not need_reinit:
       self._num_seqs = num_seqs_saved
@@ -1295,14 +1303,15 @@ class ConcatSeqsDataset(CachedDataset2):
     assert len(ls) == len(self.full_seq_list)
     return ls
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int epoch:
     :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     :rtype: bool
     """
-    super(ConcatSeqsDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
-    assert not seq_list  # not implemented
+    super(ConcatSeqsDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
+    assert not seq_list and not seq_order  # not implemented
     if not seq_list:
       def get_seq_len(i):
         """
@@ -1448,20 +1457,21 @@ class ChunkShuffleDataset(CachedDataset2):
     self.rng = Random(0)
     self.load_seqs_end = None
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :type epoch: int|None
-    :param list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     """
     need_reinit = self.epoch is None or self.epoch != epoch
-    super(ChunkShuffleDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(ChunkShuffleDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     self.load_seqs_end = 0
     self.dataset_last_load_seq_end = 0
     self.rng.seed(epoch or 1)
     if not need_reinit:
       return False
 
-    if seq_list:
+    if seq_list or seq_order:
       raise NotImplementedError("predefined order seq_list")
     if self.seq_ordering != "default":
       raise NotImplementedError("seq_ordering %s" % self.seq_ordering)

--- a/returnn/datasets/numpy_dump.py
+++ b/returnn/datasets/numpy_dump.py
@@ -65,14 +65,15 @@ class NumpyDumpDataset(Dataset):
 
   # ------------ Dataset API --------------
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :param int|None epoch:
     :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     :rtype: bool
     """
-    super(NumpyDumpDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
-    if seq_list:
+    super(NumpyDumpDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
+    if seq_list or seq_order:
       raise NotImplementedError
     if self.seq_ordering == "sorted":  # not supported atm
       self.seq_ordering = "default"

--- a/returnn/datasets/raw_wav.py
+++ b/returnn/datasets/raw_wav.py
@@ -206,22 +206,23 @@ class RawWavDataset(CachedDataset2):
     assert len(self.added_data[0].get_data(key).shape) == 2
     return self.added_data[0].get_data(key).shape[1]
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :type epoch: int|None
     :param epoch: epoch number
-    :type seq_list: list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     :param seq_list: only None is currently supported
     Initialize lists:
       self.seq_index  # sorted seq idx
     """
-    super(RawWavDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(RawWavDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
 
     if epoch is None:
         self._seq_index_list = range(self.num_seqs)
         return True
 
-    if seq_list:
+    if seq_list or seq_order:
       raise NotImplementedError('init_seq_order of RawWavDataset does not support a predefined seq_list yet.')
     else:
       seq_index = self.get_seq_order_for_epoch(epoch, self.num_seqs, lambda s: self.get_seq_length(s).get('data', None))

--- a/returnn/datasets/stereo.py
+++ b/returnn/datasets/stereo.py
@@ -70,16 +70,17 @@ class StereoDataset(CachedDataset2):
       partition_size += self._seq_overhead
     return partition_size
 
-  def init_seq_order(self, epoch=None, seq_list=None):
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
     """
     :type epoch: int|None
     :param epoch: epoch number
-    :type seq_list: list[str] | None seq_list: In case we want to set a predefined order.
+    :param list[str]|None seq_list:
+    :param list[int]|None seq_order:
     :param seq_list: only None is currently supported
     Initialize lists:
       self.seq_index  # sorted seq idx
     """
-    super(StereoDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list)
+    super(StereoDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     if epoch is None:
         self._seq_index_list = range(self.num_seqs)
         return True
@@ -87,7 +88,7 @@ class StereoDataset(CachedDataset2):
     self._current_partition = (epoch - 1) % self._partition_epoch
     partition_size = self._get_partition_size(self._current_partition)
 
-    if seq_list:
+    if seq_list or seq_order:
       raise NotImplementedError('init_seq_order of StereoDataset does not support a predefined seq_list yet.')
     else:
       seq_index = self.get_seq_order_for_epoch(epoch, partition_size, lambda s: self.get_seq_length(s).get('data', None))


### PR DESCRIPTION
I introduced a parameter to init_seq_order by which you can set a predefined sequence order via indices, rather than using sequence tags, and used this in CombinedDataset to set the sequence orderings of the subsets.

It's not super nice to have two different ways to do the same thing, but we need this for efficiency. I tested this with a CombinedDataset having three HDFDatasets as subsets with 1M sequences each. With the current implementation, which loads all tags of the subsets and then passes the right tags to the subsets dataset, dataset initialization takes 18 minutes. With this change it reduces to 30 seconds. Also, memory consumption reduces by 500MB, which if you scale it to 10M or 100M sequences becomes significant.

95% of the changes are just adjusting all init_seq_order calls. In trivial cases (like `self.seq_order = seq_order`) I implemented the new option for other datasets, although I only use it for HDFDataset and TranslationDataset. Let's hope those cases are really as trivial as they look 😬 