### PR TITLE
tf.network: check for data availabibility

### DIFF
--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -481,6 +481,7 @@ def execute_main_task():
       batch_size=config.int('forward_batch_size', 0))
   elif task == "search":
     engine.use_search_flag = True
+    engine.use_eval_flag = config.bool("search_do_eval", True)
     engine.init_network_from_config(config)
     if config.value("search_data", "eval") in ["train", "dev", "eval"]:
       data = {"train": train_data, "dev": dev_data, "eval": eval_data}[config.value("search_data", "eval")]

--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -2201,7 +2201,7 @@ class Engine(EngineBase):
   def search(self, dataset, do_eval=True, output_layer_names="output", output_file=None, output_file_format="txt"):
     """
     :param Dataset dataset:
-    :param bool do_eval: calculate errors. can only be done if we have the reference target
+    :param bool do_eval: calculate errors and print reference. can only be done if we have the reference target
     :param str|list[str] output_layer_names:
     :param str output_file:
     :param str output_file_format: "txt" or "py"
@@ -2296,7 +2296,8 @@ class Engine(EngineBase):
       for target_idx in range(num_targets):
         outputs.append(kwargs["output_" + output_layer_names[target_idx]])
         beam_scores.append(kwargs["beam_scores_" + output_layer_names[target_idx]])
-        targets.append(kwargs["target_" + target_keys[target_idx]])
+        if do_eval:
+          targets.append(kwargs["target_" + target_keys[target_idx]])
 
       n_batch = len(seq_idx)  # without beam
       assert n_batch == len(seq_tag)
@@ -2307,7 +2308,7 @@ class Engine(EngineBase):
           assert beam_scores[target_idx].shape == (n_batch, out_beam_sizes[target_idx])
 
         assert n_batch * (out_beam_sizes[target_idx] or 1) == len(outputs[target_idx])
-        if targets[target_idx] is not None:
+        if do_eval and targets[target_idx] is not None:
           assert n_batch == len(targets[target_idx])
 
         if output_layers[target_idx].output.dim == 256 and output_layers[target_idx].output.sparse:
@@ -2337,8 +2338,9 @@ class Engine(EngineBase):
                   file=log.v4)
             out_idx = batch_idx * out_beam_sizes[target_idx]
           if target_keys[target_idx] and dataset.can_serialize_data(target_keys[target_idx]):
-            print("  ref:", dataset.serialize_data(key=target_keys[target_idx], data=targets[target_idx][batch_idx]),
-                  file=log.v4)
+            if do_eval:
+              print("  ref:", dataset.serialize_data(key=target_keys[target_idx], data=targets[target_idx][batch_idx]),
+                    file=log.v4)
             if out_beam_sizes[target_idx] is None:
               print("  hyp:", dataset.serialize_data(key=target_keys[target_idx], data=outputs[target_idx][out_idx]),
                     file=log.v4)
@@ -2378,8 +2380,9 @@ class Engine(EngineBase):
       extra_fetches["beam_scores_" + output_layer_names[target_idx]] = output_layer_beam_scores[target_idx]
       # We use target_keys[target_idx] and not output_layer_names[target_idx]
       # for the key to avoid fetching the same target multiple times.
-      extra_fetches["target_" + target_keys[target_idx]] = self.network.get_extern_data(
-        target_keys[target_idx], mark_data_key_as_used=True)
+      if do_eval:
+        extra_fetches["target_" + target_keys[target_idx]] = self.network.get_extern_data(
+          target_keys[target_idx], mark_data_key_as_used=True)
 
     runner = Runner(
       engine=self, dataset=dataset, batches=batches, train=train, eval=do_eval,

--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -80,7 +80,7 @@ class LayerBase(object):
 
     :param str name:
     :param returnn.tf.network.TFNetwork network:
-    :param Data output:
+    :param Data|None output: Set a specific output instead of using :func:`get_out_data_from_opts`
     :param NotSpecified|None|int n_out: output dim
     :param dict[str] out_type: kwargs for Data class. more explicit than n_out.
     :param list[LayerBase] sources: via self.transform_config_dict()
@@ -1341,6 +1341,16 @@ class InternalLayer(LayerBase):
   """
   This is not supposed to be used by the user.
   It is used by some code to construct a wrapper layer or so.
+  """
+
+
+class DataNotAvailableLayer(InternalLayer):
+  """
+  This is a dummy layer that is created when the output template is flagged "not available for inference".
+  The output template should be passed to the constructor to correctly forward the information
+  in case any dependent output is exported with "register_as_extern_data".
+
+  See :func:`returnn.tf.network._create_layer`
   """
 
 

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -695,6 +695,9 @@ class TFNetwork(object):
           layer_class.__name__, name, layer_desc)
         output_template.sanity_check(ignore_placeholder=True)  # placeholder might be overwritten later
         output_template_special_axes = output_template.get_special_axes_dict()
+        if not output_template.available_for_inference and not self.eval_flag:
+          from returnn.tf.layers.base import DataNotAvailableLayer
+          return DataNotAvailableLayer(name=layer_desc['name'], network=layer_desc['network'], output=output_template)
         layer = layer_class(**layer_desc)
         layer.post_init(layer_desc)
         layer.output.sanity_check()


### PR DESCRIPTION
 - Adds a DataNotAvailable Exception
 - Aborts construction stack when the output is flagged
   as available_for_inference=False

This is related to issue #372, and approaches the problem by introducing an Exception that is caught when calling the network construction from "register_as_extern_data". In all other cases the Exception will be raised globally.