### PR TITLE
fix hdf_dump without target, MetaDataset workaround

### DIFF
--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -1364,12 +1364,15 @@ class HDFDatasetWriter:
     hdf_dataset.create_dataset(attr_seqLengths, shape=(num_seqs, 2), dtype="int32")
     for i, seq_len in enumerate(seq_lens):
       data_len = seq_len[default_data_input_key]
-      targets_len = seq_len[default_data_target_key]
-      for data_key in data_target_keys:
-        assert seq_len[data_key] == targets_len, "different lengths in multi-target not supported"
-      if targets_len is None:
-        targets_len = data_len
-      hdf_dataset[attr_seqLengths][i] = [data_len, targets_len]
+      if len(data_target_keys) > 0:
+        targets_len = seq_len[default_data_target_key]
+        for data_key in data_target_keys:
+          assert seq_len[data_key] == targets_len, "different lengths in multi-target not supported"
+        if targets_len is None:
+          targets_len = data_len
+        hdf_dataset[attr_seqLengths][i] = [data_len, targets_len]
+      else:
+        hdf_dataset[attr_seqLengths][i] = [data_len]
       if use_progress_bar:
         progress_bar_with_time(float(i) / num_seqs)
 

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -333,7 +333,7 @@ class MetaDataset(CachedDataset2):
     :param list[int]|None seq_order: List of corpus sequence indices, to set a predefined order.
     :rtype: bool
     """
-    need_reinit = self.epoch is None or self.epoch != epoch or seq_list
+    need_reinit = self.epoch is None or self.epoch != epoch or seq_list or self.expected_load_seq_start > 0
     super(MetaDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
 
     if not need_reinit:


### PR DESCRIPTION
I thought fixing `hdf_dump` to dump some of my datasets was simpler, but as there were now some additional problems to be solved a PR seems to be the safer option.

So `hdf_dump` did not allow for Datasets having no targets (but only data), and I did not work with MetaDatasets at all, as the child datasets did not get a `init_seq_order` call passed.