### PR TITLE
Don't use depthwise conv if input data dim is 1

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3519,7 +3519,7 @@ class ConvLayer(_ConcatInputLayer):
     if input_data.is_batch_feature_major:
       assert self.output.is_batch_feature_major
       data_format = {1: "NCW", 2: "NCHW", 3: "NCDHW"}[len(filter_size)]
-    if groups == n_in and len(filter_size) <= 2:  # depthwise conv
+    if groups == n_in and n_in > 1 and len(filter_size) <= 2:  # depthwise conv
       x = input_data.placeholder
       if len(filter_size) == 1:
         filters = tf.reshape(filters, [filter_size[0], 1, n_in, n_out // n_in])  # [1,K,n_in,n_out//n_in]


### PR DESCRIPTION
Currently, when the input data dim (`n_in`) is 1 (e.g. raw waveform) and the default value of `groups` (also 1) is used, the depthwise convolution is used. This does not work, when `strides` is different from 1, because for the second dimension the stride is set to 1 and tensorflow does not yet support different strides for row and column dimensions:
> InvalidArgumentError: Current implementation only supports equal length strides in the row and column dimensions.
See also https://github.com/tensorflow/tensorflow/issues/33005

The simplest fix is not to use `tf.nn.depthwise_conv2d` when `n_in` is 1. Not sure about performance when `strides=(1,)`, in which case `tf.nn.depthwise_conv2d` works, but having that as another special case would add complexity which might not be needed.