### PR TITLE
Warp-RNA TF wrapper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "extern/HawkAaronWarpTransducer/warp-transducer"]
 	path = returnn/extern/HawkAaronWarpTransducer/warp-transducer
 	url = https://github.com/HawkAaron/warp-transducer.git
+[submodule "returnn/extern/WarpRna/warp-rna"]
+	path = returnn/extern/WarpRna/warp-rna
+	url = https://github.com/Spotlight0xff/warp-rna.git

--- a/returnn/extern/WarpRna/__init__.py
+++ b/returnn/extern/WarpRna/__init__.py
@@ -1,0 +1,99 @@
+"""
+Provides a RETURNN wrapper around `warp-transducer`:
+  https://github.com/1ytic/warp-rna
+
+Importing this module immediately compiles the library and TF module.
+"""
+
+import os
+import typing
+import tensorflow as tf
+from tensorflow.python.framework import ops
+from returnn.tf.util.basic import OpCodeCompiler
+
+
+warprna_dir = os.path.dirname(os.path.abspath(__file__))
+submodule_dir = os.path.join(warprna_dir, "warp-rna")
+_tf_mod = None  # type: typing.Optional[typing.Any]
+
+
+def is_checked_out():
+  """
+  Checks if the git submodule is checkout out.
+
+  :rtype: bool
+  """
+  return os.path.isfile("%s/core.cu" % submodule_dir)
+
+
+def init_warprna(verbose=False):
+  """
+  Initializes and compiles the library. Caches the TF module.
+
+  :param bool verbose:
+  """
+  global _tf_mod
+  if _tf_mod:
+    return
+  assert is_checked_out(), "submodule not checked out? Run `git submodule update --init --recursive`"
+
+  src_files = [
+    '%s/tensorflow_binding/src/warp_rna_op.cc' % submodule_dir,
+    '%s/core.cu' % submodule_dir,
+  ]
+  src_code = ""
+  for fn in src_files:
+    f_code = open(fn).read()
+    src_code += "\n// ------------ %s : BEGIN { ------------\n" % os.path.basename(fn)
+    # https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html#Line-Control
+    src_code += "#line 1 \"%s\"\n" % os.path.basename(fn)
+    src_code += f_code
+    src_code += "\n// ------------ %s : END } --------------\n\n" % os.path.basename(fn)
+
+  compiler = OpCodeCompiler(
+    base_name="warprna_kernels", code_version=1, code=src_code,
+    include_paths=(submodule_dir, os.path.dirname(submodule_dir)),
+    c_macro_defines={"WARPRNA_ENABLE_GPU": 1},
+    is_cpp=True, use_cuda_if_available=True,
+    verbose=verbose)
+  tf_mod = compiler.load_tf_module()
+  assert hasattr(tf_mod, "WarpRNA"), "content of mod: %r" % (dir(tf_mod),)
+  _tf_mod = tf_mod
+  return tf_mod
+
+
+def rna_loss(log_probs, labels, input_lengths, label_lengths, blank_label=0):
+  """Computes the RNA loss between a sequence of activations and a
+  ground truth labeling.
+  Args:
+      log_probs: A 4-D Tensor of floats.  The dimensions
+                   should be (B, T, U, V), where B is the minibatch index,
+                   T is the time index, U is the prediction network sequence
+                   length, and V indexes over activations for each
+                   symbol in the alphabet.
+      labels: A 2-D Tensor of ints, a padded label sequences to make sure
+                   labels for the minibatch are same length.
+      input_lengths: A 1-D Tensor of ints, the number of time steps
+                     for each sequence in the minibatch.
+      label_lengths: A 1-D Tensor of ints, the length of each label
+                     for each example in the minibatch.
+      blank_label: int, the label value/index that the RNA
+                   calculation should use as the blank label
+  Returns:
+      1-D float Tensor, the cost of each example in the minibatch
+      (as negative log probabilities).
+  * This class performs the softmax operation internally.
+  * The label reserved for the blank symbol should be label 0.
+  """
+  init_warprna()
+  loss, _ = _tf_mod.warp_rna(log_probs, labels, input_lengths,
+                             label_lengths, tf.reduce_min(label_lengths), blank_label)
+  return loss
+
+
+@ops.RegisterGradient("WarpRNA")
+def _warprna_loss_grad(op, grad_loss, _):
+  grad = op.outputs[1]
+  # NOTE since here we are batch first, cannot use _BroadcastMul
+  grad_loss = tf.reshape(grad_loss, (-1, 1, 1, 1))
+  return [grad_loss * grad, None, None, None, None]

--- a/tests/test_TFNativeOp.py
+++ b/tests/test_TFNativeOp.py
@@ -3114,6 +3114,72 @@ def test_warprnnt_multiple_batches():
   _run_rnnt(acts, labels, input_lengths, label_lengths, expected_costs, expected_grads, 0)
 
 
+@unittest.skipIf(not is_gpu_available(), "no gpu on this system")
+def test_warprna_forward():
+  from returnn.extern.WarpRna import rna_loss, is_checked_out
+  if not is_checked_out():
+    raise unittest.SkipTest("WarpRna not checked out?")
+  import numpy as np
+  # computed using slow TF implementation (cross-check against numpy reference impl)
+  expected_costs = np.array([2.6347387, 2.4651031])
+  expected_grads = np.array([[[[-0.34075904, -0.65924096, 0.],
+                               [0., 0., 0.],
+                               [0., 0., 0.]],
+                              [[-0.09434381, -0.24641524, 0.],
+                               [-0.4480959, 0., -0.2111451],
+                               [0., 0., 0.]],
+                              [[0., -0.09434381, 0.],
+                               [-0.25838017, 0., -0.43613094],
+                               [-0.2111451, 0., 0.]],
+                              [[0., 0., 0.],
+                               [0., 0., -0.35272402],
+                               [-0.64727604, 0., 0.]]],
+                             [[[-0.6283351, -0.37166485, 0.],
+                               [0., 0., 0.],
+                               [0., 0., 0.]],
+                              [[-0.26558593, -0.36274916, 0.],
+                               [-0.23790276, -0.13376209, 0.],
+                               [0., 0., 0.]],
+                              [[0., -0.26558593, 0.],
+                               [-0.26772842, -0.3329236, 0.],
+                               [-0.13376209, 0., 0.]],
+                              [[0., 0., 0.],
+                               [0., -0.53331435, 0.],
+                               [-0.46668565, 0., 0.]]]])
+
+  n_batch, n_time, n_target, n_vocab = 2, 4, 3, 3
+  acts = np.array([0.065357, 0.787530, 0.081592, 0.529716, 0.750675, 0.754135,
+                   0.609764, 0.868140, 0.622532, 0.668522, 0.858039, 0.164539,
+                   0.989780, 0.944298, 0.603168, 0.946783, 0.666203, 0.286882,
+                   0.094184, 0.366674, 0.736168, 0.166680, 0.714154, 0.399400,
+                   0.535982, 0.291821, 0.612642, 0.324241, 0.800764, 0.524106,
+                   0.779195, 0.183314, 0.113745, 0.240222, 0.339470, 0.134160,
+                   0.505562, 0.051597, 0.640290, 0.430733, 0.829473, 0.177467,
+                   0.320700, 0.042883, 0.302803, 0.675178, 0.569537, 0.558474,
+                   0.083132, 0.060165, 0.107958, 0.748615, 0.943918, 0.486356,
+                   0.418199, 0.652408, 0.024243, 0.134582, 0.366342, 0.295830,
+                   0.923670, 0.689929, 0.741898, 0.250005, 0.603430, 0.987289,
+                   0.592606, 0.884672, 0.543450, 0.660770, 0.377128, 0.358021], dtype=np.float32)
+  acts = np.reshape(acts, (n_batch, n_time, n_target, n_vocab))
+
+  labels = np.array([[1, 2], [1, 1]], dtype=np.int32)
+  input_lengths = np.array([4, 4], dtype=np.int32)
+  label_lengths = np.array([2, 2], dtype=np.int32)
+
+  acts_t = tf.convert_to_tensor(acts)
+  labels_t = tf.convert_to_tensor(labels)
+  input_lengths_t = tf.convert_to_tensor(input_lengths)
+  label_lengths_t = tf.convert_to_tensor(label_lengths)
+  log_probs = tf.nn.log_softmax(acts_t)
+  costs_cuda = rna_loss(log_probs, labels_t, input_lengths_t, label_lengths_t)
+  grads_cuda = tf.gradients(costs_cuda, [log_probs])[0]
+  (out_costs_cuda, out_grads_cuda) = session.run([costs_cuda, grads_cuda])
+
+  print("[CUDA] costs:", out_costs_cuda)
+  np.testing.assert_allclose(out_grads_cuda, expected_grads, rtol=1e-6)
+  np.testing.assert_allclose(out_costs_cuda, expected_costs, rtol=1e-6)
+
+
 if __name__ == "__main__":
   try:
     better_exchook.install()


### PR DESCRIPTION
Hi,

because my custom TF code for the RNA loss implementation is too slow for training,
I wrote a Tensorflow binding to the [warp-rna](https://github.com/1ytic/warp-rna) code (which is for PyTorch).
The binding itself is in my [fork](https://github.com/Spotlight0xff/warp-rna).

Other than that, this is fairly standard and very similar to the `HawkAaronWarpTransducer`.

Cheers, André