### PR TITLE
tf.Engine.search: fixed output file write not considering use of seq_list_filter_file

### DIFF
--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -2391,15 +2391,13 @@ class Engine(EngineBase):
       runner.num_steps, self.format_score(runner.score), self.format_score(runner.error)), file=log.v1)
     if output_file:
       assert out_cache
-      assert 0 in out_cache
-      assert len(out_cache) - 1 in out_cache
       if output_file_format == "txt":
-        for i in range(len(out_cache)):
+        for i in sorted(out_cache.keys()):
           output_file.write("%s\n" % out_cache[i])
       elif output_file_format == "py":
         from returnn.util.basic import better_repr
         output_file.write("{\n")
-        for i in range(len(out_cache)):
+        for i in sorted(out_cache.keys()):
           output_file.write("%r: %s,\n" % (seq_idx_to_tag[i], better_repr(out_cache[i])))
         output_file.write("}\n")
       else:


### PR DESCRIPTION
I've encountered a bug when filtering out sequences from a dataset by their tags using the `seq_list_filter_file` feature of the [`HDFDataset`](https://returnn.readthedocs.io/en/latest/api/datasets.hdf.html#returnn.datasets.hdf.HDFDataset):
RETURNN's [`tf.Engine.search`](https://returnn.readthedocs.io/en/latest/api/tf.engine.html#returnn.tf.engine.Engine.search) method still assumed that the `out_cache` would contain an output for all the lines of the dataset. That caused `AssertionError`s and further `KeyError`s on the iteration over the `out_cache` entries by using `range(len(out_cache))`. The iteration fix should be safe. However, I'm not sure how important the assertions I deleted were.