### PR TITLE
add RandIntLayer

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1663,6 +1663,8 @@ class RandIntLayer(LayerBase):
     from returnn.tf.util.data import DimensionTag
     super(RandIntLayer, self).__init__(**kwargs)
 
+    seed = seed if seed is not None else self.network.random.randint(2 ** 31)
+
     shape_parsed = []
     batch_dim_axes = []
     dyn_axes_sizes = []
@@ -1713,27 +1715,22 @@ class RandIntLayer(LayerBase):
     :param str dtype: type of the output. For random ints, int32 and int64 make sense, but could also be floats
     :rtype: Data
     """
-    from returnn.tf.util.data import DimensionTag, NotSpecified
+    from returnn.tf.util.data import DimensionTag
 
     shape_parsed = []
     batch_dim_axis = None
     for ax, s in enumerate(shape):
       if isinstance(s, int):
         shape_parsed.append(s)
-        feature_dim_axis = ax
-      elif isinstance(s, DimensionTag):
+      else:
+        assert isinstance(s, DimensionTag)
         if s.kind == DimensionTag.Types.Batch:
           batch_dim_axis = ax
         elif isinstance(s.dimension, int):
           shape_parsed.append(s.dimension)
-          feature_dim_axis = ax
-        elif s.dimension is None:
-          shape_parsed.append(None)
-          time_dim_axis = ax
         else:
-          assert False
-      else:
-        raise NotImplementedError
+          assert s.dimension is None
+          shape_parsed.append(None)
     shape_parsed = tuple(shape_parsed)
 
     return Data(

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1646,7 +1646,9 @@ class SeqLenMaskLayer(_ConcatInputLayer):
 
 
 class RandIntLayer(LayerBase):
-  """Generates random numbers using ``tf.random.uniform``"""
+  """
+  Generates random numbers using ``tf.random.uniform``
+  """
   layer_class = "rand_int"
 
   # noinspection PyUnusedLocal
@@ -1657,7 +1659,6 @@ class RandIntLayer(LayerBase):
     :param int minval: lower bound (inclusive) on range of random values
     :param str dtype: type of the output. For random ints, int32 and int64 make sense, but could also be floats
     :param int|None seed: random seed
-    :param kwargs:
     """
     from returnn.tf.util.data import DimensionTag
     super(RandIntLayer, self).__init__(**kwargs)
@@ -1679,9 +1680,9 @@ class RandIntLayer(LayerBase):
           shape_parsed.append(tf.reduce_max(s.dyn_size))
           dyn_axes_sizes.append(tf.fill(tf.shape(s.dyn_size), shape_parsed[-1]))
         else:
-          assert False
+          raise Exception("%s: invalid dim tag %s" % (self, s))
       else:
-        raise NotImplementedError
+        raise TypeError("%s: invalid dim %s" % (self, type(s)))
     shape_parsed = tuple(shape_parsed)
 
     if batch_dim_axes:
@@ -1710,15 +1711,12 @@ class RandIntLayer(LayerBase):
     :param int maxval: upper bound (exclusive) on range of random values
     :param int minval: lower bound (inclusive) on range of random values
     :param str dtype: type of the output. For random ints, int32 and int64 make sense, but could also be floats
-    :param kwargs:
     :rtype: Data
     """
     from returnn.tf.util.data import DimensionTag, NotSpecified
 
     shape_parsed = []
     batch_dim_axis = None
-    time_dim_axis = None
-    feature_dim_axis = None
     for ax, s in enumerate(shape):
       if isinstance(s, int):
         shape_parsed.append(s)
@@ -1738,17 +1736,8 @@ class RandIntLayer(LayerBase):
         raise NotImplementedError
     shape_parsed = tuple(shape_parsed)
 
-    if feature_dim_axis is not None:
-      if batch_dim_axis is None or (isinstance(batch_dim_axis, int) and batch_dim_axis > feature_dim_axis):
-        dim = shape_parsed[feature_dim_axis]
-      else:
-        dim = shape_parsed[feature_dim_axis - 1]
-    else:
-      dim = NotSpecified
-
     return Data(
-      name="%s_output" % name, shape=shape_parsed, dim=dim, dtype=dtype,
-      batch_dim_axis=batch_dim_axis, time_dim_axis=time_dim_axis, feature_dim_axis=feature_dim_axis)
+      name="%s_output" % name, shape=shape_parsed, dtype=dtype, batch_dim_axis=batch_dim_axis)
 
 
 class RangeLayer(LayerBase):

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1584,8 +1584,8 @@ def test_RandIntLayer():
     size_placeholder = net.extern_data.data["data"].size_placeholder[0]
     input_len = feed[size_placeholder]
     sz = (
-      DimensionTag(description="batch", kind=DimensionTag.Types.Batch),
-      DimensionTag(description="time", kind=DimensionTag.Types.Time, dyn_size=size_placeholder),
+      DimensionTag(kind=DimensionTag.Types.Batch),
+      net.extern_data.data["data"].get_size_dim_tag(0),
       DimensionTag(description="feature", kind=DimensionTag.Types.Feature, dimension=5),
       3,
     )

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1584,9 +1584,9 @@ def test_RandIntLayer():
     size_placeholder = net.extern_data.data["data"].size_placeholder[0]
     input_len = feed[size_placeholder]
     sz = (
+      DimensionTag(description="feature", kind=DimensionTag.Types.Feature, dimension=5),
       DimensionTag(kind=DimensionTag.Types.Batch),
       net.extern_data.data["data"].get_size_dim_tag(0),
-      DimensionTag(description="feature", kind=DimensionTag.Types.Feature, dimension=5),
       3,
     )
     net.construct_from_dict({
@@ -1596,7 +1596,7 @@ def test_RandIntLayer():
     out = net.layers["output"].output.placeholder
     v = session.run(out, feed_dict=feed)
 
-    assert_equal(v.shape, (n_batch, max(input_len), 5, 3))
+    assert_equal(v.shape, (5, n_batch, max(input_len), 3))
 
 
 def test_untrainable_params():


### PR DESCRIPTION
Add `RandIntLayer` which accepts a shape based on `DimensionTag`s or ints (only for static dims) and creates random ints using `tf.random.uniform`.