### PR TITLE
MergeDimsLayer, unset time-dim if it got merged

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2625,10 +2625,10 @@ class MergeDimsLayer(_ConcatInputLayer):
     data.shape = tuple(new_shape)
     data.time_dim_axis = cls._old_axis_to_new_axis(
       input_data=input_data, merge_axes=axes, old_axis=input_data.time_dim_axis)
-    if data.time_dim_axis == data.batch_dim_axis:  # special case: batch and time got merged
-      # Fallback to some sensible default.
-      # Note: Not sure if this is good. Maybe we change that... You can always use ReinterpretDataLayer to be explicit.
-      data.time_dim_axis = data.get_spatial_batch_axes()[0] if data.get_spatial_batch_axes() else None
+    if data.time_dim_axis is not None and data.time_dim_axis in {data.batch_dim_axis, data.feature_dim_axis}:
+      if input_data.time_dim_axis not in {input_data.batch_dim_axis, input_data.feature_dim_axis}:
+        # Time got merged with feature or batch.
+        data.time_dim_axis = None
     data.feature_dim_axis = new_feature_dim_axis
     return data
 

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1281,7 +1281,7 @@ def test_MergeDimsLayer_batch_time_time_major_ext():
       {"shape": (None, 5, 3), "time_dim_axis": 0, "batch_dim_axis": 1}, (n_time, n_batch, 5, 3),
       {"axes": "BT"}, (5, 3), (n_time * n_batch, 5, 3))
     assert layer.output.batch_dim_axis == 0
-    assert layer.output.time_dim_axis == 1  # Note: This is currently the behavior, but maybe we change that.
+    assert layer.output.time_dim_axis is None  # Note: This behavior was changed.
 
 
 def test_MergeDimsLayer_except_time_ext():
@@ -1302,7 +1302,8 @@ def test_MergeDimsLayer_static_time():
       session,
       {"shape": (3, 5), "time_dim_axis": 1}, (n_batch, 3, 5),
       {"axes": "static"}, (15,), (n_batch, 15))
-    assert layer.output.batch_dim_axis == 0 and layer.output.time_dim_axis == layer.output.feature_dim_axis == 1
+    assert layer.output.batch_dim_axis == 0 and layer.output.feature_dim_axis == 1
+    assert layer.output.time_dim_axis is None
 
 
 def test_MergeDimsLayer_SplitBatchTimeLayer_time_major():


### PR DESCRIPTION
This was the expected behavior from most users,
after a discussion whether [B,T,F|5] merge "except_batch"
should result in [B,T|F] or [B,F] or [B,T].