### PR TITLE
HDFDataset profiling

### DIFF
--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -28,7 +28,7 @@ class HDFDataset(CachedDataset):
   This was the main original dataset format of RETURNN.
   """
 
-  def __init__(self, files=None, use_cache_manager=False, **kwargs):
+  def __init__(self, files=None, use_cache_manager=False, cache_whole_file=False, **kwargs):
     """
     :param None|list[str] files:
     :param bool use_cache_manager: uses :func:`Util.cf` for files
@@ -43,6 +43,8 @@ class HDFDataset(CachedDataset):
     self.file_seq_start = []  # type: typing.List[numpy.ndarray]
     self.data_dtype = {}  # type: typing.Dict[str,str]
     self.data_sparse = {}  # type: typing.Dict[str,bool]
+    self._cache_whole_file = cache_whole_file
+    self._cached_files = []
     if files:
       for fn in files:
         self.add_file(fn)
@@ -95,6 +97,7 @@ class HDFDataset(CachedDataset):
         "expected " + str(len(self.labels['classes'])) + " got " + str(len(labels)))
     self.files.append(filename)
     self.h5_files.append(fin)
+    self._cached_files.append({})
     print("parsing file", filename, file=log.v5)
     if 'times' in fin:
       if self.timestamps is None:
@@ -276,13 +279,22 @@ class HDFDataset(CachedDataset):
 
     if key == "data":
       assert 'inputs' in fin, "'data' key is reserved for 'inputs' in the HDF file, but 'inputs' not found in HDF file."
-      inputs = fin['inputs']
+      if self._cache_whole_file:
+        if "inputs" not in self._cached_files[file_idx]:
+          self._cached_files[file_idx]["inputs"] = fin['inputs'][:]
+        inputs = self._cached_files[file_idx]["inputs"]
+      else:
+        inputs = fin['inputs']
       data = inputs[start_pos[0]:end_pos[0]]
       if self.window > 1:
         data = self._sliding_window(data)
     else:
-      assert 'targets' in fin
-      targets = fin['targets/data/' + key]
+      if self._cache_whole_file:
+        if key not in self._cached_files[file_idx]:
+          self._cached_files[file_idx][key] = fin['targets/data/' + key][:]
+        targets = self._cached_files[file_idx][key]
+      else:
+        targets = fin['targets/data/' + key]
       first_target_idx = 1 if self.num_inputs > 0 else 0  # self.num_inputs == 0 if no 'inputs' in HDF file
       ldx = first_target_idx + self.target_keys.index(key)
       data = targets[start_pos[ldx]:end_pos[ldx]]
@@ -334,7 +346,12 @@ class HDFDataset(CachedDataset):
     file_idx = self._get_file_index(real_seq_idx)
     real_file_seq_idx = real_seq_idx - self.file_start[file_idx]
 
-    s = self.h5_files[file_idx]["seqTags"][real_file_seq_idx]
+    if self._cache_whole_file:
+      if "#tags" not in self._cached_files[file_idx]:
+        self._cached_files[file_idx]["#tags"] = list(self.h5_files[file_idx]["seqTags"][:])
+      s = self._cached_files[file_idx]["#tags"][real_file_seq_idx]
+    else:
+      s = self.h5_files[file_idx]["seqTags"][real_file_seq_idx]
     s = self._decode(s)
     return s
 


### PR DESCRIPTION
I finally followed up on #434 and did some profiling of HDFDataset. I had observed that when training small networks it can be the bottleneck.

I wrote this code to go through a dummy dataset with 200000 sequences, all one data stream with content `[0]`:

```
    hdf_dataset = HDFDataset(files=[file_name], seq_ordering="default", cache_whole_file=False)
    hdf_dataset.init_seq_order(epoch=1)

    start_time = time.time()
    seq_idx = 0
    while hdf_dataset.is_less_than_num_seqs(seq_idx):
        hdf_dataset.load_seqs(seq_idx, seq_idx + 1)
        data = hdf_dataset.get_data(seq_idx, data_key)
        assert data is not None
        seq_idx += 1

    time_needed = time.time() - start_time
    print(f"Needed {time_needed:.1f} seconds to go through the RETURNN HDFDataset once.")
```

Runs in 63.5s. The file was on a local ssd, so file access should have been fast.

When I set `cache_whole_file=True` (see commit), it runs in 1.9s (~most of which is initialisation, I guess~).

For comparison, when I run
```
fin = h5py.File(file_name, "r")

start_time = time.time()
sequence_lengths = list(fin["seqLengths"][...])
sequence_tags = list(fin["seqTags"][...])
data = list(fin[f"/targets/data/{data_key}"][...])
size = list(fin["/targets/size"].attrs[data_key])

time_needed = time.time() - start_time
print(f"Needed {time_needed:.1f} seconds to load the file in one go.")
```
it takes 0.1s.


In the first case this is the beginning of the output of cProfile:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   200001   15.695    0.000   41.155    0.000 dataset.py:476(__getitem__)
   200011    8.447    0.000   16.636    0.000 group.py:255(__getitem__)
   800004    6.496    0.000    6.637    0.000 dataset.py:282(shape)
   200002    5.857    0.000    6.987    0.000 dataset.py:395(__init__)
        1    4.046    4.046   67.433   67.433 test_reading_speed.py:9(test_returnn_reading_speed)
   200002    3.302    0.000    3.302    0.000 {method 'reduce' of 'numpy.ufunc' objects}
   200000    3.171    0.000   61.370    0.000 hdf.py:262(get_data)
```
 So almost all time (61s) is spent within `HDFDataset.get_data()` where the hdf file access happens.
 
 I also tested `cache_whole_file` in a real-life experiment: sequence labelling with a 3-layer LSTM, 512 units on 150k sequences per epoch (I reduced the epoch size for profiling). Here, enabling `cache_whole_file` improved the run time of one epoch from 5.5 minutes to 2.5 minutes.
 
Obviously caching the whole file is only possible if it isn't too big. So as touched upon in #434, I wonder whether implementing an improved version of the caching already implemented in HDFDataset (which also caches targets...) would be worth it...