### PR TITLE
small fix for activation layer to work with stft layer using absolute activation

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -550,9 +550,12 @@ class ActivationLayer(_ConcatInputLayer):
     if self.output_before_activation:
       self.output.placeholder = self.output_before_activation.y
 
+
   @classmethod
   def get_out_data_from_opts(cls, sources, name, activation, **kwargs):
     """
+    :param list[LayerBase] sources:
+    :param str name:
     :param str activation:
     :rtype: Data
     """

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -551,16 +551,15 @@ class ActivationLayer(_ConcatInputLayer):
       self.output.placeholder = self.output_before_activation.y
 
   @classmethod
-  def get_out_data_from_opts(cls, sources, name, activation, **kwargs):
+  def get_out_data_from_opts(cls, activation, **kwargs):
     """
-    :param list[LayerBase] sources:
-    :param str name:
     :param str activation:
     :rtype: Data
     """
-    # get dtype based on the inputs
-    out = get_concat_sources_data_template(sources, name="%s_output" % name)
-    # modify if needed based on activation function
+    # Just the same as the input.
+    # Use CopyLayer.get_out_data_from_opts for potential extra logic for out_type.
+    out = CopyLayer.get_out_data_from_opts(**kwargs)
+    # Modify dtype if needed based on activation function
     if activation == "abs" and out.dtype == "complex64":
       out.dtype = "float32"
     return out

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -550,6 +550,9 @@ class ActivationLayer(CopyLayer):
     if self.output_before_activation:
       self.output.placeholder = self.output_before_activation.y
 
+    if activation == "abs" and self.output.dtype == "complex64":
+      self.output.dtype = "float32"
+
   @classmethod
   def get_out_data_from_opts(cls, activation, **kwargs):
     """

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -550,7 +550,6 @@ class ActivationLayer(_ConcatInputLayer):
     if self.output_before_activation:
       self.output.placeholder = self.output_before_activation.y
 
-
   @classmethod
   def get_out_data_from_opts(cls, sources, name, activation, **kwargs):
     """

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -565,6 +565,7 @@ class ActivationLayer(_ConcatInputLayer):
       out.dtype = "float32"
     return out
 
+
 class BatchNormLayer(CopyLayer):
   """
   Implements batch-normalization (http://arxiv.org/abs/1502.03167) as a separate layer.

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -520,7 +520,7 @@ class SelectSearchSourcesLayer(InternalLayer):
     return data
 
 
-class ActivationLayer(CopyLayer):
+class ActivationLayer(_ConcatInputLayer):
   """
   This layer just applies an activation function.
   See :func:`TFUtil.get_activation_function` about supported functions.
@@ -550,22 +550,18 @@ class ActivationLayer(CopyLayer):
     if self.output_before_activation:
       self.output.placeholder = self.output_before_activation.y
 
-    if activation == "abs" and self.output.dtype == "complex64":
-      self.output.dtype = "float32"
-
   @classmethod
-  def get_out_data_from_opts(cls, activation, **kwargs):
+  def get_out_data_from_opts(cls, sources, name, activation, **kwargs):
     """
     :param str activation:
     :rtype: Data
     """
-    # Get dtype based on inputs
-    out = super(ActivationLayer, cls).get_out_data_from_opts(**kwargs)
-    # Modify if needed based on activation function
+    # get dtype based on the inputs
+    out = get_concat_sources_data_template(sources, name="%s_output" % name)
+    # modify if needed based on activation function
     if activation == "abs" and out.dtype == "complex64":
       out.dtype = "float32"
     return out
-
 
 class BatchNormLayer(CopyLayer):
   """

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -399,12 +399,12 @@ def test_activation_layer_abs_for_stft():
       "num_outputs": 3,
       "num_inputs": num_inputs,
       "network": {
-        "stft": { "class": "multichannel_stft_layer", "from": "data",
-                  "frame_shift": frame_shift, "frame_size": frame_size,
-                  "window": "hanning", "fft_size": fft_size,
-                  "use_rfft": True, "pad_last_frame": False,
-                  "nr_of_channels": 1 },
-        "output": { "class": "activation", "activation": "abs", "from": ["stft"] }
+        "stft": {"class": "multichannel_stft_layer", "from": "data",
+                 "frame_shift": frame_shift, "frame_size": frame_size,
+                 "window": "hanning", "fft_size": fft_size,
+                 "use_rfft": True, "pad_last_frame": False,
+                 "nr_of_channels": 1},
+        "output": {"class": "activation", "activation": "abs", "from": ["stft"]}
       }})
     network = TFNetwork(config=config, train_flag=True)
     network.construct_from_dict(config.typed_value("network"))

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -388,6 +388,7 @@ def test_activation_layer_net_construct():
     assert_equal(v.shape, (n_batch, seq_len, num_inputs))
     assert_equal(v.tolist(), [[[0, 0], [0, 0], [2, 2]]])
 
+
 def test_activation_layer_abs_for_stft():
   with make_scope() as session:
     num_inputs = 1


### PR DESCRIPTION
When using the Activation Layer with absolute activation for the output of a stft layer there is an assertion failure that the output should have type "float32" but actually has type "complex64". I propose a fix of the problem and a test for its correctness. 