### PR TITLE
Support empty orth in bliss files

### DIFF
--- a/returnn/datasets/generating.py
+++ b/returnn/datasets/generating.py
@@ -2302,7 +2302,7 @@ class BlissDataset(CachedDataset2):
         info = SeqInfo()
         info.idx = idx
         info.tag = "/".join(name_tree)
-        info.orth_raw = elem.find("orth").text
+        info.orth_raw = elem.find("orth").text or ""
         info.audio_path = cur_recording
         info.audio_start = float(elem.attrib["start"])
         info.audio_end = float(elem.attrib["end"])

--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -436,7 +436,7 @@ def _iter_bliss(filename, callback):
 
   for tree, elem in getelements("segment"):
     elem_orth = elem.find("orth")
-    orth_raw = elem_orth.text  # should be unicode
+    orth_raw = elem_orth.text or ""  # should be unicode
     orth_split = orth_raw.split()
     orth = " ".join(orth_split)
 

--- a/tools/bliss-collect-seq-lens.py
+++ b/tools/bliss-collect-seq-lens.py
@@ -67,7 +67,7 @@ def iter_bliss(filename):
       recording_filename = elem.attrib["audio"] if event == "start" else None
     if event == 'end' and elem.tag == "segment":
       elem_orth = elem.find("orth")
-      orth_raw = elem_orth.text  # should be unicode
+      orth_raw = elem_orth.text or ""  # should be unicode
       orth_split = orth_raw.split()
       orth = " ".join(orth_split)
       segment_name = "/".join(name_tree)

--- a/tools/bliss-get-segment-names.py
+++ b/tools/bliss-get-segment-names.py
@@ -70,7 +70,7 @@ def iter_bliss(filename):
       recording_filename = elem.attrib["audio"] if event == "start" else None
     if event == 'end' and elem.tag == "segment":
       elem_orth = elem.find("orth")
-      orth_raw = elem_orth.text  # should be unicode
+      orth_raw = elem_orth.text or ""  # should be unicode
       orth_split = orth_raw.split()
       orth = " ".join(orth_split)
       segment_name = "/".join(name_tree)

--- a/tools/bliss-to-ogg-zip.py
+++ b/tools/bliss-to-ogg-zip.py
@@ -80,7 +80,7 @@ def iter_bliss(filename):
       recording_filename = elem.attrib["audio"] if event == "start" else None
     if event == 'end' and elem.tag == "segment":
       elem_orth = elem.find("orth")
-      orth_raw = elem_orth.text  # should be unicode
+      orth_raw = elem_orth.text or ""  # should be unicode
       orth_split = orth_raw.split()
       orth = " ".join(orth_split)
       elem_speaker = elem.find("speaker")

--- a/tools/collect-orth-symbols.py
+++ b/tools/collect-orth-symbols.py
@@ -104,7 +104,7 @@ def iter_bliss(filename, options, callback):
     else:
       frame_len = 0
     elem_orth = elem.find("orth")
-    orth_raw = elem_orth.text  # should be unicode
+    orth_raw = elem_orth.text or ""  # should be unicode
     orth_split = orth_raw.split()
     orth = " ".join(orth_split)
 

--- a/tools/collect-words.py
+++ b/tools/collect-words.py
@@ -67,7 +67,7 @@ def iter_bliss(filename, callback):
 
   for tree, elem in get_elements("segment"):
     elem_orth = elem.find("orth")
-    orth_raw = elem_orth.text  # should be unicode
+    orth_raw = elem_orth.text or ""  # should be unicode
     orth_split = orth_raw.split()
     orth = " ".join(orth_split)
 

--- a/tools/extract_state_tying_from_dataset.py
+++ b/tools/extract_state_tying_from_dataset.py
@@ -62,7 +62,7 @@ def iter_bliss_orth(filename):
 
   for tree, elem in getelements("segment"):
     elem_orth = elem.find("orth")
-    orth_raw = elem_orth.text  # should be unicode
+    orth_raw = elem_orth.text or ""  # should be unicode
     orth_split = orth_raw.split()
     orth = " ".join(orth_split)
 


### PR DESCRIPTION
`Element.text` is None if the node has no text content (happened in my case for silence segments). 