### PR TITLE
MetaDataset rework

### DIFF
--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -114,6 +114,7 @@ class Dataset(object):
     self.rnd_seq_drop = None  # type: typing.Optional[Random]
     self.num_inputs = 0  # usually not used, but num_outputs instead, which is more generic
     self.num_outputs = None  # type: typing.Optional[typing.Dict[str,typing.Tuple[int,int]]]  # tuple is num-classes, len(shape).  # nopep8
+    self.default_data_key = "data"  # type: str  # Allows Datasets to re-define their input/default data key
     self.window = window
     self.seq_ordering = seq_ordering  # "default", "sorted" or "random". See self.get_seq_order_for_epoch().
     if random_seed_offset is None:

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -255,7 +255,6 @@ class MetaDataset(CachedDataset2):
       if dataset_data_key in dataset.labels:
         self.labels[data_key] = dataset.labels[dataset_data_key]
 
-    self.num_inputs = self.data_dims[default_data_key][0] if default_data_key in self.data_dims.keys() else 0
     self.num_outputs = self.data_dims
 
     self.orig_seq_order_is_initialized = False


### PR DESCRIPTION
This should enable a free choice of dataset-key-mappings for the meta-dataset, and also enable future support for child-datasets that do not provide any "data" key, but instead define a "default_data_key" which is used in all cases where no explicit choices are made.

I also removed setting `num_inputs` in the MetaDataset. I am not sure if this has any additional consequences, so I put this into a separate commit for testing both changes separately (and keeping my previous edit of the line). If there is no problem, I will merge both commits.