### PR TITLE
More efficient get_seq_order_for_epoch()

### DIFF
--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -133,7 +133,7 @@ class OggZipDataset(CachedDataset2):
     if fixed_random_subset:
       self._filter_fixed_random_subset(fixed_random_subset)
     self.epoch_wise_filter = EpochWiseFilter(epoch_wise_filter) if epoch_wise_filter else None
-    self._seq_order = None  # type: typing.Optional[typing.List[int]]
+    self._seq_order = None  # type: typing.Optional[typing.Sequence[int]]
     self.init_seq_order()
 
   def _read(self, filename, zip_index):

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -373,7 +373,7 @@ class Dataset(object):
     :param int num_seqs:
     :param ((int) -> int)|None get_seq_len: function (originalSeqIdx: int) -> int
     :return: the order for the given epoch. such that seq_idx -> underlying idx
-    :rtype: list[int]
+    :rtype: typing.Sequence[int]
     """
     partition_epoch = self.partition_epoch or 1
     repeat_epoch = self.repeat_epoch or 1
@@ -491,11 +491,11 @@ class Dataset(object):
   @classmethod
   def _apply_partition_epoch(cls, seq_index, partition_epoch, epoch):
     """
-    :param list[int] seq_index: full list of ordered sequence indices
+    :param typing.Sequence[int] seq_index: full list of ordered sequence indices
     :param int partition_epoch: number of partitions seq_index should be split into
     :param int|None epoch: current epoch
     :return: partition of seq_index for current epoch
-    :rtype: list[int]
+    :rtype: typing.Sequence[int]
     """
     num_seqs = len(seq_index)
     current_partition = ((epoch or 1) - 1) % partition_epoch
@@ -553,7 +553,7 @@ class Dataset(object):
     :return: many datasets use self.get_seq_order_for_epoch. this function would return the current seq order
       for the current epoch, after self.init_seq_order was called.
       Not all datasets implement this.
-    :rtype: list[int]
+    :rtype: typing.Sequence[int]
     """
     raise OptionalNotImplementedError
 

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -403,8 +403,8 @@ class Dataset(object):
       nth = int(tmp[1]) if len(tmp) > 1 else 1
       # Keep this deterministic! Use fixed seed.
       rnd_seed = self._get_random_seed_for_epoch(epoch=epoch, num_epochs_fixed=nth)
-      numpy.random.seed(rnd_seed)
-      seq_index = numpy.random.permutation(num_seqs)
+      random_generator = numpy.random.RandomState(rnd_seed)
+      seq_index = random_generator.permutation(num_seqs)
     elif self.seq_ordering.startswith('sort_bin_shuffle'):
       # Shuffle seqs, sort by length, and shuffle bins (then shuffle seqs within each bin if sort_bin_shuffle_x2).
       assert get_seq_len
@@ -415,8 +415,8 @@ class Dataset(object):
       else:
         nth = int(tmp[1])
       rnd_seed = self._get_random_seed_for_epoch(epoch=epoch, num_epochs_fixed=nth)
-      numpy.random.seed(rnd_seed)
-      seq_index = numpy.random.permutation(num_seqs).tolist()  # type: typing.List[int]
+      random_generator = numpy.random.RandomState(rnd_seed)
+      seq_index = random_generator.permutation(num_seqs).tolist()  # type: typing.List[int]
       seq_index.sort(key=get_seq_len)  # Sort by length, starting with shortest.
       if len(tmp) == 0:
         bins = 2
@@ -425,7 +425,7 @@ class Dataset(object):
           bins = max(num_seqs // int(tmp[0][1:]), 2)
         else:  # the number of bins
           bins = int(tmp[0])
-      bin_ids = numpy.random.permutation(bins)  # Shuffle bins.
+      bin_ids = random_generator.permutation(bins)  # Shuffle bins.
       out_index = []
       for i in bin_ids:
         if i == bins - 1:
@@ -433,7 +433,7 @@ class Dataset(object):
         else:
           part = seq_index[i * len(seq_index) // bins:(i + 1) * len(seq_index) // bins][:]
         if self.seq_ordering.startswith('sort_bin_shuffle_x2'):
-          numpy.random.shuffle(part)  # Shuffle within the bin.
+          random_generator.shuffle(part)  # Shuffle within the bin.
         out_index.append(part)
       seq_index = numpy.concatenate(out_index)
     elif self.seq_ordering.startswith('laplace'):
@@ -451,8 +451,8 @@ class Dataset(object):
       else:
         nth = int(tmp[1])
       rnd_seed = self._get_random_seed_for_epoch(epoch=epoch, num_epochs_fixed=nth)
-      numpy.random.seed(rnd_seed)
-      seq_index = numpy.random.permutation(num_seqs)  # type: numpy.ndarray
+      random_generator = numpy.random.RandomState(rnd_seed)
+      seq_index = random_generator.permutation(num_seqs)  # type: numpy.ndarray
       out_index = []
       for i in range(bins):
         if i == bins - 1:

--- a/returnn/datasets/cached.py
+++ b/returnn/datasets/cached.py
@@ -86,7 +86,8 @@ class CachedDataset(Dataset):
     old_index_map = self._index_map[:]
     self._index_map = range(len(seq_index))  # sorted seq idx -> seq_index idx
 
-    if self._seq_index == seq_index and self.start_cache_initialized:
+    if (isinstance(seq_index, numpy.ndarray) and numpy.array_equal(self._seq_index, seq_index)
+        or self._seq_index == seq_index) and self.start_cache_initialized:
       return False
 
     if epoch is not None:

--- a/returnn/datasets/generating.py
+++ b/returnn/datasets/generating.py
@@ -1130,7 +1130,7 @@ class TimitDataset(CachedDataset2):
     from returnn.util.basic import CollectionReadCheckCovered
     self._random_permute_audio = CollectionReadCheckCovered.from_bool_or_dict(random_permute_audio)
 
-    self._seq_order = None  # type: typing.Optional[typing.List[int]]
+    self._seq_order = None  # type: typing.Optional[typing.Sequence[int]]
     self._init_timit()
 
     self._audio_data = {}  # seq_tag -> (audio, sample_rate). loaded by self._reader_thread_main
@@ -1648,7 +1648,7 @@ class LibriSpeechCorpus(CachedDataset2):
       self._reference_seq_order = seqs
       self.transs = {s: self.transs[s] for s in seqs}
     self.epoch_wise_filter = epoch_wise_filter
-    self._seq_order = None  # type: typing.Optional[typing.List[int]]
+    self._seq_order = None  # type: typing.Optional[typing.Sequence[int]]
     self.init_seq_order()
 
   def _collect_trans(self):
@@ -1785,7 +1785,7 @@ class LibriSpeechCorpus(CachedDataset2):
 
   def get_current_seq_order(self):
     """
-    :rtype: list[int]
+    :rtype: typing.Sequence[int]
     """
     assert self._seq_order is not None
     return self._seq_order
@@ -1936,7 +1936,7 @@ class Enwik8Corpus(CachedDataset2):
     self._batch_num_seqs = batch_num_seqs
     self._random = numpy.random.RandomState(1)  # seed will be set in init_seq_order
     self._seq_starts = numpy.arange(0, len(self._data) - 1, seq_len)
-    self._seq_order = None  # type: typing.Optional[typing.List[int]]
+    self._seq_order = None  # type: typing.Optional[typing.Sequence[int]]
 
   def get_data_dtype(self, key):
     """

--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -1136,7 +1136,7 @@ class TranslationDataset(CachedDataset2):
       unknown_label.setdefault(data_key, None)
     self._unknown_label = unknown_label
 
-    self._seq_order = None  # type: typing.Optional[typing.List[int]]  # seq_idx -> line_nr
+    self._seq_order = None  # type: typing.Optional[typing.Sequence[int]]  # seq_idx -> line_nr
     self._tag_prefix = "line-"  # sequence tag is "line-n", where n is the line number
     self._thread = Thread(name="%r reader" % self, target=self._thread_main)
     self._thread.daemon = True

--- a/returnn/datasets/map.py
+++ b/returnn/datasets/map.py
@@ -130,7 +130,7 @@ class MapDatasetWrapper(CachedDataset2):
 
   def get_current_seq_order(self):
     """
-    :rtype: list[int]
+    :rtype: typing.Sequence[int]
     """
     assert self._seq_order is not None
     return self._seq_order

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -50,7 +50,7 @@ class EpochWiseFilter:
   def filter_epoch(cls, opts, seq_order, get_seq_len, debug_msg_prefix):
     """
     :param dict[str]|returnn.util.basic.CollectionReadCheckCovered opts:
-    :param list[int] seq_order: list of seq idxs
+    :param typing.Sequence[int] seq_order: list of seq idxs
     :param ((int)->int) get_seq_len: seq idx -> len
     :param str debug_msg_prefix:
     :return: new seq_order
@@ -81,7 +81,7 @@ class EpochWiseFilter:
   def filter(self, epoch, seq_order, get_seq_len):
     """
     :param int|None epoch:
-    :param list[int] seq_order: list of seq idxs
+    :param typing.Sequence[int] seq_order: list of seq idxs
     :param ((int)->int) get_seq_len: seq idx -> len
     :return: new seq_order
     """


### PR DESCRIPTION
If training on huge datasets (e.g. 100M sequences), storing a full list of indices for the sequence order uses a significant amount of memory, especially when using a plain Python list and not a numpy array. With `default` sequence ordering this can be avoided by using a `range` instead. The full list is now only created after applying partition epoch, which usually means orders of magnitude less sequences.
I also made creating the sequence orderings a bit faster by using numpy. Again, with huge datasets that can make a difference. The random seed will be different, so to say, before and after this commit, not sure whether this is a problem.
Unfortunately, the code now sometimes goes back and forth between lists and arrays, but emulating `list.sort(key=...)` with numpy also wouldn't be too nice.


