### PR TITLE
Fix for CI and protobuf on Python 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,10 @@ jobs:
           ls ~/.local/lib/python2.7/site-packages
           # https://github.com/tensorflow/tensorboard/issues/1862#issuecomment-521876133
           rm -rf ~/.local/lib/python2.7/site-packages/tensorboard* || true
+
+          # Newer protobuf (3.18.0) seems be broken for Python 2
+          # and TF just adds protobuf>=3.3 as dependency.
+          pip install --user protobuf==3.12
         fi
 
         pip install --user -r requirements.txt | cat


### PR DESCRIPTION
I get:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/.local/lib/python2.7/site-packages/tensorflow/__init__.py", line 24, in <module>
    from tensorflow.python import *
  File "/home/runner/.local/lib/python2.7/site-packages/tensorflow/python/__init__.py", line 52, in <module>
    from tensorflow.core.framework.graph_pb2 import *
  File "/home/runner/.local/lib/python2.7/site-packages/tensorflow/core/framework/graph_pb2.py", line 6, in <module>
    from google.protobuf import descriptor as _descriptor
  File "/home/runner/.local/lib/python2.7/site-packages/google/protobuf/descriptor.py", line 113
    class DescriptorBase(metaclass=DescriptorMetaclass):
                                  ^
SyntaxError: invalid syntax
```
And TF installed this protobuf:
```
Collecting protobuf>=3.3.0
  Downloading protobuf-3.18.0-py2.py3-none-any.whl (174 kB)
```