### PR TITLE
FeedDictDataProvider: fixed no advance in single threaded case

### DIFF
--- a/returnn/tf/data_pipeline.py
+++ b/returnn/tf/data_pipeline.py
@@ -422,6 +422,7 @@ class FeedDictDataProvider(DataProviderBase):
       assert self.batches.has_more()
       assert self.batch_slice is None
       output = self.get_next_batch(consider_batch_slice=False)
+      self.batches.advance(1)
     else:
       output = self.queue.get()
     assert isinstance(output, dict)


### PR DESCRIPTION
Was not noticed because the tests that use "single_threaded" create only one batch.