### PR TITLE
Adds support for None in py-to-pickle.cpp

### DIFF
--- a/returnn/util/py-to-pickle.cpp
+++ b/returnn/util/py-to-pickle.cpp
@@ -479,6 +479,14 @@ public:
 		return c;
 	}
 
+	void parse_none(char first) {
+		if (!('o' == read_next_char() && 'n' == read_next_char() && 'e' == read_next_char())) {
+			parse_error("expected 'one' after N", first);
+			return;
+		}
+		write_char(NONE);
+	}
+
 	ParseRes parse() {
 		int c;
 		bool had_one_item = false;
@@ -511,6 +519,10 @@ public:
 				had_one_item = true;
 				if(c < 0 || !isspace(c))
 					break;
+			}
+			else if(c == 'N') {
+				parse_none(c);
+				had_one_item = true;
 			}
 			else
 				// some unexpected char

--- a/tests/test_Util.py
+++ b/tests/test_Util.py
@@ -362,6 +362,7 @@ def test_literal_py_to_pickle():
     "[]", "[1]", "[1,2,3]",
     "{}", "{'a': 'b', 1: 2}",
     "{1}", "{1,2,3}",
+    "None", "{'a': None, 'b':1, 'c':None, 'd':'d'}",
   ]
   for s in checks:
     check(s)


### PR DESCRIPTION
Currently, py-to-pickle crashes results in a parse error when the py object contains None.

I needed support for this since some of my oggzip files contained None s (speaker information).