### PR TITLE
move non-log stdout print messages to log.v3 

### DIFF
--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -357,6 +357,8 @@ def init_backend_engine():
     setup_tf_thread_pools(log_file=log.v3, tf_session_opts=tf_session_opts)
     # Print available devices. Also make sure that get_tf_list_local_devices uses the correct TF session opts.
     print_available_devices(tf_session_opts=tf_session_opts, file=log.v2)
+    from returnn.tf.native_op import OpMaker
+    OpMaker.log_stream = log.v3
     debug_register_better_repr()
     if config.is_true("distributed_tf"):
       import returnn.tf.distributed

--- a/returnn/tf/native_op.py
+++ b/returnn/tf/native_op.py
@@ -7,6 +7,7 @@ Wrappers for most relevant NativeOp ops.
 from __future__ import print_function
 
 import os
+import sys
 import tensorflow as tf
 try:
   from tensorflow.python.ops.nn import rnn_cell
@@ -74,6 +75,7 @@ class OpMaker(object):
   global_lock = RLock()
   mod_cache = {}  # cache_key -> mod
   op_cache = {}  # cache_key -> op
+  log_stream = sys.stdout  # type: typing.TextIO
 
   def __init__(self, description, compiler_opts=None,
                search_for_runtime_blas=True, search_for_numpy_blas=True, search_for_system_blas=True,
@@ -529,6 +531,7 @@ class OpMaker(object):
       include_deps=[self.support_native_op_cpp_filename],
       ld_flags=ld_flags,
       use_cuda_if_available=self.with_cuda,
+      log_stream=self.log_stream,
       **dict(self.compiler_opts))
     mod = comp.load_tf_module()
     mod._op_compiler = comp

--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -919,7 +919,7 @@ class _DeviceAttributes:
 _list_local_devices = None
 
 
-def get_tf_list_local_devices(tf_session_opts=None):
+def get_tf_list_local_devices(tf_session_opts=None, file=None):
   """
   This uses tensorflow.device_lib.list_local_devices().
   Note that a call to this will trigger the internal TF thread pool inits,
@@ -929,13 +929,14 @@ def get_tf_list_local_devices(tf_session_opts=None):
   You can get the list available in a given TF session by :func:`tf.compat.v1.Session.list_devices`.
 
   :param dict[str]|None tf_session_opts: if given, will init a temp tf.compat.v1.Session with these opts
+  :param typing.TextIO|None file: log_stream stream for print statements, defaults to sys.stdout
   :rtype: list[tensorflow.core.framework.device_attributes_pb2.DeviceAttributes|_DeviceAttributes]
   """
   check_initial_tf_thread_pool_init(tf_session_opts=tf_session_opts)
   global _list_local_devices
   if _list_local_devices is not None:
     return _list_local_devices
-  print("Collecting TensorFlow device list...")
+  print("Collecting TensorFlow device list...", file=file)
   if tf_session_opts and tf_session_opts.get("gpu_options", {}):
     # On any gpu_options, e.g. gpu_options.per_process_gpu_memory_fraction:
     # The first usage of a device will use the provided options.
@@ -990,7 +991,7 @@ def print_available_devices(tf_session_opts=None, file=None):
   so you should call :func:`setup_tf_thread_pools` first.
 
   :param dict[str]|None tf_session_opts: if given, will init a temp Session with these opts
-  :param io.FileIO file:
+  :param typing.TextIO|None file: file stream for print statements, defaults to sys.stdout
   """
   if file is None:
     file = sys.stdout
@@ -1003,7 +1004,7 @@ def print_available_devices(tf_session_opts=None, file=None):
   if tf_session_opts and tf_session_opts.get("gpu_options", {}).get("visible_device_list", None):
     print("TF session gpu_options.visible_device_list is set to %r." % (
       tf_session_opts["gpu_options"]["visible_device_list"],), file=file)
-  devs = get_tf_list_local_devices(tf_session_opts=tf_session_opts)
+  devs = get_tf_list_local_devices(tf_session_opts=tf_session_opts, file=file)
   print("Local devices available to TensorFlow:", file=file)
   for i, dev in enumerate(devs):
     print("  %i/%i: %s" % (i + 1, len(devs), "\n       ".join(str(dev).splitlines())), file=file)

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -3164,7 +3164,7 @@ class NativeCodeCompiler(object):
                is_cpp=True, c_macro_defines=None, ld_flags=None,
                include_paths=(), include_deps=None,
                static_version_name=None, should_cleanup_old_all=True, should_cleanup_old_mydir=False,
-               use_cxx11_abi=False, verbose=False):
+               use_cxx11_abi=False, log_stream=None, verbose=False):
     """
     :param str base_name: base name for the module, e.g. "zero_out"
     :param int|tuple[int] code_version: check for the cache whether to reuse
@@ -3180,6 +3180,7 @@ class NativeCodeCompiler(object):
     :param bool should_cleanup_old_all: whether we should look in the cache dir
       and check all ops if we can delete some old ones which are older than some limit (self._cleanup_time_limit_days)
     :param bool should_cleanup_old_mydir: whether we should delete our op dir before we compile there.
+    :param typing.TextIO|None log_stream: file stream for print statements
     :param bool verbose: be slightly more verbose
     """
     if self.CollectedCompilers is not None:
@@ -3203,8 +3204,9 @@ class NativeCodeCompiler(object):
       self._cleanup_old()
     self._should_cleanup_old_mydir = should_cleanup_old_mydir
     self.use_cxx11_abi = use_cxx11_abi
+    self._log_stream = log_stream
     if self.verbose:
-      print("%s: %r" % (self.__class__.__name__, self))
+      print("%s: %r" % (self.__class__.__name__, self), file=log_stream)
 
   def __repr__(self):
     return "<%s %r in %r>" % (self.__class__.__name__, self.base_name, self._mod_path)
@@ -3410,7 +3412,7 @@ class NativeCodeCompiler(object):
     cmd_bin = self._get_compiler_bin()
     cmd_args = [cmd_bin] + opts
     from subprocess import Popen, PIPE, STDOUT, CalledProcessError
-    print("%s call: %s" % (self.__class__.__name__, " ".join(cmd_args)))
+    print("%s call: %s" % (self.__class__.__name__, " ".join(cmd_args)), file=self._log_stream)
     proc = Popen(cmd_args, cwd=self._mod_path, stdout=PIPE, stderr=STDOUT)
     stdout, stderr = proc.communicate()
     assert stderr is None  # should only have stdout


### PR DESCRIPTION
I want to use RETURNN in a pipeable script (with log-verbosity:1), and right now these messages might get in my `stdout`. I am not sure how to find other messages that can still appear.

I assumed `stderr` is fine, because I did not want to add an additional dependency on `Log`.