### PR TITLE
Converted data of Task12AXDataset to single precision

### DIFF
--- a/returnn/datasets/generating.py
+++ b/returnn/datasets/generating.py
@@ -288,7 +288,7 @@ class Task12AXDataset(GeneratingDataset):
     input_seq = self.generate_input_seq(seq_len)
     output_seq = self.make_output_seq(input_seq)
     features = class_idx_seq_to_1_of_k(input_seq, num_classes=len(self._input_classes))
-    targets = numpy.array(output_seq)
+    targets = numpy.array(output_seq, dtype='int32')
     return DatasetSeq(seq_idx=seq_idx, features=features, targets=targets)
 
 

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -1250,7 +1250,7 @@ def class_idx_seq_to_1_of_k(seq, num_classes):
   :rtype: np.ndarray
   """
   num_frames = len(seq)
-  m = np.zeros((num_frames, num_classes))
+  m = np.zeros((num_frames, num_classes), dtype='float32')
   m[np.arange(num_frames), seq] = 1
   return m
 


### PR DESCRIPTION
This fixes #346 but it is valid only if we want to keep int/float32 all over the code as it is now.