### PR TITLE
SwitchLayer: Constant `true_from`/`false_from` params

### DIFF
--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -610,6 +610,33 @@ class Data(object):
     assert x.get_shape().ndims == 0, "currently only scalars supported"
     return Data(name=str(x.op.name), shape=(), batch_dim_axis=None, dtype=x.dtype.name, placeholder=x)
 
+  @classmethod
+  def template_from_constant(cls, x, name, dtype=None, with_batch_dim=False):
+    """
+    :param int|float|bool|numpy.ndarray x:
+    :param str name:
+    :param str|None dtype:
+    :param bool with_batch_dim:
+    :rtype: Data
+    """
+    import numpy
+    if dtype is None:
+      if isinstance(x, int):
+        dtype = "int32"
+      elif isinstance(x, float):
+        dtype = "float32"
+      elif isinstance(x, bool):
+        dtype = "bool"
+      elif isinstance(x, numpy.ndarray):
+        dtype = str(x.dtype)
+      else:
+        raise TypeError("cannot handle value %r of type %r" % (x, type(x)))
+    shape = x.shape if isinstance(x, numpy.ndarray) else ()
+    return Data(
+      name=name,
+      shape=shape, batch_dim_axis=0 if with_batch_dim else None, time_dim_axis=None,
+      dtype=dtype)
+
   def sanity_check(self, ignore_placeholder=False):
     """
     Performs some sanity checks on self, and raises exceptions if something is not sane.


### PR DESCRIPTION
This is especially useful to use `SwitchLayer` as a generic masking
layer. If you have some sort of `"mask"` for some `"input"` layer,
use `condition="mask", true_from="input", false_from=float("-inf")`
to e.g. mask out all unmasked values with -inf.

This commit also moves the logic from `ConstantLayer.get_out_data_from_opts` to `Data.template_from_constant` as it is very reusable. Sorry, that's a bit messy.