### PR TITLE
Add PyTorch-like GELU

### DIFF
--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -1241,6 +1241,18 @@ def gelu2(x):
   return x * tf.sigmoid(1.702 * x)
 
 
+def gelu3(x):
+  """
+  Another version of the GELU, as it is used in PyTorch
+  https://github.com/pytorch/pytorch/blob/b7f4b6a6de30116f1b44a08fab9499dd5eb2de7d/test/cpp/api/functional.cpp#L839-L845
+
+  :param tf.Tensor x:
+  :rtype: tf.Tensor
+  """
+  import numpy
+  return 0.5 * x * (1 + tf.math.erf(x / tf.cast(numpy.sqrt(2), x.dtype)))
+
+
 def random_uniform_abs_initializer(limit, **kwargs):
   """
   :param float|int|tf.Tensor limit:


### PR DESCRIPTION
I'd like to add the GELU activation to https://github.com/rwth-i6/pytorch-to-returnn. We could simply do that by adding the existing RETURNN GELU analogous to e.g. ReLU. However, the implementation in PyTorch differs, see e.g.

https://discuss.pytorch.org/t/gelu-pytorch-formula/79875/2
https://github.com/pytorch/pytorch/blob/b7f4b6a6de30116f1b44a08fab9499dd5eb2de7d/test/cpp/api/functional.cpp#L839-L845

Therefore, I added `gelu3` which now imitates the PyTorch GELU. The name is of course debatable. I chose it because the alternative `gelu2` is already there, but am open to other suggestions.