### PR TITLE
Failing test for case where sub-layer is optimized out

### DIFF
--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3131,13 +3131,6 @@ class _SubnetworkRecCell(object):
       :param str name:
       :rtype: LayerBase
       """
-      if '/' in name:
-        # It may be a hierarchical path to a sub-layer, which should have been found by get_layer()
-        # but maybe it's not constructed yet, so try constructing the root layer.
-        root_layer = get_layer(name.split('/')[0])
-        sub_layer = root_layer.get_sub_layer('/'.join(name.split('/')[1:]))  # get the sub-layer from the root-layer
-        if sub_layer:
-          return sub_layer
       if name.startswith("prev:"):
         return get_prev_layer(name[len("prev:"):])
       if name.startswith("base:"):

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -2813,6 +2813,12 @@ class _SubnetworkRecCell(object):
         return False
       if self.parent_net.search_flag and layer.search_choices:
         return False  # need to perform the search inside the loop currently
+      if '/' in layer.name:  # True if this is a sub-layer
+        root_layer_name = layer.name.split('/')[0]
+        root_layer = self.layer_data_templates.get(root_layer_name)
+        assert root_layer, "Root layer '{}' not found for sub-layer '{}'.".format(root_layer_name, layer.name)
+        # sub-layers are in the same net as the root layer by definition
+        return output_can_move_out(root_layer)
       # layer.output is used by other layers?
       for other_layer in layers_in_loop:
         if layer in other_layer.dependencies:
@@ -2849,6 +2855,12 @@ class _SubnetworkRecCell(object):
       if self.parent_net.search_flag and layer.search_choices:
         return False  # need to perform the search inside the loop currently
       layer_deps = layer.dependencies
+      if '/' in layer.name:  # True if this is a sub-layer
+        root_layer_name = layer.name.split('/')[0]
+        root_layer = self.layer_data_templates.get(root_layer_name)
+        assert root_layer, "Root layer '{}' not found for sub-layer '{}'.".format(root_layer_name, layer.name)
+        # sub-layers are in the same net as the root layer by definition
+        return input_can_move_out(root_layer)
       # We depend on other layers from this sub-network?
       for other_layer in layers_in_loop:
         if other_layer in layer_deps:
@@ -3282,8 +3294,6 @@ class _TemplateLayer(LayerBase):
 
     sub_layer_template = _TemplateLayer(self.network, full_layer_name)
     is_output_layer = self.is_output_layer()  # make sub-layers output layers too
-    # Do not use collocate_with on the sub layer, otherwise it could never be moved out.
-    # _move_outside_loop should handle this.
     sub_layer_template.init(output, sub_layer_class, is_output_layer=is_output_layer,
                             name=full_layer_name, network=network)
     return sub_layer_template

--- a/tests/test_TFEngine.py
+++ b/tests/test_TFEngine.py
@@ -1497,6 +1497,12 @@ def test_attention_two_targets():
 
   check_train_and_search_two_targets(net_dict=net_dict)
 
+  # Also test with label feedback from only one of the outputs. This is a special case, where during search the
+  # sub-layer "output_1" == "output/out_1" could be optimized out of the loop, but the root layer is in the loop.
+  net_dict["output"]["unit"]["orth_embed"]["from"] = ["orth_embed_0"]
+
+  check_train_and_search_two_targets(net_dict=net_dict)
+
 
 def test_attention_two_dependent_targets():
   """

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -3385,7 +3385,9 @@ def check_reclayer_optimize_out(subnet_layer_dict, other_subnet_layers=None, sha
     assert_equal(set(net1_subnet.input_layers_moved_out), set())
     assert_equal(set(net2_subnet.input_layers_moved_out), set())
     assert_equal(set(net1_subnet.output_layers_moved_out), set())
-    assert_equal(set(net2_subnet.output_layers_moved_out), {"output"}.union(set(other_subnet_layers or [])))
+    # output_layers_moved_out will contain sublayers if present
+    output_root_layers_moved_out = [name for name in net2_subnet.output_layers_moved_out if '/' not in name]
+    assert_equal(set(output_root_layers_moved_out), {"output"}.union(set(other_subnet_layers or [])))
     assert_equal([
       v.name.split("/")[1:] for v in net1.get_params_list()], [v.name.split("/")[1:] for v in net2.get_params_list()])
     net1.initialize_params(session=session)


### PR DESCRIPTION
This is the issue I discovered in #395.

The test passes if one reverts 8f16741. But the TODO suggests that this should be handled in `_move_outside_loop()` instead, I will try.