### PR TITLE
custom iterate_seqs for RNN-T chunked training

### DIFF
--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -1006,6 +1006,10 @@ class Engine(EngineBase):
     if config.has("eval_datasets"):
       for dataset_name, dataset_opts in config.typed_value("eval_datasets", {}).items():
         self.eval_datasets[dataset_name] = init_dataset(dataset_opts, default_kwargs={"name": dataset_name})
+    if config.has("custom_iterate_seqs"):  # monkey-patch `iterate_seqs`
+      custom_iterate_seqs = config.typed_value("custom_iterate_seqs")
+      assert callable(custom_iterate_seqs)
+      self.train_data.__class__.iterate_seqs = custom_iterate_seqs
     self.start_epoch, self.start_batch = self.get_train_start_epoch_batch(config)
     self.batch_size = config.typed_value('batch_size', 1)
     self.shuffle_batches = config.bool('shuffle_batches', False)

--- a/tests/test_Dataset.py
+++ b/tests/test_Dataset.py
@@ -61,6 +61,215 @@ def test_iterate_seqs_chunking_1():
   assert_equal(seqs[5], (1, 10, 11))
 
 
+def iterate_seqs_rnnt(dataset, chunk_size=None, chunk_step=None, used_data_keys=None,
+                      alignment_key="alignment", classes_key="classes", data_key="data",
+                      blank_index=0):
+  """
+  Takes chunking into consideration, special case for RNN-T.
+  Because RNN-T does not operate time-synchronous
+  (but rather alignment-synchronously), we have to take this into
+  consideration when doing chunking.
+  This implementation currently chunks along the data-dimension,
+  that means that the chunks are constant for "data" (except the last chunk).
+  Also because our alignment is computed on the encoder-axis,
+  the chunking is performed on this level also. When you have time-reduction
+  from your input to the alignment, you have to consider this when outputting
+  chunks for "data" (e.g. just multiply with time-reduction factor).
+
+  Note: chunking_variance is not supported.
+
+  :param Dataset dataset:
+  :param int|dict|NumbersDict chunk_size:
+  :param int|dict|NumbersDict chunk_step:
+  :param set(str)|None used_data_keys:
+  :param str alignment_key:
+  :param str classes_key:
+  :param str data_key:
+  :param int blank_index:
+  :return: generator which yields tuples (seq index, seq start, seq end)
+  :rtype: list[(int,NumbersDict,NumbersDict)]
+  """
+  if chunk_size is None:
+    chunk_size = dataset.chunk_size
+  if chunk_step is None:
+    chunk_step = dataset.chunk_step
+  chunk_size = NumbersDict(chunk_size)
+  chunk_step = NumbersDict(chunk_step)
+  print("Dataset %r: min_chunk_size: %i" % (dataset, dataset.min_chunk_size))
+  print("chunk_step:", chunk_step)
+  print("chunk_size:", chunk_size)
+
+  s = 0
+  data_keys = dataset.data_keys  # for other than `StaticDataset` this may be dataset.get_data_keys()
+  assert alignment_key in data_keys, "key '%s' in data-keys %r" % (alignment_key, data_keys)
+  assert classes_key in data_keys, "No key '%s' in data-keys %r" % (classes_key, data_keys)
+  assert data_key in data_keys, "No key '%s' in data-keys %r" % (classes_key, data_keys)
+  assert data_key in chunk_size.keys(), "specify the chunking only in one key"
+  assert classes_key not in chunk_size.keys(), "specify the chunking only one key"
+  assert alignment_key not in chunk_size.keys(), "specify the chunking only one key"
+
+  def compute_dynamic_chunk_sizes(chunk):
+    """
+    Computes the dynamic chunk size from a given chunk.
+    We currently support just data, classes and alignment itself.
+
+    :param np.ndarray chunk: from alignment
+    """
+    nr_of_symbols = len(np.where(chunk != blank_index)[0])
+    nr_of_blanks = len(chunk) - nr_of_symbols
+    num_dict = NumbersDict({
+      data_key: nr_of_blanks,
+      alignment_key: len(chunk),
+      classes_key: nr_of_symbols,
+    })
+    return num_dict
+
+  while dataset.is_less_than_num_seqs(s):
+    length = dataset.get_seq_length(s)
+    if chunk_size == 0:
+      yield s, NumbersDict.constant_like(0, numbers_dict=length), length
+    else:
+      alignment = dataset.get_data(s, alignment_key)
+
+      # in the given chunk of alignment data, we check for:
+      # * blank indices (advance input)
+      # * non-blank indices (advance target/classes)
+      # We can either advance input or target by a constant amount each time.
+      # Currently only advanced input-len a constant amount is supported.
+
+      blank_indices = np.where(alignment == blank_index)[0]  # [T]
+      blank_length = len(blank_indices)
+      nr_of_chunks = (blank_length - 1) // chunk_step[data_key] + 1
+
+      # index into the different data-keys
+      t = NumbersDict({data_key: 0, classes_key: 0, alignment_key: 0})
+      for chunk_idx in range(nr_of_chunks):
+        chunk_start = t
+        data_chunk_indices = blank_indices[t[data_key]:t[data_key]+chunk_size[data_key]]
+        # we might miss some data (in the alignment) after the last blank.
+        end = len(alignment) if len(data_chunk_indices) < chunk_size[data_key] else data_chunk_indices[-1]+1
+        alignment_size_chunk = alignment[chunk_start[alignment_key]:end]
+        dynamic_chunk_size = compute_dynamic_chunk_sizes(alignment_size_chunk)
+        chunk_start = t.copy()
+        chunk_end = NumbersDict.min([chunk_start + dynamic_chunk_size, length])
+
+        # compute dynamic chunk step:
+        chunk_indices_step = blank_indices[t[data_key]:t[data_key] + chunk_step[data_key]]
+        end_step = len(alignment) if len(chunk_indices_step) < chunk_step[data_key] else chunk_indices_step[-1] + 1
+        alignment_step_chunk = alignment[chunk_start[alignment_key]:end_step]
+        dynamic_chunk_step = compute_dynamic_chunk_sizes(alignment_step_chunk)
+        t += dynamic_chunk_step
+        yield s, chunk_start, chunk_end
+    s += 1
+  return
+
+
+def test_iterate_seqs_chunking_rnnt():
+  # Simulate transducer data: classes, alignment, data
+  np.random.seed(42)
+  blank_index = 0
+  n_batch = 3
+  alignments = [
+    np.array([0, 0, 1, 0, 2, 0, 0, 1, 0, 0, 3]),  # T=7, U=4
+    np.array([0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 4]),  # T=8, U=3
+    np.array([1, 2, 1, 0, 5, 0, 1, 1, 2, 4, 3]),  # T=2, U=9
+  ]
+  data = [np.arange(7), np.arange(8), np.arange(2)]
+  classes = [
+    np.array([1, 2, 1, 3]),
+    np.array([2, 2, 4]),
+    np.array([1, 2, 1, 0, 5, 0, 1, 1, 2, 4, 3]),
+  ]
+  from returnn.datasets.generating import StaticDataset
+  dataset = StaticDataset([{"data": data[i],
+                            "classes": classes[i],
+                            "alignment": alignments[i]} for i in range(n_batch)],
+                          output_dim={"data": (5, 1),
+                                      "classes": (5, 1),
+                                      "alignment": (5, 1)})
+  dataset.init_seq_order(1)
+
+  def wrapper_iterate_seqs(self, chunk_size=None, chunk_step=None, used_data_keys=None):
+    return iterate_seqs_rnnt(self, chunk_size, chunk_step, used_data_keys,
+                             alignment_key="alignment", classes_key="classes",
+                             data_key="data", blank_index=blank_index)
+  StaticDataset.iterate_seqs = wrapper_iterate_seqs  # we simply monkey-patch it
+
+  # first test, size==step
+  seqs = list(dataset.iterate_seqs(chunk_size={'data': 6}, chunk_step={'data': 6}, used_data_keys=None))
+  print("We got %i seqs." % len(seqs))
+  for s in seqs:
+    print(s)
+
+  # seq[0]: (seq index, seq start, seq end)
+  # np.array([0, 0, 1, 0, 2, 0, 0, 1, 0, 0, 3]),  # T=7, U=4
+  # -> [0, 0, 1, 0, 2, 0, 0, 1, 0] (T=[0,6), U=[0,3), len(align)=[0,3))
+  # -> [0, 3]  # (T=[6,7), U=[3,4), A=[9,11))
+  assert_equal(seqs[0], (0,
+                         NumbersDict({'data': 0, 'classes': 0, 'alignment': 0}),
+                         NumbersDict({'data': 6, 'classes': 3, 'alignment': 9})))
+  assert_equal(seqs[1], (0,
+                         NumbersDict({'data': 6, 'classes': 3, 'alignment': 9}),
+                         NumbersDict({'data': 7, 'classes': 4, 'alignment': 11})))
+
+  # np.array([0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 4]),  # T=8, U=3
+  # -> [0, 0, 0, 0, 0, 0]  # (T=[0,6), U=[0,0), A=[0,6))
+  # -> [0, 2, 2, 0, 4]     # (T=[6,8), U=[0,3), A=[6,11))
+  assert_equal(seqs[2], (1,
+                         NumbersDict({'data': 0, 'classes': 0, 'alignment': 0}),
+                         NumbersDict({'data': 6, 'classes': 0, 'alignment': 6})))
+  assert_equal(seqs[3], (1,
+                         NumbersDict({'data': 6, 'classes': 0, 'alignment': 6}),
+                         NumbersDict({'data': 8, 'classes': 3, 'alignment': 11})))
+
+  # np.array([1, 2, 1, 0, 5, 0, 1, 1, 2, 4, 3]),  # T=2, U=9
+  # -> [0, 0]  # (T=[0,2), U=[0,9), A=[0,11))
+  assert_equal(seqs[4], (2,
+                         NumbersDict({'data': 0, 'classes': 0, 'alignment': 0}),
+                         NumbersDict({'data': 2, 'classes': 9, 'alignment': 11})))
+
+  #
+  # Testing for overlapping chunks!
+  #
+  seqs = list(dataset.iterate_seqs(chunk_size={'data': 6}, chunk_step={'data': 3}, used_data_keys=None))
+  print("We got %i seqs." % len(seqs))
+  for s in seqs:
+    print(s)
+  # np.array([0, 0, 1, 0, > 2, 0, 0, 1, 0, > 0, 3]),  # T=7, U=4
+  # -> [0, 0, 1, 0, 2, 0, 0, 1, 0]  # (T=[0,6), U=[0,3), A=[0,9))
+  # -> [2, 0, 0, 1, 0, 0, 3]        # (T=[3,7), U=[1,4), A=[4,11))
+  # -> [0, 3]                       # (T=[6,7), U=[3,4), A=[9, 11))
+  assert_equal(seqs[0], (0,
+                         NumbersDict({'data': 0, 'classes': 0, 'alignment': 0}),
+                         NumbersDict({'data': 6, 'classes': 3, 'alignment': 9})))
+  assert_equal(seqs[1], (0,
+                         NumbersDict({'data': 3, 'classes': 1, 'alignment': 4}),
+                         NumbersDict({'data': 7, 'classes': 4, 'alignment': 11})))
+  assert_equal(seqs[2], (0,
+                         NumbersDict({'data': 6, 'classes': 3, 'alignment': 9}),
+                         NumbersDict({'data': 7, 'classes': 4, 'alignment': 11})))
+
+  # np.array([0, 0, 0, > 0, 0, 0, > 0, 2, 2, 0, 4]),  # T=8, U=3, A=11
+  # -> [0, 0, 0, 0, 0, 0]        # T=[0,6),  U=[0,0), A=[0,6)
+  # -> [0, 0, 0, 0, 2, 2, 0, 4]  # T=[3,8), U=[0,3), A=[3,11)
+  # -> [0, 2, 2, 0, 4]           # T=[6,8), U=[0,3), A=[6,11)
+  assert_equal(seqs[3], (1,
+                         NumbersDict({'data': 0, 'classes': 0, 'alignment': 0}),
+                         NumbersDict({'data': 6, 'classes': 0, 'alignment': 6})))
+  assert_equal(seqs[4], (1,
+                         NumbersDict({'data': 3, 'classes': 0, 'alignment': 3}),
+                         NumbersDict({'data': 8, 'classes': 3, 'alignment': 11})))
+  assert_equal(seqs[5], (1,
+                         NumbersDict({'data': 6, 'classes': 0, 'alignment': 6}),
+                         NumbersDict({'data': 8, 'classes': 3, 'alignment': 11})))
+
+  # np.array([1, 2, 1, 0, 5, 0, 1, 1, 2, 4, 3]),  # T=2, U=9
+  # -> [1, 2, 1, 0, 5, 0, 1, 1, 2, 4, 3]  # (T=2, U=9, A=11)
+  assert_equal(seqs[6], (2,
+                         NumbersDict({'data': 0, 'classes': 0, 'alignment': 0}),
+                         NumbersDict({'data': 2, 'classes': 9, 'alignment': 11})))
+
+
 def test_iterate_seqs_chunking_varying_sequence_length():
   dataset = DummyDatasetMultipleSequenceLength(input_dim=2, output_dim=3, num_seqs=2, seq_len={'data': 24, 'classes': 12})
   dataset.init_seq_order(1)


### PR DESCRIPTION
Hey,

I've added a test for a custom `Dataset.iterate_seqs` for RNN-T chunked training.
Also, to use this during training in a config, there is an option `custom_iterate_seqs`
which simply monkey-patches the `__class__` of the train_data to use a user-specified `iterate_seqs`.
The patch is only applied to the training dataset, because for the other cases, we don't want chunking anyways.

I know that monkey-patching should be discouraged (and hacky), but since this feature is probably very seldom used,
this may be ok. If anyone has a better suggestion where to implement this, please let me know :)

Also the custom `iterate_seqs` for RNN-T is not very efficient and could very well be improved,
but this should only show how it can be done.

Cheers, André