### PR TITLE
ReinterpretDataLayer: remove vocab if dim changes

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3702,12 +3702,15 @@ class ReinterpretDataLayer(_ConcatInputLayer):
           out.dim = None
         else:
           out.dim = out.batch_shape[out.feature_dim_axis]
+    old_dim = out.dim
     if set_sparse_dim is not NotSpecified:
       assert set_sparse_dim is None or isinstance(set_sparse_dim, int)
       out.dim = set_sparse_dim
     if increase_sparse_dim:
       assert out.sparse
       out.dim += increase_sparse_dim
+    if old_dim != out.dim:
+      out.vocab = None
     return out
 
 


### PR DESCRIPTION
If we want to reinterpret `data:classes` with `ReinterpretDataLayer` and change the `sparse_dim`, via either `set_sparse_dim` or `increase_sparse_dim`, the output data ends up in a mismatch with the vocab dimension.

Here I solve this by **removing the vocab**.

But one could think of a more generic way of doing this.
In most of the cases, we need to do this when when we either add an extra label(e.g. EOS or blank) or want to remove it.
I am not sure if it's possible to change the vocab so easily?
