### PR TITLE
fixes for uncommon network flags

### DIFF
--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3287,10 +3287,6 @@ class _SubnetworkRecCell(object):
         return self._get_parent_layer(name[len("base:"):])
       if name in self.input_layers_moved_out:
         return self.input_layers_net.get_layer(name)
-      if name not in self.layer_data_templates:
-        raise LayerNotFound(
-          "layer not found: %s/%s" % (self.output_layers_net, name),
-          layer_name=name, network=self.output_layers_net)
       if name in self.output_layers_moved_out or name.startswith("data:") or name == "data":
         # noinspection PyBroadException
         try:
@@ -3299,6 +3295,10 @@ class _SubnetworkRecCell(object):
           print("Exception occurred during output-net construction of layer %r." % name)
           self._handle_construct_exception()
           raise
+      if name not in self.layer_data_templates:
+        raise LayerNotFound(
+          "layer not found: %s/%s" % (self.output_layers_net, name),
+          layer_name=name, network=self.output_layers_net)
       # It means that the layer is inside the loop.
       return get_loop_acc_layer(name)
 

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -2261,7 +2261,7 @@ class _SubnetworkRecCell(object):
             assert isinstance(layer, LayerBase)
             if layer_name == "output":
               assert layer.output.have_time_axis()
-              assert rec_layer.output.is_same_time_dim(layer.output)
+              assert layer.output.get_time_dim_tag() in self._time_dim_tags
             # Only unroll if that is the same time dim.
             if not layer.output.mark_same_time(self._time_dim_tags):
               continue


### PR DESCRIPTION
Now that I wanted to continue on fixing the `tf_compile_graph.py` tool, I found out that even my "basic" test case is not working after the recent updates. I wrote a specific engine test case that replicates the error.

The error only appears when no flag (e.g. train or search) is set, otherwise plenty of other tests would fail.

This is the error:

```python3
  File "/home/nick/env/tf25/lib/python3.9/site-packages/nose/case.py", line 198, in TestBase.runTest
    line: self.test(*self.arg)
    locals:
      self = <local> test_TFEngine.test_engine_create_network
      self.test = <local> <function test_engine_create_network at 0x7f5927e750d0>
      self.arg = <local> ()
  File "/home/nick/github/returnn/tests/test_TFEngine.py", line 253, in test_engine_create_network
    line: engine.create_network(
            config=config, rnd_seed=0, train_flag=False, eval_flag=False, search_flag=False,
            net_dict=config.typed_dict['network'])
    locals:
      engine = <local> <returnn.tf.engine.Engine object at 0x7f5927e6ee50>
      engine.create_network = <local> <bound method Engine.create_network of <class 'returnn.tf.engine.Engine'>>
      config = <local> <returnn.config.Config object at 0x7f5927e6ec40>
      rnd_seed = <not found>
      train_flag = <not found>
      eval_flag = <not found>
      search_flag = <not found>
      net_dict = <not found>
      config.typed_dict = <local> {'model': '/tmp/tmp9ocicmsu/model', 'num_outputs': 3, 'num_inputs': 2, 'network': {'enc0': {'class': 'linear', 'from': 'data', 'activation': 'sigmoid', 'n_out': 3}, 'output': {'class': 'rec', 'from': [], 'target': 'classes', 'unit': {'embed': {'class': 'linear', 'from': 'prev:output', 'activation..., len = 7
  File "/home/nick/github/returnn/returnn/tf/engine.py", line 1316, in Engine.create_network
    line: network.construct_from_dict(net_dict)
    locals:
      network = <local> <TFNetwork 'root' train=False>
      network.construct_from_dict = <local> <bound method TFNetwork.construct_from_dict of <TFNetwork 'root' train=False>>
      net_dict = <local> {'enc0': {'class': 'linear', 'from': 'data', 'activation': 'sigmoid', 'n_out': 3}, 'output': {'class': 'rec', 'from': [], 'target': 'classes', 'unit': {'embed': {'class': 'linear', 'from': 'prev:output', 'activation': 'sigmoid', 'n_out': 3}, 'prob': {'class': 'softmax', 'from': ['embed', 'base:en...
  File "/home/nick/github/returnn/returnn/tf/network.py", line 602, in TFNetwork.construct_from_dict
    line: self.construct_layer(net_dict, name, get_layer=get_layer)
    locals:
      self = <local> <TFNetwork 'root' train=False>
      self.construct_layer = <local> <bound method TFNetwork.construct_layer of <TFNetwork 'root' train=False>>
      net_dict = <local> {'enc0': {'class': 'linear', 'from': 'data', 'activation': 'sigmoid', 'n_out': 3}, 'output': {'class': 'rec', 'from': [], 'target': 'classes', 'unit': {'embed': {'class': 'linear', 'from': 'prev:output', 'activation': 'sigmoid', 'n_out': 3}, 'prob': {'class': 'softmax', 'from': ['embed', 'base:en...
      name = <local> 'output', len = 6
      get_layer = <local> None
  File "/home/nick/github/returnn/returnn/tf/network.py", line 928, in TFNetwork.construct_layer
    line: return add_layer(name=name_with_prefix, layer_class=layer_class, **layer_desc)
    locals:
      add_layer = <local> <bound method TFNetwork.add_layer of <TFNetwork 'root' train=False>>
      name = <local> 'output', len = 6
      name_with_prefix = <local> 'output', len = 6
      layer_class = <local> <class 'returnn.tf.layers.rec.RecLayer'>
      layer_desc = <local> {'target': 'classes', '_network': <TFNetwork 'root' train=False>, '_name': 'output', 'n_out': <class 'returnn.util.basic.NotSpecified'>, 'sources': [], '_time_dim_tag': DimensionTag{'dyn-time:output'[?]}, 'unit': <_SubnetworkRecCell 'root/output(rec-subnet)'>}, len = 7
  File "/home/nick/github/returnn/returnn/tf/network.py", line 1074, in TFNetwork.add_layer
    line: layer = self._create_layer(name=name, layer_class=layer_class, **layer_desc)
    locals:
      layer = <not found>
      self = <local> <TFNetwork 'root' train=False>
      self._create_layer = <local> <bound method TFNetwork._create_layer of <TFNetwork 'root' train=False>>
      name = <local> 'output', len = 6
      layer_class = <local> <class 'returnn.tf.layers.rec.RecLayer'>
      layer_desc = <local> {'target': 'classes', '_network': <TFNetwork 'root' train=False>, '_name': 'output', 'n_out': <class 'returnn.util.basic.NotSpecified'>, 'sources': [], '_time_dim_tag': DimensionTag{'dyn-time:output'[?]}, 'unit': <_SubnetworkRecCell 'root/output(rec-subnet)'>}, len = 7
  File "/home/nick/github/returnn/returnn/tf/network.py", line 995, in TFNetwork._create_layer
    line: layer = layer_class(**layer_desc)
    locals:
      layer = <not found>
      layer_class = <local> <class 'returnn.tf.layers.rec.RecLayer'>
      layer_desc = <local> {'target': 'classes', '_network': <TFNetwork 'root' train=False>, '_name': 'output', 'n_out': <class 'returnn.util.basic.NotSpecified'>, 'sources': [], '_time_dim_tag': DimensionTag{'dyn-time:output'[?]}, 'unit': <_SubnetworkRecCell 'root/output(rec-subnet)'>, 'name': 'output', 'network': <TFNetw..., len = 10
  File "/home/nick/github/returnn/returnn/tf/layers/rec.py", line 238, in RecLayer.__init__
    line: y = self._get_output_subnet_unit(self.cell)
    locals:
      y = <not found>
      self = <local> <RecLayer 'output' out_type=Data{[T|'dyn-time:output'[?],B], dtype='int32', sparse=True, dim=3}>
      self._get_output_subnet_unit = <local> <bound method RecLayer._get_output_subnet_unit of <RecLayer 'output' out_type=Data{[T|'dyn-time:output'[?],B], dtype='int32', sparse=True, dim=3}>>
      self.cell = <local> <_SubnetworkRecCell 'root/output(rec-subnet)'>
  File "/home/nick/github/returnn/returnn/tf/layers/rec.py", line 925, in RecLayer._get_output_subnet_unit
    line: output = cell.get_output()
    locals:
      output = <not found>
      cell = <local> <_SubnetworkRecCell 'root/output(rec-subnet)'>
      cell.get_output = <local> <bound method _SubnetworkRecCell.get_output of <_SubnetworkRecCell 'root/output(rec-subnet)'>>
  File "/home/nick/github/returnn/returnn/tf/layers/rec.py", line 2266, in _SubnetworkRecCell.get_output
    line: assert rec_layer.output.is_same_time_dim(layer.output)
    locals:
      rec_layer = <local> <RecLayer 'output' out_type=Data{[T|'dyn-time:output'[?],B], dtype='int32', sparse=True, dim=3}>
      rec_layer.output = <local> Data{'output_output', [T|'dyn-time:output'[?],B], dtype='int32', sparse=True, dim=3}
      rec_layer.output.is_same_time_dim = <local> <bound method Data.is_same_time_dim of Data{'output_output', [T|'dyn-time:output'[?],B], dtype='int32', sparse=True, dim=3}>
      layer = <local> <ChoiceLayer output/'output' out_type=Data{[B,T|'time:var:extern_data:classes'[B]], dtype='int32', sparse=True, dim=3}>
      layer.output = <local> Data{'classes', [B,T|'time:var:extern_data:classes'[B]], dtype='int32', sparse=True, dim=3}
AssertionError: 
```

I created the PR as draft, we can add the solution either here or directly to the master.