### PR TITLE
Subnetwork: add construction warning

### DIFF
--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -2536,7 +2536,11 @@ class Subnetwork:
         return get_layer(layer_name)
 
       else:  # name != "data"
-        return base_get_layer("data:%s" % name)
+        try:
+          return base_get_layer("data:%s" % name)
+        except KeyError as e:
+          print("warning: possibly missing concat_sources=False in %s" % self, file=log.v3)
+          raise e
 
     # Not concat_sources
     for i, arg in enumerate(self._from_arg):


### PR DESCRIPTION
This is only a simple change, but I also wanted to ask with this about future logging messages. The problem is, that the errors/exceptions during construction are often not related to the actual error at all.
Sometimes it takes hours to work through the different Exceptions, especially if you have a new config and you are not sure about what exactly is correct.

In the case here a simple missing `concat_sources=False` in `SubnetworkLayer` caused 5 new completely unrelated Exceptions, because the construction continued after throwing a KeyError. The problem is, that the new Exceptions seemed to be much more relevant, as they were related to the (config) code that was changed.

So in the future I would like to add warnings like this one to make the construction log more verbose, and to give reasonable hints that may save many hours of useless debugging.

In the location of the code I changed the KeyError can only occur in 2 cases: You have an actual typo in the key, or your forgot to add `concat_sources=False` and RETURNN searches for the key in a wrong location, so for me it would be reasonable to give the user information about this second case (the first one is clear from the KeyError itself).

Another question: Are there actually cases where having a KeyError is okay, and the construction will continue to a valid solution? If not, we might want to directly fail the construction here.