### PR TITLE
Accumulate loop dyn size

### DIFF
--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3375,10 +3375,10 @@ class _SubnetworkRecCell(object):
     # Same scope as the main subnet, so that it stays compatible.
     # noinspection PyProtectedMember
     with reuse_name_scope(self.parent_rec_layer._rec_scope):
+      for layer_name in sorted(extra_output_layers):
+        self.output_layers_net.layers[layer_name] = get_layer(layer_name)
       for layer_name in self.output_layers_moved_out:
         get_layer(layer_name)
-      for layer_name in extra_output_layers:
-        self.output_layers_net.layers[layer_name] = get_layer(layer_name)
 
     # We want to have one single layer with search choices.
     for name, search_choices in search_choices_cache.items():

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3247,6 +3247,7 @@ class _SubnetworkRecCell(object):
     from returnn.tf.util.basic import tensor_array_stack, concat_with_opt_broadcast
     from returnn.tf.network import TFNetwork, ExternData
     from .base import InternalLayer
+    from .basic import LengthLayer
 
     self.output_layers_net = TFNetwork(
       name="%s/%s(rec-subnet-output)" % (
@@ -3317,6 +3318,10 @@ class _SubnetworkRecCell(object):
         if latest_layer_choice_name:
           loop_acc_layers_search_choices[name] = latest_layer_choice_name
         loop_acc_layers[name] = layer_
+        if isinstance(in_loop_layer, LengthLayer):
+          tag = in_loop_layer.dim_tag.get_for_batch_ctx(layer_.output.batch, layer_.output.control_flow_ctx)
+          if not tag.dyn_size_ext:
+            tag.dyn_size_ext = layer_.output
         return layer_
 
     # noinspection PyShadowingNames

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -2664,6 +2664,18 @@ class Data(object):
     """
     return [self.get_dim(axis) for axis in range(self.batch_ndim)]
 
+  def have_varying_shape_in_ctx(self):
+    """
+    :return: whether the (dynamic) shape can change in this control flow context.
+      E.g. when self.control_flow_context is a loop, and we have one dynamic dim
+      where dyn_size_ext has the same control_flow_context
+      (such that dyn_size_ext has e.g. shape [B,T] outside the loop).
+      This can be relevant for accumulating values of self.placeholder
+      e.g. via tf.TensorArray.
+    :rtype: bool
+    """
+    return any(tag.control_flow_ctx for tag in self.dim_tags)
+
   @property
   def size_placeholder(self):
     """


### PR DESCRIPTION
Support of accumulation of dynamic sizes (`DimensionTag.dyn_size_ext`) within a recurrent context (`control_flow_context`). E.g. when the dyn size (seq lengths) is of shape [B] inside the loop, and this dyn size changes in every iteration (i.e. `control_flow_context` is set to the rec loop), then the accumulated dyn size outside the loop would have shape [T,B].

Further, when some layer inside the loop has such a dynamic shape [B,T_per_frame], where T_per_frame is the dyn size as mentioned before, this means that we cannot use the current `TensorArray` logic, which expects that elements always have the same shape in every frame. This PR also extends that logic to support that.

This was a request by #635 and also makes sense for #589, #579 (and other related commits for #391).
