### PR TITLE
SoftmaxLayer fix constructor signature

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1650,8 +1650,8 @@ class SoftmaxLayer(LinearLayer):
   """
   layer_class = "softmax"
 
-  def __init__(self, activation="softmax", **kwargs):
-    super(SoftmaxLayer, self).__init__(activation=activation, **kwargs)
+  def __init__(self, **kwargs):
+    super(SoftmaxLayer, self).__init__(activation="softmax", **kwargs)
 
 
 class LengthLayer(LayerBase):


### PR DESCRIPTION
The current `activation` parameter is not necessary and leads to a confusing constructor signature when using the new returnn_common modules.