### PR TITLE
SplitLayer template construction fails if used after SplitDimsLayer

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2707,6 +2707,14 @@ class SplitLayer(_ConcatInputLayer):
     return self._sub_layers.get(layer_name, None)
 
   @classmethod
+  def get_out_data_from_opts(cls, sources, **kwargs):
+    """
+    :param list[LayerBase] sources:
+    :rtype: Data
+    """
+    return get_concat_sources_data_template(sources)
+
+  @classmethod
   def get_sub_layer_out_data_from_opts(cls, layer_name, parent_layer_kwargs):
     """
     :param str layer_name: name of the sub_layer (right part of '/' separated path)


### PR DESCRIPTION
See the test case I added, [which currently fails](https://github.com/rwth-i6/returnn/runs/1875491241?check_suite_focus=true).
I get the error:
```
  File "/u/petrick/software/returnn/official/returnn/tf/network.py", line 708, in _create_layer
    line: assert output_template_special_axes == output_special_axes, "%s %r: not equal: %r == %r, from data %r -> %r" % (
            layer_class.__name__, name,
            output_template_special_axes, output_special_axes,
            output_template, layer.output)
    locals:
      output_template_special_axes = <local> {'time_dim_axis': 1, 'feature_dim_axis': 2}
      output_special_axes = <local> {'time_dim_axis': 1, 'feature_dim_axis': 3}
      layer_class = <local> <class 'returnn.tf.layers.basic.SplitLayer'>
      layer_class.__name__ = <local> 'SplitLayer', len = 10
      name = <local> 'split_qkv', len = 9
      output_template = <local> Data(name='split_qkv_output', shape=(None, 2, None), batch_shape_meta=[B,T|?,F|2,?])
      layer = <local> <SplitLayer 'split_qkv' out_type=Data(shape=(None, 2, 20), batch_shape_meta=[B,T|'time:var:extern_data:data',2,F|20])>
      layer.output = <local> Data(name='split_heads_output', shape=(None, 2, 20), batch_shape_meta=[B,T|'time:var:extern_data:data',2,F|20])
AssertionError: SplitLayer 'split_qkv': not equal: {'time_dim_axis': 1, 'feature_dim_axis': 2} == {'time_dim_axis': 1, 'feature_dim_axis': 3}, from data Data(name='split_qkv_output', shape=(None, 2, None), batch_shape_meta=[B,T|?,F|2,?]) -> Data(name='split_heads_output', shape=(None, 2, 20), batch_shape_meta=[B,T|'time:var:extern_data:data',2,F|20])
```