### PR TITLE
Solve extra added rnn scope

### DIFF
--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -3571,6 +3571,8 @@ class CustomCheckpointLoader:
       "lstm_cell/weights": "lstm_cell/kernel",
       "lstm_cell/bias": "rnn/lstm_cell/bias",
       "lstm_cell/kernel": "rnn/lstm_cell/weights",
+      "rnn/lstm_cell/bias": "lstm_cell/bias",
+      "rnn/lstm_cell/kernel": "lstm_cell/kernel",
       "cudnn/params_canonical/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/bias": "lstm_fused_cell/bias",
       "cudnn/params_canonical/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/kernel": "lstm_fused_cell/kernel",
     }


### PR DESCRIPTION
When saving the variables of a `ZoneoutLstm` layer in a checkpoint an extra "rnn" is added in the name of the variables. This breaks the process of loading the parameters from a checkpoint.
``` log
Variables to restore which are not in checkpoint:
output/rec/slow_rnn/masked/lstm0/rec/lstm_cell/bias
output/rec/slow_rnn/masked/lstm0/rec/lstm_cell/kernel

Variables in checkpoint which are not needed for restore:
output/rec/slow_rnn/masked/lstm0/rec/rnn/lstm_cell/bias
output/rec/slow_rnn/masked/lstm0/rec/rnn/lstm_cell/kernel

```

It happens [here](https://github.com/rwth-i6/returnn/blob/522ce85122103fc8a21df5798e9596476250a96d/returnn/tf/layers/rec.py#L701) when calling the [tensorflow.python.ops.rnn.dynamic_rnn()](https://github.com/tensorflow/tensorflow/blob/6bba1b6e6d0a3d57258acd204987869806b3a852/tensorflow/python/ops/rnn.py#L505) with default `scope` parameter, which ends up adding the "rnn" as parts of the scope.


I can think of 2 ways how to solve it:
1. Give an empty scope instead of the default one.  (Haven't tried yet)
2. Or add an extra mapping in `map_list` defined in  [network/get_variable_value_map()](https://github.com/rwth-i6/returnn/blob/522ce85122103fc8a21df5798e9596476250a96d/returnn/tf/network.py#L3569) to reverse the extra "rnn" scope.  (Proposed in this commit)