### PR TITLE
get_initializer: Do not override seed set by user

### DIFF
--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -1431,7 +1431,7 @@ def get_initializer(s, seed=None, eval_local_ns=None, dtype=tf.float32):
   :param str|dict[str]|float|numpy.ndarray s: e.g. "glorot_uniform" or "truncated_normal" or "orthogonal",
     or config dict with "class",
     or string to be `eval`ed if it contains "(". constant if a float is given.
-  :param int|tf.Tensor seed:
+  :param int|tf.Tensor seed: used in case the initializer has no explicit seed specified.
   :param dict[str]|None eval_local_ns:
   :param tf.DType|str dtype:
   :return: (function (shape) -> tf.Tensor) | tf.Initializer
@@ -1505,7 +1505,10 @@ def get_initializer(s, seed=None, eval_local_ns=None, dtype=tf.float32):
       raise Exception("invalid initializer: %r" % s)
     if seed is not None:
       assert isinstance(f, init_ops.Initializer)
-      if hasattr(f, "seed"):
+      if hasattr(f, "seed") and f.seed is None:
+        # If f.seed is not None, do not override the seed.
+        # This e.g. happens when the user explicitly specifies a seed in the initializer constructor:
+        # Use the user's seed instead.
         f.seed = seed
   except Exception:
     error()


### PR DESCRIPTION
When adding a param, most layers pass sth like `self.network.random.randint(2 ** 31)` as seed to `get_initializer`: e.g.

https://github.com/rwth-i6/returnn/blob/master/returnn/tf/layers/basic.py#L6911

However, when the provided initializer already contains a seed, this is just overridden: E.g. 
```
{'class': 'variable', 'add_batch_axis': True, 'shape': (8, 1, 64, 2), 'trainable': False,
 'init': "variance_scaling_initializer(mode='fan_in', distribution='uniform', 'scale=1.0, seed=100)'}
```
will be initialized differently for different global `random_seed`s.

That is definitely not what I expect: If I explicitly provide a seed to the initializer, I expect it to always initialize my tensor to the same value - independent of the network seed.

In this PR, I change `get_initializer` to only override the `seed` if the initializer had none set before.