### PR TITLE
SliceNdLayer added set_tag_on_size_tensor for dynamic size case

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -901,6 +901,7 @@ class SliceNdLayer(_ConcatInputLayer):
         beam=slice_tag.batch.beam if slice_tag.batch else self.output.beam,
         control_flow_ctx=slice_tag.control_flow_ctx)
       slice_tag.dyn_size_ext = dyn_size_ext
+      slice_tag.set_tag_on_size_tensor(dyn_size)
     gather_positions_data = start_data.copy_template(name="%s_gather_positions" % self.name)
     gather_positions_data = gather_positions_data.copy_add_dim_by_tag(
       slice_tag,

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -2723,18 +2723,10 @@ def test_SliceNdLayer_set_tag_on_size_tensor():
     # the construction of the "compare" layer will fail if set_tag_on_size_tensor is not called on the slice axis
     # inside of the SliceNdLayer
     net.construct_from_dict({
-      "output": {
-        "class": "rec", "from": "data:data", "unit": {
-          "start": {"class": "copy", "from": "prev:choice"},
-          "slices": {"class": "slice_nd", "from": "base:data", "start": "start", "size": None},
-          "range0": {"class": "range_in_axis", "from": "slices", "axis": "dyn:-1"},
-          "range1": {"class": "range_in_axis", "from": "slices", "axis": "t"},
-          "compare": {"class": "compare", "from": ["range0", "range1"], "kind": "equal"},
-          "output": {"class": "reduce", "from": "compare", "mode": "all", "axes": "dyn:-1", "use_time_mask": False},
-          "prob": {"class": "softmax", "from": "data:source", "target": "classes", "loss": "ce"},
-          'choice': {
-            'class': 'choice', 'target': "classes", 'beam_size': 3, 'from': "prob", "input_type": "prob",
-            "initial_output": 0}}}})
+      "start": {"class": "range_in_axis", "from": "data", "axis": "b"},
+      "slices": {"class": "slice_nd", "from": "data", "start": "start", "size": None},
+      "output": {"class": "compare", "from": ["slices", "slices"], "kind": "equal"}
+    })
 
 
 def test_WindowLayer_output_placeholder():


### PR DESCRIPTION
If we do not do the `set_tag_on_size_tensor`, then the `"_is_size_of_dim_tag"` attribute of the tag will not be set and this can lead to an error in follow-up layers:
```
File "/mnt/projects/i6/returnn/returnn/tf/util/data.py", line 342, in DimensionTag.can_compare
    line: assert self.get_tag_from_size_tensor(self.dyn_size).get_same_base() is self
    locals:
      self = <local> DimensionTag{'sliced-time:segments'[B,'time'[B]]}
      self.get_tag_from_size_tensor = <local> <bound method DimensionTag.get_tag_from_size_tensor of <class 'returnn.tf.util.data.DimensionTag'>>
      self.dyn_size = <local> <tf.Tensor 'output/rec/segments/Maximum_1:0' shape=(?, ?) dtype=int32>
      get_same_base = <not found>
AttributeError: 'NoneType' object has no attribute 'get_same_base'
```