### PR TITLE
compile_tf_graph: use absolute layer names

### DIFF
--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -701,7 +701,7 @@ def main(argv):
         continue
       if layer.output.batch_dim_axis is None:
         continue
-      with layer.cls_layer_scope(layer.name):
+      with layer.cls_layer_scope(layer.get_absolute_name()):
         tf.identity(layer.output.get_placeholder_as_batch_major(), name="output_batch_major")
 
     tf.group(*network.get_post_control_dependencies(), name="post_control_dependencies")


### PR DESCRIPTION
In many of my setups, I use `compile_tf_graph.py` to compile the graph based on my RETURNN config and then use this graph in RASR for recognition. In RASR, I always used `output/output_batch_major` as tensor name to obtain the posteriors that I needed.

This does not work as expected anymore, since `network.layers` used to include only `SubnetworkLayers` but now also includes all layers inside the subnetwork. Therefore, if I have a subnetwork with a layer named "output" inside, the name of the tensor I actually want changes to `output/output_batch_major_1`.

We can avoid this by using absolute layer names in the script. Not sure if this breaks some setups people recently built, but obviously not doing this also breaks setups as in my case.