### PR TITLE
allow passing a custom variable name mapping for preloading of parameters

### DIFF
--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -1135,7 +1135,8 @@ class Engine(EngineBase):
           params_prefix=self_prefix, load_if_prefix=load_if_prefix,
           ignore_missing=opts.get("ignore_missing", False),
           ignore_params=opts.get("ignore_params", ()),
-          ignore_params_prefixes=opts.get("ignore_params_prefixes", ()))
+          ignore_params_prefixes=opts.get("ignore_params_prefixes", ()),
+          var_name_mapping=opts.get("var_name_mapping", {}))
         # `set_as_custom_init` is also a marker for the vars, that they are preloaded,
         # such that further checkpoint loaders will not load them again.
         loader.set_as_custom_init()

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -3580,7 +3580,7 @@ class CustomCheckpointLoader:
         return
       self.assigned = True
       values_dict = {
-        name: (self.reader.get_tensor(self.var_name_mapping[name]) if name in self.var_name_mapping else self.reader.get_tensor(self.prefix_param_name + name) )
+        name: self.reader.get_tensor(self.var_name_mapping.get(name, self.prefix_param_name + name))
         for name in self.checkpoint_param_names}
       self.reader = None  # Allow GC now, we do not need it anymore.
       print("Custom param import of layer %r with original params %r." % (

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -3898,7 +3898,7 @@ class CustomCheckpointLoader:
       if v.endswith(MakeLoadCudnnRnn.cudnn_postfix):
         var_name_map.update(
           MakeLoadCudnnRnn(prefix=v[:-len(MakeLoadCudnnRnn.cudnn_postfix) + 1]).get_lazy_dict())
-    var_name_map.update({name : make_load_renamed(old_name) for name, old_name in self.var_name_mapping.items()})
+    var_name_map.update({name: make_load_renamed(old_name) for name, old_name in self.var_name_mapping.items()})
 
     could_not_find_map_list = [v for v in missing_var_names if v not in var_name_map]
     if self.ignore_missing or not could_not_find_map_list:

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -3482,6 +3482,8 @@ class CustomCheckpointLoader:
       however, if there is no single var in the checkpoint, this is still an error.
     :param typing.Container[str] ignore_params: these param (by name) will not be loaded
     :param typing.Iterable[str] ignore_params_prefixes: these param (by prefix name) will not be loaded
+    :param dict[str,str] var_name_mapping: defines a custom mapping (new_name -> name_in_checkpoint) for 
+      renamed vars in the checkpoint 
     :param TFNetwork network:
     """
     self.filename = filename

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -3482,8 +3482,8 @@ class CustomCheckpointLoader:
       however, if there is no single var in the checkpoint, this is still an error.
     :param typing.Container[str] ignore_params: these param (by name) will not be loaded
     :param typing.Iterable[str] ignore_params_prefixes: these param (by prefix name) will not be loaded
-    :param dict[str,str] var_name_mapping: defines a custom mapping (new_name -> name_in_checkpoint) for 
-      renamed vars in the checkpoint 
+    :param dict[str,str] var_name_mapping: defines a custom mapping (new_name -> name_in_checkpoint) for
+      renamed vars in the checkpoint
     :param TFNetwork network:
     """
     self.filename = filename


### PR DESCRIPTION
For preloading a model where some parameters have been renamed this enables more flexibility than only removing a common prefix.