### PR TITLE
Generic inference function

### DIFF
--- a/returnn/datasets/map.py
+++ b/returnn/datasets/map.py
@@ -1,0 +1,210 @@
+"""
+Provides :class:`MapDatasetBase`
+"""
+
+from returnn.datasets.basic import DatasetSeq
+from returnn.datasets.cached2 import CachedDataset2
+from returnn.util.basic import OptionalNotImplementedError
+
+
+class MapDatasetBase(object):
+  """
+  This dataset can be used as template to implement user-side Datasets, where the data can be access in arbitrary order.
+  For global sorting, the length information needs to be known beforehand.
+  """
+
+  def __init__(self, num_outputs=None):
+    """
+    :param dict num_outputs: definition of the data as constructor parameters of a Data object
+    """
+    self.num_outputs = num_outputs or {}
+
+  def __len__(self):
+    """
+    :return: total number of sequences in the dataset
+    :rtype: int
+    """
+    raise NotImplementedError
+
+  def __getitem__(self, seq_idx):
+    """
+    This function does the actual data loading, the order can be arbitrary.
+
+    :param int seq_idx:
+    :return: The content of a single dataset entry
+    :rtype: dict[str,numpy.array]
+    """
+    raise NotImplementedError
+
+  def get_seq_len(self, seq_idx):
+    """
+    This optional function provides the sequence length for the `seq_ordering` parameter.
+    If not specified only a limited set of options is available.
+
+    :param seq_idx:
+    :return:
+    :rtype: int|None
+    """
+    raise OptionalNotImplementedError
+
+  def get_seq_tag(self, seq_idx):
+    """
+    Optionally return a sequence tag.
+
+    :param int seq_idx:
+    :return:
+    :rtype: str|None
+    """
+    return "seq-%i" % seq_idx
+
+  def get_seq_order(self, epoch=None):
+    """
+    Override to implement a dataset specific sequence order for a given epoch.
+    The number of sequences can be less than the total number.
+    This will override the effects of `partition_epoch` and `seq_ordering` when using MapDatasetWrapper.
+
+    :param epoch:
+    :return: seq_order
+    :rtype: list[int]
+    """
+    raise OptionalNotImplementedError
+
+
+class MapDatasetWrapper(CachedDataset2):
+  """
+  Takes a MapDataset and turns it into a returnn.datasets.Dataset by providing the required class methods.
+  """
+  def __init__(self, map_dataset, name=None, seq_ordering='default', random_seed_offset=None, partition_epoch=None):
+    """
+    :param MapDatasetBase map_dataset: the MapDataset to be wrapped
+    :param str name: name of the dataset
+    :param str seq_ordering: string to define the sequence ordering
+    :param int|None random_seed_offset: provide a seed offset for the sequence ordering
+    :param int|None partition_epoch:
+    """
+
+    super(MapDatasetWrapper, self).__init__(
+      name=name,
+      seq_ordering=seq_ordering,
+      random_seed_offset=random_seed_offset,
+      partition_epoch=partition_epoch
+    )
+
+    self._dataset = map_dataset
+    self._seq_order = None
+
+  @property
+  def num_seqs(self):
+    """
+    :returns number of sequences in the current epoch
+    :rtype: int
+    """
+    assert self._seq_order is not None, "num_seqs is only known after calling init_seq_order()"
+    return len(self._seq_order)
+
+  def init_seq_order(self, epoch=None, seq_list=None, seq_order=None):
+    """
+    :param int|None epoch:
+    :param list[str]|None seq_list: List of sequence tags, to set a predefined order.
+    :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
+    :rtype: bool
+    :returns whether the order changed (True is always safe to return)
+    """
+    super(MapDatasetWrapper, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
+
+    if seq_list or seq_order:
+      raise NotImplementedError
+
+    try:
+      self._seq_order = self._dataset.get_seq_order(epoch=epoch)
+    except OptionalNotImplementedError:
+      try:
+        self._seq_order = self.get_seq_order_for_epoch(
+          epoch=epoch, num_seqs=len(self._dataset), get_seq_len=self._dataset.get_seq_len)
+      except OptionalNotImplementedError:
+        # only support seq_ordering that need no length here
+        assert self.seq_ordering in ["default", "reverse", "random"]
+        self._seq_order = self.get_seq_order_for_epoch(
+          epoch=epoch, num_seqs=len(self._dataset), get_seq_len=None)
+
+    return True
+
+  def _collect_single_seq(self, seq_idx):
+    """
+    :param int seq_idx: sorted seq idx
+    :return:
+    """
+    corpus_seq_idx = self.get_corpus_seq_idx(seq_idx)
+    return DatasetSeq(
+      seq_idx, features=self._dataset[corpus_seq_idx], seq_tag=self._dataset.get_seq_tag(corpus_seq_idx))
+
+  def get_current_seq_order(self):
+    """
+    :rtype: list[int]
+    """
+    assert self._seq_order is not None
+    return self._seq_order
+
+  def get_tag(self, sorted_seq_idx):
+    """
+    :param sorted_seq_idx:
+    :return:
+    """
+    seq_tag = self._dataset.get_seq_tag(self.get_corpus_seq_idx(sorted_seq_idx))
+    return seq_tag
+
+  def get_corpus_seq_idx(self, sorted_seq_idx):
+    """
+    :param int sorted_seq_idx:
+    :return corpus_seq_idx
+    :rtype: int
+    """
+    return self._seq_order[sorted_seq_idx]
+
+  def get_data_dim(self, key):
+    """
+    :param str key: e.g. "data" or "classes"
+    :return: number of classes, no matter if sparse or not
+    :rtype: int
+    """
+    if key in self._dataset.num_outputs:
+      return self._dataset.num_outputs[key].get("dim", 1)
+    return 1  # unknown
+
+  def get_data_dtype(self, key):
+    """
+    :param str key: e.g. "data" or "classes"
+    :return: dtype as str, e.g. "int32" or "float32"
+    :rtype: str
+    """
+    if key in self._dataset.num_outputs and "dtype" in self._dataset.num_outputs[key]:
+      return self._dataset.num_outputs[key]["dtype"]
+    if self.is_data_sparse(key):
+      return "int32"
+    return "float32"
+
+  def is_data_sparse(self, key):
+    """
+    :param str key: e.g. "data" or "classes"
+    :return: whether the data is sparse
+    :rtype: bool
+    """
+    # Note: We cannot call get_data_dtype, as we would maybe result in infinite recursion.
+    if key in self._dataset.num_outputs:
+      return self._dataset.num_outputs[key].get("sparse", False)
+    return False
+
+  def get_data_shape(self, key):
+    """
+    :returns get_data(*, key).shape[1:], i.e. num-frames excluded
+    :rtype: list[int]
+    """
+    if key in self._dataset.num_outputs:
+      if "shape" in self._dataset.num_outputs[key].keys():
+        if self._dataset.num_outputs[key]["shape"][0] is None:
+          return self._dataset.num_outputs[key]["shape"][1:]
+        else:
+          assert False, "data shape has no time axis, calling get_data_shape is not possible"
+    if self.is_data_sparse(key):
+      return []
+    return [self.get_data_dim(key)]

--- a/returnn/datasets/map.py
+++ b/returnn/datasets/map.py
@@ -208,3 +208,42 @@ class MapDatasetWrapper(CachedDataset2):
     if self.is_data_sparse(key):
       return []
     return [self.get_data_dim(key)]
+
+
+class FromListDataset(MapDatasetBase):
+  """
+  Simple implementation of a MapDataset where all data is given in a list.
+  """
+  def __init__(self, data_list, num_outputs, sort_data_key=None):
+    """
+    :param list[dict[str,numpy.ndarray]] data_list: sequence data as a dict data_key -> data for all sequences.
+    :param str sort_data_key: Sequence length will be determined from data of this data_key.
+    """
+    self._data_list = data_list
+    assert not sort_data_key or sort_data_key in num_outputs
+    self._sort_data_key = sort_data_key
+    super(FromListDataset, self).__init__(num_outputs=num_outputs)
+
+  def __len__(self):
+    """
+    :return: total number of sequences in the dataset
+    :rtype: int
+    """
+    return len(self._data_list)
+
+  def __getitem__(self, seq_idx):
+    """
+    :param int seq_idx:
+    :return: The content of a single dataset entry
+    :rtype dict[str,numpy.array]
+    """
+    return self._data_list[seq_idx]
+
+  def get_seq_len(self, seq_idx):
+    """
+    :param seq_idx:
+    :return:
+    :rtype: int|None
+    """
+    assert self._sort_data_key, "Specify which data key should be used for sequence sorting via 'sort_data_key'."
+    return len(self._data_list[seq_idx][self._sort_data_key])

--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -2429,7 +2429,7 @@ class Engine(EngineBase):
       sequences, see above.
     :rtype: list[dict]|dict
     """
-    from returnn.datasets.map import FromListDataset
+    from returnn.datasets.map import FromListDataset, MapDatasetWrapper
 
     is_single_sequence = False
     if not isinstance(input_data, list):
@@ -2483,7 +2483,7 @@ class Engine(EngineBase):
         output_layer_beam_scores = search_choices.beam_scores
         fetches_dict[output_layer_name + ":beam_scores"] = output_layer_beam_scores
 
-    dataset = FromListDataset(data_list=input_data_converted, num_outputs=input_data_types)
+    dataset = MapDatasetWrapper(FromListDataset(data_list=input_data_converted, num_outputs=input_data_types))
     dataset.init_seq_order(epoch=1)
 
     output_batch = self.run_single(dataset=dataset, output_dict=fetches_dict, seq_idx=-1)


### PR DESCRIPTION
When using RETURNN as framework we have been using `Engine.search_single_string_to_string_seq()` to run search for a given loaded model. This function is tailored for the standard MT use case where in- and output are both a single string. What we now need is support for additional inputs - strings ("sparse") as well as floats ("dense").

This PR proposes a generalized inference function that supports any kind of in- and outputs. What we wanted to keep from `search_single_string_to_string_seq()`:
- vocabulary lookup of string in- and outputs
- removal of padding, i.e. cutting outputs according to sequence length
- output of beam scores

In addition, the new function works for both "search" and "forward".
Also, it groups the batch dim into beams, such that there is really one output per input sequence.

I used @JackTemaki 's MapDataset, but I will adjust to whatever we decide on in #353.
