### PR TITLE
DataNotAvailableLayer fixes

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3686,7 +3686,8 @@ class ReinterpretDataLayer(_ConcatInputLayer):
         setattr(out, s, i)
         if s == "feature_dim_axis":
           out.dim = out.batch_shape[out.feature_dim_axis]
-    if size_base:
+    if out.size_placeholder is not None and size_base:  # size_placeholder might be None, e.g. via DataNotAvailableLayer
+      assert size_base.output.size_placeholder is not None
       assert len(out.size_placeholder) == len(size_base.output.size_placeholder)
       # Keep same indices. Assumes same order of spatial dims.
       out.size_placeholder = {


### PR DESCRIPTION
1. Fixed one place where trying to access the size placeholder fails in `get_out_data_from_opts()` when the input is a `DataNotAvailableLayer`. I suspect there might be more such cases in the code.

2. `DataNotAvailableLayer` has to do "register_as_extern_data" because the data template might be needed at inference time, e.g. as the target of a ChoiceLayer. Usually this happens in `LayerBase.post_init()`, however this is not called for `DataNotAvailableLayer`.