### PR TITLE
Check size_placeholder in Data.sanity_check

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2627,6 +2627,12 @@ class MergeDimsLayer(_ConcatInputLayer):
         # Time got merged with feature or batch.
         data.time_dim_axis = None
     data.feature_dim_axis = new_feature_dim_axis
+    # Set size_placeholder, here for now without merging any axes. Merged axes are then updated in __init__.
+    data.size_placeholder = {}
+    for old_axis, dyn_size in sorted(input_data.size_placeholder.items()):
+      new_axis = cls._old_axis_to_new_axis(input_data=input_data, merge_axes=axes, old_axis=old_axis)
+      if new_axis != data.batch_dim_axis:
+        data.size_placeholder[data.get_batch_axis_excluding_batch(new_axis)] = dyn_size
     return data
 
 

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -657,6 +657,13 @@ class Data(object):
     if self.feature_dim_axis is not None:
       assert self.dim == self.batch_shape[self.feature_dim_axis], (
         "%s: inconsistent dim. feature axis or unspecified: %r." % (self, self.feature_dim_axis_or_unspecified))
+    if self.size_placeholder is not None:
+      assert None not in self.size_placeholder
+      for i, dyn_size in self.size_placeholder.items():
+        assert 0 <= i < self.ndim
+        assert dyn_size.dtype in (tf.int32, tf.int64)
+        assert dyn_size.shape.ndims == 1, (
+          "%s: all size_placeholder entries should have shape [B], but got: %r" % (self, self.size_placeholder))
     if not ignore_placeholder and self.placeholder is not None:
       # Note: We could just call self.placeholder.set_shape.
       # However, we are more explicit. We assume that the placeholder has already a known shape, and error otherwise.


### PR DESCRIPTION
Adds some basic checks about `size_placeholder` in `Data.sanity_check`.

E.g. in `MergeDimsLayer`, this was set incorrectly in `get_out_data_from_opts`, but only in `__init__` (because it needs to create a new size tensor).
I now changed it so that at least the axes are correct.