### PR TITLE
StaticDataset: sequence ordering and fixes

### DIFF
--- a/returnn/datasets/generating.py
+++ b/returnn/datasets/generating.py
@@ -938,6 +938,14 @@ class StaticDataset(GeneratingDataset):
     """
     return str(self.data[0][key].dtype)
 
+  def is_data_sparse(self, key):
+    """
+    :param str key:
+    :rtype: bool
+    """
+    data_type = self.get_data_dtype(key)
+    return data_type.startswith("int")
+
 
 class CopyTaskDataset(GeneratingDataset):
   """

--- a/returnn/datasets/generating.py
+++ b/returnn/datasets/generating.py
@@ -936,7 +936,7 @@ class StaticDataset(GeneratingDataset):
     :param str key:
     :rtype: str
     """
-    return self.data[0][key].dtype
+    return str(self.data[0][key].dtype)
 
 
 class CopyTaskDataset(GeneratingDataset):


### PR DESCRIPTION
`get_data_dtype()` was returning `numpy.dtype` instead of `str` (which caused an assertion error when creating `Data` instances for me).

 `Dataset.is_data_sparse()` does not work in case of dense scalars, i.e. single float values as data (with or without time dimension). `Dataset.num_outputs`, which is of the form `(num-classes, len(shape)`, would be `[1, 1]` or `[1, 0]` in those cases, I guess. But data is assumed to be dense if `len(shape) <= 1`. (Even if we required a feature dimension, in this case of size 1, the case without time dimension would still fail.) I get that this is a best guess in the base class, but not many Datasets override this, e.g. `CachedDataset2.is_data_sparse()` makes the same assumption, so this is a more general problem.
Anyway, I just inferred sparseness from the data type now in StaticDataset.

And I added sequence ordering for StaticDataset. Which might go a bit against the name of it... But as StaticDataset is the easiest way to create a dataset on the fly when using RETURNN as a framework, this feature was necessary for me.
