### PR TITLE
Fix optimizer selection code

### DIFF
--- a/docs/generate_optimizer.py
+++ b/docs/generate_optimizer.py
@@ -19,18 +19,14 @@ def generate():
   updater._init_optimizer_classes_dict()
   optimizer_dict = updater._OptimizerClassesDict
 
-
   rst_file = open("optimizer.rst", "w")
   rst_file.write(header_text)
 
   for optimizer_name, optimizer_class in sorted(optimizer_dict.items()):
-
     if not optimizer_name.endswith("optimizer"):
       module = optimizer_class.__module__
       class_name = optimizer_class.__name__
-      if class_name == "creator":
-        continue
-      name = class_name[:-len("Optimizer")]
+      name = class_name[:-len("Optimizer")] if class_name.endswith("Optimizer") else class_name
 
       rst_file.write("\n")
       rst_file.write("%s\n" % name)

--- a/returnn/tf/updater.py
+++ b/returnn/tf/updater.py
@@ -53,6 +53,8 @@ def _init_optimizer_classes_dict():
       continue
     if not issubclass(v, allowed_types):
       continue
+    if v is KerasOptimizerWrapper:
+      continue
     register_optimizer_class(v, name=name)
 
 

--- a/returnn/tf/updater.py
+++ b/returnn/tf/updater.py
@@ -62,7 +62,7 @@ def _init_optimizer_classes_dict():
 
 def _check_valid_optimizer(optimizer_class):
   """
-  :param type
+  :param type optimizer_class:
   """
   if tf_compat.v2:
     assert (issubclass(optimizer_class, tf_compat.v2.keras.optimizers.Optimizer) or

--- a/tests/test_TFEngine.py
+++ b/tests/test_TFEngine.py
@@ -236,6 +236,14 @@ def test_engine_train_newbob():
   test_engine_train(additional_config)
 
 
+def test_engine_train_optimizer_class():
+  from returnn.tf.updater import NormalizedSGD
+  additional_config = {
+    "optimizer": {"class": NormalizedSGD},
+  }
+  test_engine_train(additional_config)
+
+
 def test_engine_train_keras_optimizer():
   additional_config = {
     "optimizer": {"class": "nadam"},

--- a/tests/test_TFEngine.py
+++ b/tests/test_TFEngine.py
@@ -199,7 +199,7 @@ def test_DatasetDataProvider():
     data_provider.stop_threads()
 
 
-def test_engine_train():
+def test_engine_train(additional_config=None):
   from returnn.datasets.generating import DummyDataset
   seq_len = 5
   n_data_dim = 2
@@ -218,6 +218,8 @@ def test_engine_train():
     "start_epoch": 1,
     "num_epochs": 2
   })
+  if additional_config:
+    config.update(additional_config)
   _cleanup_old_models(config)
   engine = Engine(config=config)
   engine.init_train_from_config(config=config, train_data=train_data, dev_data=cv_data, eval_data=None)
@@ -227,31 +229,18 @@ def test_engine_train():
 
 
 def test_engine_train_newbob():
-  from returnn.datasets.generating import DummyDataset
-  seq_len = 5
-  n_data_dim = 2
-  n_classes_dim = 3
-  train_data = DummyDataset(input_dim=n_data_dim, output_dim=n_classes_dim, num_seqs=4, seq_len=seq_len)
-  train_data.init_seq_order(epoch=1)
-  cv_data = DummyDataset(input_dim=n_data_dim, output_dim=n_classes_dim, num_seqs=2, seq_len=seq_len)
-  cv_data.init_seq_order(epoch=1)
-
-  config = Config()
-  config.update({
-    "model": "%s/model" % _get_tmp_dir(),
-    "num_outputs": n_classes_dim,
-    "num_inputs": n_data_dim,
-    "network": {"output": {"class": "softmax", "loss": "ce"}},
-    "start_epoch": 1,
+  additional_config = {
     "num_epochs": 5,
     "learning_rate_control": "newbob",
-  })
-  _cleanup_old_models(config)
-  engine = Engine(config=config)
-  engine.init_train_from_config(config=config, train_data=train_data, dev_data=cv_data, eval_data=None)
-  engine.train()
+  }
+  test_engine_train(additional_config)
 
-  engine.finalize()
+
+def test_engine_train_keras_optimizer():
+  additional_config = {
+    "optimizer": {"class": "nadam"},
+  }
+  test_engine_train(additional_config)
 
 
 def test_engine_train_new_dataset_pipeline():


### PR DESCRIPTION
Some bugfixing and extending features in the `updater.py` code:
 - Keras optimizers are now longer stored as wrapper function reference (caused problems due to inconsistencies of `type` vs `callable`)
 - Optimizer types can directly be used as "class" parameter -> allows to use external optimizers such as those from `tensorflow_addons` 
 - The documentation correctly displays also the Optimizers available via Keras (e.g. Nadam and Adamax)