### PR TITLE
Explicit definition of the batch norm parameters in the BatchNorm Layer

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -607,11 +607,10 @@ class BatchNormLayer(CopyLayer):
     - The running average includes the statistics of the current batch.
     - The running average is also updated when not training.
     """
+    local = locals()
     from returnn.util.basic import getargspec
     batch_norm_kwargs = getargspec(self.batch_norm).args[1:]  # first is self, ignore
-    batch_norm_opts = {key: locals()[key]
-                     for key in batch_norm_kwargs
-                     if key in locals()}
+    batch_norm_opts = {key: local[key] for key in batch_norm_kwargs if key in local}
     super(BatchNormLayer, self).__init__(batch_norm=batch_norm_opts, **kwargs)
 
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -572,15 +572,15 @@ class BatchNormLayer(CopyLayer):
   """
   layer_class = "batch_norm"
 
-  def __init__(self, use_shift=True, use_std=True, use_sample=0.0, force_sample=False,
-               momentum=0.99, epsilon=1e-3,
-               sample_mean=None, sample_variance=None,
-               update_sample_only_in_training=False,
-               delay_sample_update=False,
-               param_version=0,
-               gamma=None, beta=None,
-               gamma_init=1.0, beta_init=0.0,
-               masked_time=True, **kwargs):
+  def __init__(self, use_shift=NotSpecified, use_std=NotSpecified, use_sample=NotSpecified, force_sample=NotSpecified,
+               momentum=NotSpecified, epsilon=NotSpecified,
+               sample_mean=NotSpecified, sample_variance=NotSpecified,
+               update_sample_only_in_training=NotSpecified,
+               delay_sample_update=NotSpecified,
+               param_version=NotSpecified,
+               gamma=NotSpecified, beta=NotSpecified,
+               gamma_init=NotSpecified, beta_init=NotSpecified,
+               masked_time=NotSpecified, **kwargs):
     """
     :param bool use_shift:
     :param bool use_std:
@@ -600,6 +600,8 @@ class BatchNormLayer(CopyLayer):
     :param bool masked_time: flatten and mask input tensor
     :rtype: tf.Tensor
 
+    The default settings for these variables are set in the function "batch_norm" of the LayerBase. If you do not want
+    to change them you can leave them undefined here. 
     With our default settings:
 
     - In training: use_sample=0, i.e. not using running average, using current batch mean/var.
@@ -610,8 +612,8 @@ class BatchNormLayer(CopyLayer):
     local = locals()
     from returnn.util.basic import getargspec
     batch_norm_kwargs = getargspec(self.batch_norm).args[1:]  # first is self, ignore
-    batch_norm_opts = {key: local[key] for key in batch_norm_kwargs if key in local}
-    super(BatchNormLayer, self).__init__(batch_norm=batch_norm_opts, **kwargs)
+    batch_norm_opts = {key: local[key] for key in batch_norm_kwargs if key in local and local[key] != NotSpecified}
+    super(BatchNormLayer, self).__init__(batch_norm=batch_norm_opts or True, **kwargs)
 
 
 class LayerNormLayer(_ConcatInputLayer):

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -601,7 +601,7 @@ class BatchNormLayer(CopyLayer):
     :rtype: tf.Tensor
 
     The default settings for these variables are set in the function "batch_norm" of the LayerBase. If you do not want
-    to change them you can leave them undefined here. 
+    to change them you can leave them undefined here.
     With our default settings:
 
     - In training: use_sample=0, i.e. not using running average, using current batch mean/var.

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -607,10 +607,12 @@ class BatchNormLayer(CopyLayer):
     - The running average includes the statistics of the current batch.
     - The running average is also updated when not training.
     """
-    batch_norm_opts = locals()
-    del batch_norm_opts['self']
-    del batch_norm_opts['kwargs']
-    super(BatchNormLayer, self).__init__(batch_norm=batch_norm_opts or True, **kwargs)
+    from returnn.util.basic import getargspec
+    batch_norm_kwargs = getargspec(self.batch_norm).args[1:]  # first is self, ignore
+    batch_norm_opts = {key: locals()[key]
+                     for key in batch_norm_kwargs
+                     if key in locals()}
+    super(BatchNormLayer, self).__init__(batch_norm=batch_norm_opts, **kwargs)
 
 
 class LayerNormLayer(_ConcatInputLayer):

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -4604,6 +4604,14 @@ def test_automatic_seq_lengths2():
     assert out_lens is in_data.size_placeholder[0]
 
 
+def test_batch_norm_args():
+  from returnn.tf.layers.basic import BatchNormLayer
+  from returnn.util.basic import getargspec
+  batch_norm_args = getargspec(BatchNormLayer.batch_norm).args[2:] #drop self and data
+  layer_args = getargspec(BatchNormLayer.__init__).args[1:] #drop self
+  assert batch_norm_args == layer_args #different arguments in BatchNormLayer and LayerBase.batch_norm()
+
+
 if __name__ == "__main__":
   try:
     better_exchook.install()

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -4607,9 +4607,9 @@ def test_automatic_seq_lengths2():
 def test_batch_norm_args():
   from returnn.tf.layers.basic import BatchNormLayer
   from returnn.util.basic import getargspec
-  batch_norm_args = getargspec(BatchNormLayer.batch_norm).args[2:] #drop self and data
-  layer_args = getargspec(BatchNormLayer.__init__).args[1:] #drop self
-  assert batch_norm_args == layer_args #different arguments in BatchNormLayer and LayerBase.batch_norm()
+  batch_norm_args = getargspec(BatchNormLayer.batch_norm).args[2:]  # drop self and data
+  layer_args = getargspec(BatchNormLayer.__init__).args[1:]  # drop self
+  assert batch_norm_args == layer_args  # different arguments in BatchNormLayer and LayerBase.batch_norm()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR copies the parameters used for `batch_norm()` in the `LayerBase` directly into the `BatchNorm` layer, instead of them being extracted from the `kwargs` in the `BatchNorm` layer. This change should not make functional differences and is in order to make the generated `BatchNorm` layer in the `returnn_common` interfaces easier to use. This change enables directly defining the parameters of the layer in the new interface instead of handing over a dict of strings.