### PR TITLE
HDFDumpLayer: Add batch dim to "extra" inputs

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -7677,7 +7677,11 @@ class HDFDumpLayer(LayerBase):
     self.filename = filename
     if extra is None:
       extra = {}
-    extra = {key: layer.output.copy_as_batch_spatial_major() for (key, layer) in extra.items()}
+    extra = {key: layer.output for (key, layer) in extra.items()}
+    extra = {
+      key: output.copy_add_batch_dim(0, batch=data.batch)
+      if not output.have_batch_axis() else output for (key, output) in extra.items()}
+    extra = {key: output.copy_as_batch_spatial_major() for (key, output) in extra.items()}
     self.extra = extra  # type: typing.Dict[str,Data]
     self.dump_whole_batches = dump_whole_batches
     self.num_seqs_written = 0

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -7680,7 +7680,8 @@ class HDFDumpLayer(LayerBase):
     extra = {key: layer.output for (key, layer) in extra.items()}
     extra = {
       key: output.copy_add_batch_dim(0, batch=data.batch)
-      if not output.have_batch_axis() else output for (key, output) in extra.items()}
+      if not output.have_batch_axis() else output
+      for (key, output) in extra.items()}
     extra = {key: output.copy_as_batch_spatial_major() for (key, output) in extra.items()}
     self.extra = extra  # type: typing.Dict[str,Data]
     self.dump_whole_batches = dump_whole_batches


### PR DESCRIPTION
I had `extra` inputs of a HDF dump layer which did not have any batch dim.
Here I change it so that all `extra` inputs without batch dim get an unbroadcasted batch dim of the main input.