### PR TITLE
Explicit Data dimension tags

### DIFF
--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -281,7 +281,7 @@ class LayerBase(object):
     # You are supposed to set self.output.{batch_dim_axis,time_dim_axis} explicitly,
     # as well as check the inputs if they are as you would suggest.
     # However, a good default is often to use the same as the input.
-    if all([k not in out_type for k in Data.SpecialAxesNames]):
+    if all([k not in out_type for k in Data.SpecialAxesNames]) and "dim_tags" not in out_type:
       if sources_data:
         out_type.setdefault("batch_dim_axis", sources_data.batch_dim_axis)
         out_type.setdefault("time_dim_axis", sources_data.time_dim_axis)

--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -293,8 +293,6 @@ class LayerBase(object):
               out_type.setdefault("feature_dim_axis", None)
       elif network.is_inside_rec_layer() and None not in out_type.get("shape", ()):
         out_type.setdefault("time_dim_axis", None)
-    # TODO how do we resolve this? in many user configs, the user would provide "old-style" shape,
-    #   but via Data.get_kwargs we get dim_tags ...
     if "shape" not in out_type and "dim_tags" not in out_type:
       if sources_data:
         if out_type.get("sparse", False):

--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -355,7 +355,7 @@ class LayerBase(object):
     # However, in many cases, this will just be {0: time-lengths} and the same as from the input.
     # We check for this case and preset it by that if possible.
     # If you want to have it different in your layer, just overwrite it.
-    common_source = Data.get_common_data([s.output for s in sources if s])
+    common_source = Data.get_common_data([s.output for s in sources if s], ignore_feature_dim=True)
     if not output.size_placeholder:
       if network.eval_flag and size_target:
         output.size_placeholder = cls._static_get_target_value(

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1224,13 +1224,13 @@ class GatherNdLayer(_ConcatInputLayer):
       position_data = position_data.copy_as_batch_major()
     else:
       position_data = position_data.copy_add_batch_dim(batch_dim_axis=0, batch=input_data.batch)
-    shape = list(position_data.shape) + list(input_data.shape[1:])  # (B, ...) (w/o batch)
+    dim_tags = list(position_data.dim_tags) + list(input_data.dim_tags[2:])  # (B, ...) (w/o batch)
     out_type = position_data.get_kwargs()
     out_type["name"] = "%s_output" % name
-    out_type["shape"] = shape  # TODO ...
+    out_type["dim_tags"] = dim_tags
     if position_data.time_dim_axis is None:
       if input_data.time_dim_axis is not None and input_data.time_dim_axis_excluding_batch >= 1:
-        out_type["time_dim_axis"] = len(shape) + input_data.time_dim_axis_excluding_batch - 1
+        out_type["time_dim_axis"] = len(dim_tags) + input_data.time_dim_axis_excluding_batch - 2
     out_type["dim"] = input_data.dim
     out_type["sparse"] = input_data.sparse
     out_type["dtype"] = input_data.dtype

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -97,7 +97,7 @@ def concat_sources(src_layers):
     return network.concat_sources_dropout_cache[cache_key].copy()
   data = get_concat_sources_data_template(src_layers)
   # Currently we assume that get_concat_sources_data_template will match Data.get_common_data (besides the dim).
-  common_source = Data.get_common_data([s.output for s in src_layers], warnings_out=log.v4)
+  common_source = Data.get_common_data([s.output for s in src_layers], ignore_feature_dim=True, warnings_out=log.v4)
   data.size_placeholder = common_source.size_placeholder.copy()  # to get right dimension tags
   layers_data = []
   with _name_scope_for_concat_src_layers(src_layers, "concat_sources"):
@@ -139,7 +139,7 @@ def get_concat_sources_data_template(src_layers, name=None):
     name = "concat_" + "_".join([layer.name for layer in src_layers])
   dim = 0
   beam = None
-  common_source = Data.get_common_data([s.output for s in src_layers])
+  common_source = Data.get_common_data([s.output for s in src_layers], ignore_feature_dim=True)
   for layer in src_layers:
     # Note: We do not perform much compatibility checks at this point,
     # as this is for a template only anyway.

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5892,6 +5892,8 @@ class CombineLayer(LayerBase):
     out_type_["name"] = "%s_output" % kwargs["name"]
     if out_type:
       if isinstance(out_type, dict):
+        if "shape" in out_type:
+          out_type_.pop("dim_tags", None)
         out_type_.update(out_type)
       elif callable(out_type):
         def call_out_type_with_eval_locals(**out_type_kwargs):

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3013,6 +3013,7 @@ class SplitBatchTimeLayer(_ConcatInputLayer):
     :rtype: Data
     """
     data = get_concat_sources_data_template(sources).copy_as_batch_major()
+    data.batch = base.output.batch
     data = data.copy_add_dim_by_tag(base.output.get_time_dim_tag(), axis=1, unbroadcast=True)
     return data.copy("%s_output" % name)
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2420,20 +2420,21 @@ class PadLayer(_ConcatInputLayer):
     self.output.size_placeholder = self.input_data.size_placeholder.copy()
     for a in axes:
       p = sum(paddings[a])
+      tag = self.input_data.dim_tags[a]
       a = self.input_data.get_batch_axis_excluding_batch(a)
       if a is None:
         continue
-      if a not in self.output.size_placeholder:
+      if tag.dyn_size is None:
         continue
       if p == 0:
         continue
-      size = self.output.size_placeholder[a]
+      size = tag.dyn_size
       with tf_util.same_control_flow_ctx(size):
         size = tf_util.simplify_add(size, p)
       if not DimensionTag.get_tag_from_size_tensor(size):
         tag = DimensionTag(
           description="spatial:%i:%s" % (a, self.get_absolute_name()),
-          kind=DimensionTag.Types.Spatial)
+          kind=tag.kind)
         tag.set_tag_on_size_tensor(size)
       self.output.size_placeholder[a] = size
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6328,6 +6328,7 @@ class CondLayer(LayerBase):
       assert isinstance(size, tf.Tensor)
       assert size.shape.ndims == 1
       # Note: Not quite clear what dimension-tag to set...
+      # TODO ...
       self.output.size_placeholder[i] = size
 
   def _cond_layer_return(self, layer):

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3106,12 +3106,13 @@ class UnflattenNdLayer(_ConcatInputLayer):
     assert sizes_data.batch_ndim == 2
     assert sizes_data.batch_shape[1] in (None, num_axes)  # also allow None...
     self.output.placeholder = tf_util.unflatten_nd(input_data.placeholder, sizes_data.placeholder, num_axes=num_axes)
-    self.output.size_placeholder = {i: sizes_data.placeholder[:, i] for i in range(num_axes)}
+    size_placeholder = {i: sizes_data.placeholder[:, i] for i in range(num_axes)}
     if declare_same_sizes_as:
       for i, other in declare_same_sizes_as.items():
         assert 0 <= i < num_axes
         other_dim_tag = other.output.get_size_dim_tag(0)
-        other_dim_tag.set_tag_on_size_tensor(self.output.size_placeholder[i])
+        other_dim_tag.set_tag_on_size_tensor(size_placeholder[i])
+    self.output.size_placeholder = size_placeholder
 
   def get_dep_layers(self):
     """

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1085,14 +1085,14 @@ class GatherLayer(_ConcatInputLayer):
     gather_axis = max(batch_dims, old_gather_axis)
 
     # (BatchAxes.., InputAxesBeforeGatherAxis, PositionAxes.., InputAxesAfterGatherAxis..)
-    shape = (
-      [input_data.batch_shape[ax] for ax in common_axes_input if ax != input_data.batch_dim_axis] +
-      [input_data.batch_shape[ax] for ax in input_axes[:gather_axis-batch_dims] if ax != input_data.batch_dim_axis] +
-      [position_data.batch_shape[ax] for ax in position_axes if ax != position_data.batch_dim_axis] +
-      [input_data.batch_shape[ax] for ax in input_axes[gather_axis-batch_dims:] if ax != input_data.batch_dim_axis])
+    dim_tags = (
+      [input_data.dim_tags[ax] for ax in common_axes_input] +
+      [input_data.dim_tags[ax] for ax in input_axes[:gather_axis-batch_dims]] +
+      [position_data.dim_tags[ax] for ax in position_axes] +
+      [input_data.dim_tags[ax] for ax in input_axes[gather_axis-batch_dims:]])
     out_type = input_data.get_kwargs()
     out_type["name"] = "%s_output" % name
-    out_type["shape"] = shape  # TODO...
+    out_type["dim_tags"] = dim_tags
     out_type["beam"] = SearchBeam.get_combined_beam(input_data.beam, position_data.beam)
     out_type["available_for_inference"] = input_data.available_for_inference and position_data.available_for_inference
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6329,8 +6329,9 @@ class CondLayer(LayerBase):
     :param LayerBase|dict[str] true_layer:
     :param LayerBase|dict[str] false_layer:
     """
-    super(CondLayer, self).__init__(**kwargs)
     import os
+    from ..util.data import DimensionTag
+    super(CondLayer, self).__init__(**kwargs)
     self._parent_scope = os.path.dirname(tf_compat.v1.get_variable_scope().name)
     self.condition_desc = condition
     self.condition_layer = self._make_layer("condition", self.condition_desc)
@@ -6349,8 +6350,10 @@ class CondLayer(LayerBase):
     for i, size in zip(sorted(self.output.size_placeholder.keys()), sizes):
       assert isinstance(size, tf.Tensor)
       assert size.shape.ndims == 1
-      # Note: Not quite clear what dimension-tag to set...
-      # TODO ...
+      old_size = self.output.size_placeholder[i]
+      old_tag = DimensionTag.get_tag_from_size_tensor(old_size)
+      assert old_tag
+      old_tag.set_tag_on_size_tensor(size)
       self.output.size_placeholder[i] = size
 
   def _cond_layer_return(self, layer):

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1896,7 +1896,7 @@ class RandIntLayer(LayerBase):
       if isinstance(s, int):
         shape_parsed.append(s)
       elif isinstance(s, DimensionTag):
-        if s.kind == DimensionTag.Types.Batch:
+        if s.is_batch_dim():
           shape_parsed.append(self.get_batch_dim())
         elif isinstance(s.dimension, int):
           shape_parsed.append(s.dimension)
@@ -1941,7 +1941,7 @@ class RandIntLayer(LayerBase):
         shape_parsed.append(s)
       else:
         assert isinstance(s, DimensionTag)
-        if s.kind == DimensionTag.Types.Batch:
+        if s.is_batch_dim():
           assert batch_dim_axis is None, "Cannot have multiple batch axes"
           batch_dim_axis = ax
         elif isinstance(s.dimension, int):
@@ -2654,9 +2654,9 @@ class MergeDimsLayer(_ConcatInputLayer):
     else:
       new_feature_dim_axis = cls._old_axis_to_new_axis(
         input_data=input_data, merge_axes=axes, old_axis=input_data.feature_dim_axis)
-    if any(tag.kind == DimensionTag.Types.Batch for tag in merge_dim_tags):
+    if any(tag.is_batch_dim() for tag in merge_dim_tags):
       res_dim_tag_kind = DimensionTag.Types.Batch
-    elif any(tag.kind == DimensionTag.Types.Feature for tag in merge_dim_tags):
+    elif any(tag.is_feature_dim() for tag in merge_dim_tags):
       res_dim_tag_kind = DimensionTag.Types.Feature
     else:
       res_dim_tag_kind = DimensionTag.Types.Spatial

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2082,12 +2082,17 @@ class RangeInAxisLayer(LayerBase):
     else:
       data_opts = source.get_kwargs(include_special_axes=False)
       dim_tags = [source.dim_tags[axis]]
+      if not dim_tags[0].is_batch_dim():
+        data_opts.pop("batch", None)
+        data_opts.pop("beam", None)
     data_opts["name"] = "%s_output" % name
     data_opts["dim_tags"] = dim_tags
     data_opts["dtype"] = dtype
     data_opts["sparse"] = sparse
     if sparse:
       data_opts["dim"] = None
+    else:
+      data_opts.pop("dim", None)
     return Data(**data_opts)
 
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2470,8 +2470,6 @@ class PadLayer(_ConcatInputLayer):
     padding = cls._transform_padding(padding=padding, axes=axes)
     dim_tags = data.dim_tags
     for i, a in enumerate(axes):
-      if data.shape[a] is None:
-        continue
       tag = dim_tags[a]
       dim = None if tag.dimension is None else (tag.dimension + sum(padding[i]))
       tag = DimensionTag(kind=tag.kind, description="%s_pad%i" % (name, i), dimension=dim)

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1227,7 +1227,7 @@ class GatherNdLayer(_ConcatInputLayer):
     shape = list(position_data.shape) + list(input_data.shape[1:])  # (B, ...) (w/o batch)
     out_type = position_data.get_kwargs()
     out_type["name"] = "%s_output" % name
-    out_type["shape"] = shape
+    out_type["shape"] = shape  # TODO ...
     if position_data.time_dim_axis is None:
       if input_data.time_dim_axis is not None and input_data.time_dim_axis_excluding_batch >= 1:
         out_type["time_dim_axis"] = len(shape) + input_data.time_dim_axis_excluding_batch - 1

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2280,7 +2280,8 @@ class WindowLayer(_ConcatInputLayer):
             filter_size=window_size, stride=stride, dilation_rate=1, padding=padding)
         DimensionTag(
           kind=DimensionTag.Types.Spatial, description="%s:window:%i" % (self.name, axis_wo_b),
-          dimension=None, dyn_size=size)
+          dimension=None, dyn_size=size, batch=self.output.batch,
+          src_data=self.output, src_axis=axis)
         self.output.size_placeholder[axis_wo_b] = size
 
   @classmethod
@@ -5621,7 +5622,10 @@ class ShiftAxisLayer(_ConcatInputLayer):
       new_size = tf.clip_by_value(
         self.output.size_placeholder[axis_wob] + size_delta, 0, tf.shape(shifted)[axis])
       from ..util.data import DimensionTag
-      DimensionTag(kind=DimensionTag.Types.Spatial, description="shift_axis", dyn_size=new_size)
+      DimensionTag(
+        kind=DimensionTag.Types.Spatial, description="shift_axis",
+        dyn_size=new_size, batch=self.output.batch,
+        src_data=self.output, src_axis=axis)
       self.output.size_placeholder[axis_wob] = new_size
 
   @classmethod

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4274,7 +4274,7 @@ class TransposedConvLayer(_ConcatInputLayer):
     :param dict[str,str]|None filter_perm: transposes the filter (input filter as layer)
     :param LayerBase|None bias: if given, will not create an own parameter, but use this as the bias
     """
-    from returnn.tf.util.basic import DimensionTag, get_initializer, get_activation_function, get_shape
+    from returnn.tf.util.basic import get_initializer, get_activation_function, get_shape
     super(TransposedConvLayer, self).__init__(**kwargs)
     input_data = self.input_data.copy_as_batch_spatial_major()
     spatial_axes = input_data.get_spatial_axes()

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2059,7 +2059,9 @@ class RangeInAxisLayer(LayerBase):
     self.output.placeholder = out
 
   @classmethod
-  def get_out_data_from_opts(cls, name, sources, axis, dtype="int32", unbroadcast=False, keepdims=True, sparse=False, **kwargs):
+  def get_out_data_from_opts(cls,
+                             name, sources, axis, dtype="int32", unbroadcast=False, keepdims=True, sparse=False,
+                             **kwargs):
     """
     :param str name:
     :param list[LayerBase] sources:

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2678,6 +2678,13 @@ class MergeDimsLayer(_ConcatInputLayer):
     data_opts["feature_dim_axis"] = new_feature_dim_axis
     data = Data(**data_opts)
 
+    data.time_dim_axis = cls._old_axis_to_new_axis(
+      input_data=input_data, merge_axes=axes, old_axis=input_data.time_dim_axis)
+    if data.time_dim_axis is not None and data.time_dim_axis in {data.batch_dim_axis, data.feature_dim_axis}:
+      if input_data.time_dim_axis not in {input_data.batch_dim_axis, input_data.feature_dim_axis}:
+        # Time got merged with feature or batch.
+        data.time_dim_axis = None
+
     if input_data.batch_dim_axis in axes and data.batch:
       for axis in axes:
         if axis != input_data.batch_dim_axis:

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2086,6 +2086,8 @@ class RangeInAxisLayer(LayerBase):
     data_opts["dim_tags"] = dim_tags
     data_opts["dtype"] = dtype
     data_opts["sparse"] = sparse
+    if sparse:
+      data_opts["dim"] = None
     return Data(**data_opts)
 
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5907,7 +5907,10 @@ class CombineLayer(LayerBase):
     """
     out_type_ = {}
     if sources:
-      out_type_.update(Data.get_common_data([s.output for s in sources], warnings_out=log.v4).get_kwargs())
+      out_type_.update(
+        Data.get_common_data(
+          [s.output for s in sources], warnings_out=log.v4)
+        .get_kwargs(include_special_axes=False))
     if n_out is not NotSpecified:
       out_type_["dim"] = n_out
     out_type_["name"] = "%s_output" % kwargs["name"]

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6261,14 +6261,14 @@ class SwitchLayer(LayerBase):
       :rtype: Data
       """
       if isinstance(source, LayerBase):
-        return source.output.copy(source_name)
+        return source.output.copy_template(source_name)
       return Data.template_from_constant(source, name=source_name)
 
     if isinstance(condition, bool):
       return get_source_template(true_from if condition else false_from, source_name="%s_output" % name)
     true_data = get_source_template(true_from, source_name="%s_true" % name)
     false_data = get_source_template(false_from, source_name="%s_false" % name)
-    out = Data.get_common_data([true_data, false_data, condition.output])
+    out = Data.get_common_data([true_data, false_data, condition.output.copy_template()])
     out.dtype = true_data.dtype
     out.sparse = true_data.sparse
     if out.feature_dim_axis is not None:
@@ -6276,6 +6276,7 @@ class SwitchLayer(LayerBase):
     else:
       out.dim = true_data.dim
     out.vocab = true_data.vocab
+    out.sanity_check()
     return out.copy(name="%s_output" % name)
 
   def get_dep_layers(self):

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2979,7 +2979,10 @@ class SplitDimsLayer(_ConcatInputLayer):
       if i != rem_dim_idx else rem_dim
       for i in range(len(dims)))
     new_dim_tags = data.dim_tags[:axis] + resolved_dims + data.dim_tags[axis + 1:]
-    return data.copy_template_new_dim_tags(new_dim_tags)
+    out = data.copy_template_new_dim_tags(new_dim_tags)
+    if data.time_dim_axis is None:
+      out.time_dim_axis = None
+    return out
 
 
 class SplitBatchTimeLayer(_ConcatInputLayer):

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -6152,6 +6152,7 @@ class SelfAttentionLayer(_ConcatInputLayer):
     assert sources
     import numpy
     out = sources[0].output.copy_as_batch_major().copy(name="%s_output" % name)
+    batch_dim_tag = out.dim_tags[out.batch_dim_axis]
     feat_tag = DimensionTag(kind=DimensionTag.Types.Feature, description="%s_self_att_feat" % name, dimension=n_out)
     if len(out.shape_dense) >= 2:
       if all(out.shape_dense[:-1]):
@@ -6160,15 +6161,16 @@ class SelfAttentionLayer(_ConcatInputLayer):
         time_dim = None
       time_tag = DimensionTag(
         kind=DimensionTag.Types.Spatial, description="%s_self_att_time" % name, dimension=time_dim)
-      dim_tags = (time_tag, feat_tag)
+      dim_tags = (batch_dim_tag, time_tag, feat_tag)
     else:
-      dim_tags = (feat_tag,)
+      dim_tags = (batch_dim_tag, feat_tag)
     data_opts = out.get_kwargs(include_special_axes=False)
     data_opts["dim_tags"] = dim_tags
     data_opts["dtype"] = "float32"
     data_opts.pop("sparse", None)
     data_opts.pop("vocab", None)
-    return out
+    data_opts.pop("dim", None)
+    return Data(**data_opts)
 
   # noinspection PyMethodOverriding
   @classmethod

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3234,6 +3234,8 @@ class _SubnetworkRecCell(object):
                   size, axis=0,
                   multiples=tf.shape(output.size_placeholder[0])[0] // tf.shape(size)[0])
                 size._RETURNN_dyn_size_beam = output.beam
+                if tag:
+                  tag.set_tag_on_size_tensor(size)
               output.size_placeholder[i + 1] = size
         assert isinstance(self.output_layers_net, TFNetwork)
         layer_ = self.output_layers_net.add_layer(

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3202,6 +3202,8 @@ class _SubnetworkRecCell(object):
           output.beam = None
         if output.beam:
           resolved_seq_len._RETURNN_dyn_size_beam = output.beam
+        if time_dim_tag:
+          time_dim_tag.set_tag_on_size_tensor(resolved_seq_len)
         max_len = tf.reduce_max(resolved_seq_len)
         # We should have accumulated it.
         output.placeholder = tensor_array_stack(acc_ta, stop=max_len)  # e.g. (time,batch,dim)
@@ -3214,9 +3216,9 @@ class _SubnetworkRecCell(object):
               size = tile_transposed(
                 seq_len, axis=0, multiples=output.beam.beam_size // self.parent_rec_layer.output.beam.beam_size)
               size._RETURNN_dyn_size_beam = output.beam
+              if time_dim_tag:
+                time_dim_tag.set_tag_on_size_tensor(size)
               output.size_placeholder[0] = size
-        if time_dim_tag:
-          time_dim_tag.set_tag_on_size_tensor(output.size_placeholder[0])
         if inner_layer.output.size_placeholder:
           for i, size in inner_layer.output.size_placeholder.items():
             tag = DimensionTag.get_tag_from_size_tensor(size)

--- a/returnn/tf/layers/signal_processing.py
+++ b/returnn/tf/layers/signal_processing.py
@@ -456,7 +456,10 @@ class MultiChannelMultiResolutionStftLayer(_ConcatInputLayer):
         nf_of_paded_frames = 1
       new_size = nr_of_full_frames + nf_of_paded_frames
       from ..util.data import DimensionTag
-      DimensionTag(kind=DimensionTag.Types.Spatial, description="MultiChannelMultiResolutionStft", dyn_size=new_size)
+      DimensionTag(
+        kind=DimensionTag.Types.Spatial, description="MultiChannelMultiResolutionStft",
+        dyn_size=new_size, batch=self.output.batch,
+        src_data=self.output, src_axis=self.output.get_batch_axis(0))
       size_placeholder_dict[0] = new_size
       return size_placeholder_dict
 

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -149,6 +149,8 @@ class ExternData(object):
       if not data.batch:
         data.batch = batch_info
       for tag in data.dim_tags:
+        if tag.is_batch_dim() and not tag.batch:
+          tag.batch = batch_info
         if tag.dyn_size_ext and tag.dyn_size_ext.have_batch_axis():
           if not tag.dyn_size_ext.batch:
             tag.dyn_size_ext.batch = batch_info

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -148,6 +148,12 @@ class ExternData(object):
     for data in self.data.values():
       if not data.batch:
         data.batch = batch_info
+      for tag in data.dim_tags:
+        if tag.dyn_size_ext and tag.dyn_size_ext.have_batch_axis():
+          if not tag.dyn_size_ext.batch:
+            tag.dyn_size_ext.batch = batch_info
+          if not tag.batch:
+            tag.batch = batch_info
 
   def check_matched_dataset(self, dataset, used_data_keys=None):
     """

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -2152,13 +2152,19 @@ class Data(object):
       dimension=new_dim, dyn_size=new_size)
     return self.copy_template_replace_dim_tag(axis=axis, new_dim_tag=dim_tag)
 
-  def copy_template_new_dim_tags(self, new_dim_tags):
+  def copy_template_new_dim_tags(self, new_dim_tags, name=None, keep_special_axes=False):
     """
     :param list[DimensionTag]|tuple[DimensionTag] new_dim_tags:
+    :param str|None name:
+    :param bool keep_special_axes:
     :rtype: Data
     """
-    opts = self.get_kwargs(include_special_axes=False)
+    if keep_special_axes:
+      assert len(new_dim_tags) == self.batch_ndim
+    opts = self.get_kwargs(include_special_axes=keep_special_axes)
     opts["dim_tags"] = new_dim_tags
+    if name:
+      opts["name"] = name
     return Data(**opts)
 
   def _get_variable_dim_pattern(self):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -2100,11 +2100,9 @@ class Data(object):
       kwargs.pop("dim", None)
     other_special_axes = self.get_special_axes_dict(counted_with_batch_dim=True, only_available=True)
     for axis_name, axis in other_special_axes.items():
-      assert axis_name in kwargs
       if axis == exclude_axis:
-        del kwargs[axis_name]
-      else:
-        kwargs[axis_name] = axis if (axis < exclude_axis) else (axis - 1)
+        continue
+      kwargs[axis_name] = axis if (axis < exclude_axis) else (axis - 1)
     new_dim_tags = list(self.dim_tags)
     del new_dim_tags[exclude_axis]
     kwargs["dim_tags"] = new_dim_tags

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3686,12 +3686,13 @@ def _default_time_dim_axis_dim_tags(dim_tags):
   :return: time dim axis, counted with batch-dim
   :rtype: int|None
   """
+  # Consistent to _default_time_dim_axis.
+  # Any spatial dynamic axis.
+  # Or otherwise any dynamic axis (including maybe feature).
+  # Not using any static axes.
   dim_tags_dyn_spatial = [i for i, tag in enumerate(dim_tags) if tag.is_spatial_dim() and tag.dyn_size_ext]
   if dim_tags_dyn_spatial:
     return dim_tags_dyn_spatial[0]
-  dim_tags_spatial = [i for i, tag in enumerate(dim_tags) if tag.is_spatial_dim()]
-  if dim_tags_spatial:
-    return dim_tags_spatial[0]
   dim_tags_dyn = [i for i, tag in enumerate(dim_tags) if not tag.is_batch_dim() and tag.dyn_size_ext]
   if dim_tags_dyn:
     return dim_tags_dyn[0]

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1674,7 +1674,7 @@ class Data(object):
       placeholder = tf.expand_dims(self.placeholder, batch_dim_axis, name="%s_add_batch_dim" % self.name)
       if not isinstance(batch.dim, int) or batch.dim != 1:
         tiles = [1] * batch_dim_axis + [batch.dim] + [1] * (self.batch_ndim - batch_dim_axis)
-        placeholder = tf.tile(data_opts["placeholder"], tiles)
+        placeholder = tf.tile(placeholder, tiles)
     dim_tags = list(self.dim_tags)
     if dim_tag:
       assert dim_tag.kind == DimensionTag.Types.Batch

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -72,14 +72,16 @@ class DimensionTag(object):
     :return: some short repr
     :rtype: str
     """
+    if self.is_batch_dim():
+      return "B"
     desc = repr(self.description)
     if self.dimension is not None:
       desc += "(%i)" % self.dimension
     else:
       if self.dyn_size_ext:
-        desc += "_[%s]" % ",".join(self.dyn_size_ext.get_batch_axes_short_description())
+        desc += "[%s]" % ",".join(self.dyn_size_ext.get_batch_axes_short_description())
       else:
-        desc += "_[?]"
+        desc += "[?]"
     return desc
 
   def copy(self, kind=None):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -11,7 +11,7 @@ import os
 import typing
 import tensorflow as tf
 
-from returnn.util.basic import NotSpecified, BehaviorVersion
+from returnn.util.basic import NotSpecified
 import returnn.tf.compat as tf_compat
 
 

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -74,12 +74,13 @@ class DimensionTag(object):
     """
     if self.is_batch_dim():
       return "B"
-    desc = "%s%r" % ("F" if self.is_feature_dim() else "", self.description)
+    desc = "%s%r" % ("F" if self.is_feature_dim() else "", self.get_same_base().description)
     if self.dimension is not None:
       desc += "(%i)" % self.dimension
     else:
-      if self.dyn_size_ext:
-        desc += "[%s]" % ",".join(self.dyn_size_ext.get_batch_axes_short_description())
+      dyn_size_ext = self.dyn_size_ext or self.get_same_base().dyn_size_ext
+      if dyn_size_ext:
+        desc += "[%s]" % ",".join(dyn_size_ext.get_batch_axes_short_description())
       else:
         desc += "[?]"
     return desc

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -2259,11 +2259,9 @@ class Data(object):
     """
     :param tuple[int|None] shape:
     """
-    # BehaviorVersion.require(
-    #  False, "Data.shape assign not allowed. Use XXX instead...", version=2)
-    # TODO not sure what to do
-    raise Exception("%s: set shape... %s" % (self, shape))
-    # _infer_dim_tags_tuple_from_shape()
+    if tuple(shape) == self.shape:
+      return
+    raise Exception("%s: setting the shape is not allowed (new shape %s)" % (self, shape))
 
   @property
   def batch_shape(self):
@@ -2303,8 +2301,6 @@ class Data(object):
     """
     :param dict[int,tf.Tensor]|None sizes:
     """
-    #  self._dynamic_sizes.clear()  # TODO does not make sense anymore
-    # BehaviorVersion.require(False, "XXX", version=2)  # TODO should we have this?
     if sizes is None:
       return
     for axis_wo_b, size in sizes.items():
@@ -2416,7 +2412,6 @@ class Data(object):
     """
     if axis == self.batch_dim_axis:
       return
-    # TODO, not sure how to handle this... for new code, not needed. but compatibility for old code?
     raise Exception("%s: cannot set batch_dim_axis = %s" % (self, axis))
 
   def _default_feature_dim_axis(self):
@@ -2890,14 +2885,6 @@ class Data(object):
       assert sizes_tag, "%s: assign dyn sizes %s without defined dim tag" % (self, sizes)
       self._dim_tags = self.dim_tags[:axis] + (sizes_tag,) + self.dim_tags[axis + 1:]
 
-  def del_dynamic_size(self, axis):
-    """
-    :param int axis: counted with batch-dim axis. :func:`is_axis_dynamic` should be True
-    """
-    # TODO disallow now? doesnt make sense?
-    # del self._dynamic_sizes[axis]
-    pass
-
   def get_dynamic_axes(self):
     """
     :return: list of axes, counted with batch-dim axis (but we exclude the batch dim axis itself)
@@ -3367,7 +3354,7 @@ class _SizePlaceholderProxy:
 
   def __delitem__(self, key):
     self._assert_sane_axis_wo_batch(key)
-    self.data.del_dynamic_size(axis=self.data.get_batch_axis(key))
+    raise Exception("%s: cannot delete items from size_placeholder" % self.data)
 
   def __iter__(self):
     return iter(self.keys())
@@ -3408,8 +3395,7 @@ class _SizePlaceholderProxy:
     """
     Remove all.
     """
-    for key in self.keys():
-      del self[key]
+    raise Exception("%s: cannot clear size_placeholder" % self.data)
 
   def keys(self):
     """

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1820,7 +1820,7 @@ class Data(object):
         return self.copy_add_batch_dim(
           batch_dim_axis=axis, batch=batch_info, dim_tag=dim_tag if dim_tag.dimension == 1 else None)
 
-    data_opts = self.get_kwargs(include_special_axes=False)
+    data_opts = self.get_kwargs()
     # Note: if dim_tag is feature, but we are sparse, we just make it spatial
     if self.sparse and dim_tag.kind == DimensionTag.Types.Feature:
       dim_tag = dim_tag.copy(kind=DimensionTag.Types.Spatial)

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1998,9 +1998,9 @@ class Data(object):
         with same_control_flow_ctx(v):
           sizes = tile_transposed(v, axis=0, multiples=beam.beam_size)
         sizes._RETURNN_dyn_size_beam = beam
-        data.size_placeholder[i] = sizes
         if tag is not None:
           tag.set_tag_on_size_tensor(sizes)
+        data.size_placeholder[i] = sizes
       if data.batch:
         data.batch = data.batch.copy_set_beam(beam)
       data.beam = beam

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1173,7 +1173,7 @@ class Data(object):
     if placeholder is None and auto_create_placeholders:
       with tf.name_scope("extern_data/placeholders/%s/" % name):
         placeholder = tf_compat.v1.placeholder(**self.get_placeholder_kwargs(with_batch=True))
-    self.placeholder = placeholder  # type: tf.Tensor  # this will hold the data value itself
+    self._placeholder = placeholder  # type: tf.Tensor  # this will hold the data value itself
     # The size_placeholder is for each variable length dimension in shape, i.e. excluding the batch-dim.
     if size_placeholder:
       self.size_placeholder = size_placeholder  # type: typing.Dict[int,tf.Tensor]  # axis w.o. batch -> size (batch,)
@@ -2415,6 +2415,21 @@ class Data(object):
     if self.time_dim_axis is None:
       return None
     return self.get_batch_axis_excluding_batch(self.time_dim_axis)
+
+  @property
+  def placeholder(self):
+    """
+    :rtype: tf.Tensor|None
+    """
+    return self._placeholder
+
+  @placeholder.setter
+  def placeholder(self, value):
+    """
+    :param tf.Tensor|None value:
+    """
+    self._placeholder = value
+    self.sanity_check()
 
   def time_dimension(self):
     """

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -65,14 +65,7 @@ class DimensionTag(object):
       self.dyn_size = dyn_size
 
   def __repr__(self):
-    attribs = ["kind"]
-    for attr in ["description", "dimension"]:
-      if getattr(self, attr) is not None:
-        attribs.append(attr)
-    attribs.append("id")
-    if self.same_as:
-      attribs.append("same_base_id")
-    return "DimensionTag(%s)" % ", ".join(["%s=%r" % (attr, getattr(self, attr)) for attr in attribs])
+    return "DimensionTag{%s}" % self.short_repr()
 
   def short_repr(self):
     """

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1218,15 +1218,12 @@ class Data(object):
       assert self.dim == vocab.num_labels, "%s dims do not match with vocab %s" % (self, vocab)
     self.vocab = vocab  # type: typing.Optional[Vocabulary]
     if same_dim_tags_as:
-      # Note that this currently does not work as intended at template construction time...
       for _axis, _dim_tag in sorted(same_dim_tags_as.items()):
         _axis = self.get_axis_from_description(_axis)
         assert isinstance(_dim_tag, DimensionTag)
         base_tag = self._dim_tags[_axis]
         if base_tag != _dim_tag:
-          base_tag.declare_same_as(_dim_tag)  # TODO or other way around?
-          # Overtake the given dim tag.
-          # self._dim_tags[_axis] = _dim_tag  # TODO ?
+          base_tag.declare_same_as(_dim_tag)
           if _dim_tag.dyn_size is not None:
             self.set_dynamic_size(_axis, _dim_tag.dyn_size)
     self.sanity_check(assume_complete=False)

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1469,9 +1469,7 @@ class Data(object):
         else:
           descriptions.append(dim_tag.short_repr())
       elif axis != self.batch_dim_axis or not self.batch:
-        descriptions.append(str(self.batch_shape[axis]))
-        if dim_tag.kind == DimensionTag.Types.Spatial and dim_tag.dyn_size is not None:
-          descriptions.append(dim_tag.short_repr())
+        descriptions.append(dim_tag.short_repr())
       res.append("|".join(descriptions))
     return res
 

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3524,10 +3524,15 @@ def _infer_dim_tags_tuple_from_shape(
         dyn_size = tf_compat.v1.placeholder(
           name="%s_dim%i_size" % (name, axis_wo_b), dtype=Data.size_dtype, shape=(None,))
         if not tag:
+          if axis == time_dim_axis:
+            tag_name = "time"
+          elif axis == feature_dim_axis:
+            tag_name = "feature"
+          else:
+            tag_name = "spatial%i" % axis
           tag = DimensionTag(
-            description="%s:var:extern_data:%s" % (
-              "time" if axis == time_dim_axis else "spatial%i" % axis, name),
-            kind=DimensionTag.Types.Spatial)
+            description="%s:var:extern_data:%s" % (tag_name, name),
+            kind=DimensionTag.Types.Feature if axis == feature_dim_axis else DimensionTag.Types.Spatial)
           dim_tags[axis] = tag
         tag.set_tag_on_size_tensor(dyn_size)
     if tag:

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3690,10 +3690,10 @@ def _default_time_dim_axis_dim_tags(dim_tags):
   # Any spatial dynamic axis.
   # Or otherwise any dynamic axis (including maybe feature).
   # Not using any static axes.
-  dim_tags_dyn_spatial = [i for i, tag in enumerate(dim_tags) if tag.is_spatial_dim() and tag.dyn_size_ext]
+  dim_tags_dyn_spatial = [i for i, tag in enumerate(dim_tags) if tag.is_spatial_dim() and tag.dimension is None]
   if dim_tags_dyn_spatial:
     return dim_tags_dyn_spatial[0]
-  dim_tags_dyn = [i for i, tag in enumerate(dim_tags) if not tag.is_batch_dim() and tag.dyn_size_ext]
+  dim_tags_dyn = [i for i, tag in enumerate(dim_tags) if not tag.is_batch_dim() and tag.dimension is None]
   if dim_tags_dyn:
     return dim_tags_dyn[0]
   return None

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -2152,6 +2152,15 @@ class Data(object):
       dimension=new_dim, dyn_size=new_size)
     return self.copy_template_replace_dim_tag(axis=axis, new_dim_tag=dim_tag)
 
+  def copy_template_new_dim_tags(self, new_dim_tags):
+    """
+    :param list[DimensionTag]|tuple[DimensionTag] new_dim_tags:
+    :rtype: Data
+    """
+    opts = self.get_kwargs(include_special_axes=False)
+    opts["dim_tags"] = new_dim_tags
+    return Data(**opts)
+
   def _get_variable_dim_pattern(self):
     """
     :return: tuple with bools specifying which dims of the shape (excluding batch-dim) are of variable length.
@@ -2198,9 +2207,8 @@ class Data(object):
     # BehaviorVersion.require(
     #  False, "Data.shape assign not allowed. Use XXX instead...", version=2)
     # TODO not sure what to do
-    #  use _infer_dim_tags ... ?
-    # raise Exception("%s: set shape...")
-    _infer_dim_tags_tuple_from_shape()
+    raise Exception("%s: set shape... %s" % (self, shape))
+    # _infer_dim_tags_tuple_from_shape()
 
   @property
   def batch_shape(self):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -74,7 +74,7 @@ class DimensionTag(object):
     """
     if self.is_batch_dim():
       return "B"
-    desc = repr(self.description)
+    desc = "%s%r" % ("F" if self.is_feature_dim() else "", self.description)
     if self.dimension is not None:
       desc += "(%i)" % self.dimension
     else:

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -118,6 +118,20 @@ class DimensionTag(object):
     else:
       self.set_tag_on_size_tensor(dyn_size)
 
+  def is_batch_dim(self):
+    """
+    :return: whether this dim tag is of kind batch
+    :rtype: bool
+    """
+    return self.kind == DimensionTag.Types.Batch
+
+  def is_feature_dim(self):
+    """
+    :return: whether this dim tag is of kind feature
+    :rtype: bool
+    """
+    return self.kind == DimensionTag.Types.Feature
+
   def set_tag_on_size_tensor(self, x):
     """
     :param tf.Tensor x:

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -78,9 +78,8 @@ class DimensionTag(object):
     if self.dimension is not None:
       desc += "(%i)" % self.dimension
     else:
-      dyn_size_ext = self.dyn_size_ext or self.get_same_base().dyn_size_ext
-      if dyn_size_ext:
-        desc += "[%s]" % ",".join(dyn_size_ext.get_batch_axes_short_description())
+      if self.dyn_size_ext:
+        desc += "[%s]" % ",".join(self.dyn_size_ext.get_batch_axes_short_description())
       else:
         desc += "[?]"
     return desc
@@ -340,6 +339,8 @@ class DimensionTag(object):
       # This is important such that self.can_compare() is sane.
       if self.same_as.dyn_size is None or self.same_as.dyn_size.graph is not self.dyn_size.graph:
         self.same_as.dyn_size_ext = self.dyn_size_ext
+    if not self.dyn_size_ext and other.dyn_size_ext:
+      self.dyn_size_ext = other.dyn_size_ext.copy()
 
   @classmethod
   def get_existing_tag_from_collection(cls, other, tags, is_equal_opts=None):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3168,15 +3168,6 @@ class Data(object):
     axis_wo_batch = sorted(self.size_placeholder.keys())[number]
     return self.get_dim_tag(self.get_batch_axis(axis_wo_batch))
 
-  def set_dim_tag(self, axis, tag):
-    """
-    :param int axis: counted with batch-dim
-    :param DimensionTag tag:
-    """
-    # TODO ... disallow?
-    # self._dim_tags[axis] = tag
-    raise Exception("Not allowed...")  # TODO..
-
   def get_batch_shape_dim_tags(self):
     """
     :return: list of dimension tags, for each axis (counted with batch dim, i.e. len is batch_ndim)


### PR DESCRIPTION
Follow-up from #577. Needed for #391.

This introduces the `dim_tags` argument and attribute for `Data`.

This disallows `Data.shape` and `Data.batch_dim_axis` assignments.

Much `Data` util code got adapted to consistently make use of dim tags.
Many layers got adapted to not operate on the shape but on dim tags instead.
