### PR TITLE
Handle nan and inf in better_repr

### DIFF
--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -16,6 +16,7 @@ import inspect
 import os
 import sys
 import shlex
+import math
 import numpy as np
 import re
 import time
@@ -901,6 +902,8 @@ def better_repr(o):
       return "{%s}" % ", ".join(ls)
   if isinstance(o, set):
     return "set([\n%s])" % "".join(map(lambda v: better_repr(v) + ",\n", o))
+  if isinstance(o, float) and (math.isnan(o) or math.isinf(o)):
+    return "float('%s')" % repr(o)
   # fallback
   return repr(o)
 


### PR DESCRIPTION
To create search output files in the py format we currently kind of rely on `better_repr` to generate valid python code.

But this is not the case if the output contains infs or nans (e.g. beam scores (can happen in my case since I am doing a kind of constrained search where I mask invalid hypotheses)).
To fix this, this changes the output of `better_repr` from e.g. `-inf` to `float('-inf')`.

