### PR TITLE
add custom chunking logic

### DIFF
--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -1173,7 +1173,7 @@ class Engine(EngineBase):
         # but in that case, the newly initialized dataset
         # would use the right chunking option from the config overwrite.
         # noinspection PyProtectedMember
-        self.train_data.chunk_size, self.train_data.chunk_step = Dataset._parse_chunking(value)
+        self.train_data.chunk_size, self.train_data.chunk_step, self.dynamic_chunk_gen = Dataset._parse_chunking(value)
       if key in ["train", "dev", "eval"]:
         # `train` actually gets some special treatment, but unify nevertheless now.
         key, value = "eval_datasets", {key: value}


### PR DESCRIPTION
This commit tries to add custom chunking logic without breaking anything and solve #375. It is related to #376, but doesn't offer a solution for that, no reorganization, it just makes it more complicated.

The `iterate_seqs` gets now an extra input `chunking_logic` that provides with the extra information required. 

## chunking_logic
#### Inputs 
- sequence(`numpy.array`)
- chunks_step(`int`)
- chunk_size(`int`)
#### Outputs
- chunks_length(`int`): number of chunks that can be generated from given sequence, chunk_size and chunk_step
- custom_chunk_generators(`dict[str, ()->(int, int)]`): dict with generators for every data_key that has a custom chunking logic



The names are not final and can be changed. This commit only presents the logic. Will add Andre's RNNT chunking and some tests afterwards. 

@albert is the idea ok in general?


**Edit**: Is there any script to run the tests locally? Couldn't find any information in the wiki or contribution. 
**Edit**: I am not very acquainted with the tests, but looks like chunking is being tested as part of different tests. Should I create a new file for testing chunking?