### PR TITLE
small fix in TransposedConvLayer

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4252,7 +4252,7 @@ class TransposedConvLayer(_ConcatInputLayer):
     padding = padding.lower()
     if strides is None:
       strides = filter_size
-    if not isinstance(remove_padding, (tuple, int)):
+    if not isinstance(remove_padding, (tuple, tuple)):
       remove_padding = [remove_padding] * len(spatial_axes)
     if not isinstance(output_padding, (list, tuple)):
       output_padding = [output_padding] * len(spatial_axes)

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4252,7 +4252,7 @@ class TransposedConvLayer(_ConcatInputLayer):
     padding = padding.lower()
     if strides is None:
       strides = filter_size
-    if not isinstance(remove_padding, (tuple, tuple)):
+    if not isinstance(remove_padding, (list, tuple)):
       remove_padding = [remove_padding] * len(spatial_axes)
     if not isinstance(output_padding, (list, tuple)):
       output_padding = [output_padding] * len(spatial_axes)


### PR DESCRIPTION
I assume it was intended this way as the default value for `remove_padding` is 0 and later `len(remove_padding)` is checked, which crashes with the default value right now.