### PR TITLE
Fixed confusion of TF graphs when running multiple Engines

### DIFF
--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -1957,7 +1957,7 @@ class Engine(EngineBase):
     """
     if self._checked_uninitialized_vars:
       return
-    with tf.name_scope("check_uninitialized_vars"):
+    with tf.name_scope("check_uninitialized_vars"), self.tf_session.graph.as_default():
       # Like tf.report_uninitialized_variables().
       var_list = tf_compat.v1.global_variables() + tf_compat.v1.local_variables()
       if not var_list:


### PR DESCRIPTION
I got
```
File "/home/pwilken/src/returnn_dev/returnn/tf/engine.py", line 1961, in check_uninitialized_vars
    line: var_mask = tf.logical_not(tf.stack(
            [tf_compat.v1.is_variable_initialized(v) for v in var_list])).eval(session=self.tf_session)
[...]
ValueError: Cannot use the given session to evaluate tensor: the tensor's graph is different from the session's graph.
```
when running two RETURNN Engines in the same python session (which works fine except for this issue!).

What I do is:
1. Create `engine_1 = Engine(...)` and run `engine_1.init_network_from_config()`
2. Create `engine_2 = Engine(...)` and run `engine_2.init_network_from_config()`
3. Running `engine_1.search_single_string_to_string_seq(...)` resulting in the error

(1. and 2. are part of a server startup, so I can't run 3. before 2.)

To my understanding, what happens is: We don't explicitly define a TF graph in RETURNN, therefore we always use the default graph.  `init_network_from_config()` calls* `tf_compat.v1.reset_default_graph()` before creating the network. Therefore, after step 2 the default graph is `engine_2.tf_session.graph`, which is different from `engine_1.tf_session.graph`. In step 3.,`check_uninitialized_vars()` tries to initialize variables from the default graph, which however contains the network from `engine_2`.

Maybe the default graph should be set on a higher level than in my fix, but this is really just a problem when accessing `tf_compat.v1.GraphKeys.GLOBAL_VARIABLES`. There are a couple of other places in the code where this is done...


 \*via `init_network()` -> `_reset_graph()`