### PR TITLE
Fix unused TF operations in Batchnorm

### DIFF
--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -1271,17 +1271,22 @@ class LayerBase(object):
       else:
         sample_variance = updated_sample_variance
       # If train or if force_sample, use default use_sample=0.0, otherwise use_sample=1.0.
-      if self.network.train_flag is not False or force_sample:
-        if force_sample:
-          pass  # leave use_sample as-is
-        else:
-          use_sample = tf.where(self.network.train_flag, use_sample, 1.0)
+      skip_updates = self.network.train_flag is False and update_sample_only_in_training and not force_sample
+      if skip_updates:
+        mean = sample_mean
+        variance = sample_variance
       else:
-        use_sample = 1.0
-      mean = (1. - use_sample) * mean + use_sample * sample_mean
-      variance = (1. - use_sample) * variance + use_sample * sample_variance
-      bn = (data.placeholder - mean) * tf_compat.v1.rsqrt(variance + epsilon)
-      if delayed_ops:
+        if self.network.train_flag is not False or force_sample:
+          if force_sample:
+            pass  # leave use_sample as-is
+          else:
+            use_sample = tf.where(self.network.train_flag, use_sample, 1.0)
+        else:
+          use_sample = 1.0
+        mean = (1. - use_sample) * mean + use_sample * sample_mean
+        variance = (1. - use_sample) * variance + use_sample * sample_variance
+      bn = (data.placeholder - mean) * tf_compat.v1.rsqrt(tf_util.optional_add(variance, epsilon))
+      if not skip_updates and delayed_ops and (isinstance(use_sample, tf.Tensor) or use_sample != 0.0):
         for op in delayed_ops:
           # Make sure we update after we calculated the batch norm.
           tf_util.add_control_input(op, control_input=bn.op)


### PR DESCRIPTION
A student worker at AppTek found that using batch norm during search has a lot of computational overhead (up tp 30%), and the graph includes nodes that should not be needed during search, as e.g. re-estimating the variance and mean.

This PR fixes this issue, reducing the computational share of the BN from 30% to 13% in this specific case. The problem is that TF does not detect multiplications with 0 automatically, and will still run the full graph, thus, zero cases need to be handled explicitely. 

The adding the epsilon also had a share of 2% computation, so I also disabled the addition when the epsilon is zero.