### PR TITLE
SwitchLayer: Set dim correctly

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6193,7 +6193,10 @@ class SwitchLayer(LayerBase):
     out = Data.get_common_data([true_data, false_data, condition.output])
     out.dtype = true_data.dtype
     out.sparse = true_data.sparse
-    out.dim = true_data.dim
+    if out.feature_dim_axis is not None:
+      out.dim = out.batch_shape[out.feature_dim_axis]
+    else:
+      out.dim = true_data.dim
     out.vocab = true_data.vocab
     return out.copy(name="%s_output" % name)
 

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1481,6 +1481,24 @@ def test_SwitchLayer_masking():
     print(out)
 
 
+def test_SwitchLayer_template_const_from():
+  net = TFNetwork(extern_data=ExternData())
+  # [T]
+  condition = InternalLayer(network=net, name="condition", output=Data(
+    "condition_output", batch_dim_axis=None, time_dim_axis=0, feature_dim_axis=None, shape=(None,)))
+  true_from = 42
+  # [B,F|2,T]
+  false_from = InternalLayer(network=net, name="false_from", output=Data(
+    "false_from_output", batch_dim_axis=0, time_dim_axis=2, feature_dim_axis=1, shape=(2, None), dim=2))
+
+  # should be [B,F|2,T]
+  switch = SwitchLayer.get_out_data_from_opts('switch', condition=condition, true_from=true_from,
+    false_from=false_from)
+  assert switch.batch_ndim == 3
+  assert switch.batch_dim_axis == 0 and switch.time_dim_axis == 2 and switch.feature_dim_axis == 1
+  assert switch.dim == 2
+
+
 def test_CondLayer_subnetwork_train():
   n_batch, n_time, n_in, n_out = 3, 7, 11, 13
   config = Config({


### PR DESCRIPTION
`SwitchLayer` previously just copied its `dim` from `true_data`. If (e.g.) `true_data` is a constant scalar, but `false_data` has a `feature_dim_axis`, then also the output will have a `feature_dim_axis`, and thus this is wrong.