### PR TITLE
Test cases and example fixes for tf_compile_graph with recurrent step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
           - TEST=TaskSystem
           - TEST=TaskSystem_SharedMem
           - TEST=TheanoUtil
+          - TEST=tools
           - TEST=Util
         include:
           - action: TEST=TFUtil

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -994,8 +994,6 @@ class _SubnetworkRecCell(object):
     self.parent_rec_layer = None  # type: typing.Optional[RecLayer]
     self.parent_net = parent_net
     self.net_dict = safe_deep_copy(net_dict)
-    self.rec_layer_name = rec_layer_name
-    self.parent_get_layer = parent_get_layer
     from returnn.tf.network import TFNetwork, ExternData, LossHolder
     from returnn.tf.util.data import ControlFlowContext
     control_flow_ctx = ControlFlowContext(

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -994,6 +994,8 @@ class _SubnetworkRecCell(object):
     self.parent_rec_layer = None  # type: typing.Optional[RecLayer]
     self.parent_net = parent_net
     self.net_dict = safe_deep_copy(net_dict)
+    self.rec_layer_name = rec_layer_name
+    self.parent_get_layer = parent_get_layer
     from returnn.tf.network import TFNetwork, ExternData, LossHolder
     from returnn.tf.util.data import ControlFlowContext
     control_flow_ctx = ControlFlowContext(
@@ -1053,6 +1055,8 @@ class _SubnetworkRecCell(object):
 
   def set_parent_layer(self, parent_rec_layer):
     """
+    Only called from RecLayer._get_cell to define itself as parent
+
     :param RecLayer parent_rec_layer:
     """
     assert parent_rec_layer.network is self.parent_net

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,82 @@
+"""
+Test cases for different tools
+"""
+
+from __future__ import print_function
+
+import tempfile
+import _setup_test_env  # noqa
+from subprocess import Popen, PIPE, STDOUT, CalledProcessError
+import os
+import sys
+
+
+py = sys.executable
+print("Python:", py)
+
+
+def run(*args):
+  args = list(args)
+  print("run:", args)
+  # RETURNN by default outputs on stderr, so just merge both together
+  p = Popen(args, stdout=PIPE, stderr=STDOUT)
+  out, _ = p.communicate()
+  if p.returncode != 0:
+    print("Return code is %i" % p.returncode)
+    print("std out/err:\n---\n%s\n---\n" % out.decode("utf8"))
+    raise CalledProcessError(cmd=args, returncode=p.returncode, output=out)
+  return out.decode("utf8")
+
+
+###############################
+# Tests for compile_tf_graph.py
+###############################
+
+rec_decoder_config = """
+#!rnn.py
+network = {
+    "enc0": {"class": "linear", "activation": "sigmoid", "n_out": 3},
+    "enc1": {"class": "reduce", "mode": "max", "axis": "t", "from": "enc0"},
+    "output": {
+      "class": "rec", "from": [], "max_seq_len": 10, "target": "classes",
+      "unit": {
+        "embed": {"class": "linear", "from": "prev:output", "activation": "sigmoid", "n_out": 3},
+        "prob": {"class": "softmax", "from": ["embed", "base:enc1"], "loss": "ce", "target": "classes"},
+        "output": {"class": "choice", "beam_size": 4, "from": "prob", "target": "classes", "initial_output": 0},
+        "end": {"class": "compare", "from": "output", "value": 0}
+      }
+    },
+    "decision": {"class": "decide", "from": "output", "loss": "edit_distance"}
+}
+num_inputs = 5
+num_outputs = 3
+use_tensorflow = True
+"""
+
+
+def test_compile_tf_graph_basic():
+  tmp_dir = tempfile.mkdtemp()
+  with open(os.path.join(tmp_dir, "returnn.config"), "wt") as config:
+    config.write(rec_decoder_config)
+  args = [
+    "tools/compile_tf_graph.py",
+    "--output_file",
+    os.path.join(tmp_dir, "graph.metatxt"),
+    os.path.join(tmp_dir, "returnn.config")
+  ]
+  run(*args)
+
+
+def test_compile_tf_graph_recurrent_step():
+  tmp_dir = tempfile.mkdtemp()
+  with open(os.path.join(tmp_dir, "returnn.config"), "wt") as config:
+    config.write(rec_decoder_config)
+  args = [
+    "tools/compile_tf_graph.py",
+    "--output_file",
+    os.path.join(tmp_dir, "graph.metatxt"),
+    "--rec_step_by_step",
+    "output",
+    os.path.join(tmp_dir, "returnn.config")
+  ]
+  run(*args)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -35,10 +35,10 @@ def run(*args):
 rec_decoder_config = """
 #!rnn.py
 network = {
-    "enc0": {"class": "linear", "activation": "sigmoid", "n_out": 3},
+    "enc0": {"class": "linear", "from": "data", "activation": "sigmoid", "n_out": 3},
     "enc1": {"class": "reduce", "mode": "max", "axis": "t", "from": "enc0"},
     "output": {
-      "class": "rec", "from": [], "max_seq_len": 10, "target": "classes",
+      "class": "rec", "from": [], "target": "classes",
       "unit": {
         "embed": {"class": "linear", "from": "prev:output", "activation": "sigmoid", "n_out": 3},
         "prob": {"class": "softmax", "from": ["embed", "base:enc1"], "loss": "ce", "target": "classes"},

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -234,7 +234,6 @@ class RecStepByStepLayer(RecLayer):
       self.var = tf_compat.v1.get_variable(
         name=name, initializer=zero_initializer, validate_shape=False)  # type: tf.Variable
       self.var.set_shape(self.var_data_shape.batch_shape)
-      assert self.var.shape.as_list() == list(self.var_data_shape.batch_shape)
       print("New state var %r: %s, shape %s" % (name, self.var, self.var_data_shape))
       self.final_value = None  # type: typing.Optional[tf.Tensor]
 


### PR DESCRIPTION
Tries to fix issues when compiling with `--rec_step_by_step` by doing the following changes:

 - Adapted the code to the new internal structure of the rec layer
 - Resolved the dependency issue on the target length for the `cond` state var
 - Added two test cases with a simple search decoder, one for default compilation, one for compiling with rec-step-by-step