### PR TITLE
HDFDataset / HDFDatasetWriter: Support for only using targets

### DIFF
--- a/returnn/datasets/cached.py
+++ b/returnn/datasets/cached.py
@@ -482,7 +482,7 @@ class CachedDataset(Dataset):
     d = {}
     first_target_idx = 0
     # We allow using only targets. In this case self.num_inputs == 0 and the "data" key is not used.
-    if self.num_inputs > 1:
+    if self.num_inputs > 0:
       d["data"] = lengths[0]
       first_target_idx = 1
     for k, l in zip(self.target_keys, lengths[first_target_idx:]):

--- a/returnn/datasets/cached.py
+++ b/returnn/datasets/cached.py
@@ -479,8 +479,13 @@ class CachedDataset(Dataset):
     :rtype: NumbersDict
     """
     lengths = self.get_seq_length_nd(seq_idx)
-    d = {"data": lengths[0]}
-    for k, l in zip(self.target_keys, lengths[1:]):
+    d = {}
+    first_target_idx = 0
+    # We allow using only targets. In this case self.num_inputs == 0 and the "data" key is not used.
+    if self.num_inputs > 1:
+      d["data"] = lengths[0]
+      first_target_idx = 1
+    for k, l in zip(self.target_keys, lengths[first_target_idx:]):
       d[k] = l
     return NumbersDict(d)
 


### PR DESCRIPTION
Necessary changes to support HDF files without 'inputs'.

Also, there was a check that targets have to be of equal sequence length in the HDFDatasetWriter. I tested targets with different lengths and I didn't find a reason why this check was there.