### PR TITLE
HDFDataset: search without reference

### DIFF
--- a/returnn/datasets/cached.py
+++ b/returnn/datasets/cached.py
@@ -43,7 +43,7 @@ class CachedDataset(Dataset):
     self._index_map = range(len(self._seq_index))  # sorted seq idx -> seq_index idx
     self._tag_idx = {}  # type: typing.Dict[str,int]  # map of tag -> real-seq-idx. call _update_tag_idx
     self.targets = {}
-    self.target_keys = []
+    self.target_keys = []  # the keys for which we provide data; we may have labels for additional keys in self.labels
     self.timestamps = None
 
   def initialize(self):

--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -113,7 +113,6 @@ class HDFDataset(CachedDataset):
       prev_target_keys = self.target_keys
     if 'targets' in fin:
       self.target_keys = sorted(
-        set(fin['targets/labels'].keys()) |
         set(fin['targets/data'].keys()) |
         set(fin['targets/size'].attrs.keys()))
     else:


### PR DESCRIPTION
I want to do search on a HDFDataset without having a reference, and without creating a dummy target.
This is possible using `++search_do_eval False`, but I needed these two fixes:

1. Make it possible to provide the target labels in the HDF file without having target data. For this, simply don't include the additional labels in `self.target_keys`. (`self.target_keys` always has to correspond to the existing data, e.g. because of number of `seqLengths` entries)
2. Don't check the missing targets in `check_matched_dataset()` because the dataset might not be able to provide the shape and dtype of missing data. (For HDFDataset, `get_data_dtype()` fails.)