### PR TITLE
CompareLayer: output cannot have voc

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4910,6 +4910,7 @@ class CompareLayer(LayerBase):
     elif out_type_.get("sparse", False):
       out_type_["dim"] = 2
     out_type_["dtype"] = "bool"
+    out_type_["vocab"] = None
     out_type_["name"] = "%s_output" % kwargs["name"]
     if out_type:
       if isinstance(out_type, dict):


### PR DESCRIPTION
Vocabulary has to be set to None, otherwise we run into a dimension mismatch assertion (2 vs. voc size). 
This was unintentionally dropped in 4578b43, I assume.
@mattiadg Take a quick look.