### PR TITLE
TransposedConvLayer: fix output shape

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3319,6 +3319,14 @@ class TransposedConvLayer(_ConcatInputLayer):
     out = out.copy_template(name="%s_output" % name)
     assert out.have_feature_axis()
     out = out.copy_template_replace_dim(axis=-1, new_dim=n_out)
+    shape = list(out.shape)
+    if strides is None:
+      strides = filter_size
+    assert len(strides) == len(out.get_spatial_axes()), "Expected strides for all spatial axes"
+    for idx, axis in enumerate(out.get_spatial_axes()):  # counted without batch-dim axis
+      if axis + 1 not in out.get_dynamic_axes():  # out.get_dynamic_axes() is counted with batch-dim axis
+        shape[axis] *= strides[idx]
+    out.shape = tuple(shape)
     out.size_placeholder.clear()  # will be reset in __init__
     return out
 


### PR DESCRIPTION
When doing a transposed convolution with strides, the output shape is not configured correctly (note that by default, strides are set to filter size). 

The proposed change adapts the shape of the non-dynamic spatial axes according to the stride. Note that this is only valid for `padding="SAME"`, which is always used here because it is the default in `tf.nn.conv2d_transpose`.