### PR TITLE
CombinedDataset: fix crash at end of epoch if sampling_size > num_seq

### DIFF
--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -922,8 +922,6 @@ class CombinedDataset(CachedDataset2):
       total_num_seqs = None
 
     if total_num_seqs is not None:
-      self.used_num_seqs_per_subset = [
-        self.datasets[self.dataset_idx2key_map[dataset_idx]].num_seqs for dataset_idx in range(len(self.datasets))]
       self.dataset_seq_idx_boundaries = self._create_dataset_seq_idx_boundaries()
 
       if self.sampling_sizes:
@@ -958,9 +956,11 @@ class CombinedDataset(CachedDataset2):
       del seq_order
 
       # Re-initialize sequence orders of sub-datasets with created sequence list.
+      self.used_num_seqs_per_subset = []
       for dataset_idx, dataset_key in self.dataset_idx2key_map.items():
         assert self.datasets[dataset_key].have_corpus_seq_idx()
         self.datasets[dataset_key].init_seq_order(epoch=epoch, seq_order=seq_order_subdatasets[dataset_idx])
+        self.used_num_seqs_per_subset.append(len(seq_order_subdatasets[dataset_idx]))
 
     else:
       self.dataset_sorted_seq_idx_list = []  # We will fill this as we go
@@ -975,8 +975,11 @@ class CombinedDataset(CachedDataset2):
 
     :rtype: list[int]
     """
+    num_seqs_per_subset = [
+      self.datasets[self.dataset_idx2key_map[dataset_idx]].num_seqs for dataset_idx in range(len(self.datasets))]
+
     dataset_seq_idx_boundaries = [0]
-    for dataset_num_seqs in self.used_num_seqs_per_subset:
+    for dataset_num_seqs in num_seqs_per_subset:
       dataset_seq_idx_boundaries.append(dataset_num_seqs + dataset_seq_idx_boundaries[-1])
 
     return dataset_seq_idx_boundaries


### PR DESCRIPTION
This is something I overlooked when we decided to use `_expand_dataset_sec_idxs()` for both known and unknown num_seqs. `self.used_num_seqs_per_subset` in the case of known num_seqs is not just the total number of sequences in the subsets, but we have to account for sequence ordering, sampling, etc.
This lead to running into the exception at the bottom of `_expand_dataset_sec_idxs()` at the end of an epoch, however only in case we artificially increase the number of sequences, e.g. by repeat_epoch or sampling more sequences than the total number.