### PR TITLE
added warning when extra config parameter can't be evaluated

### DIFF
--- a/returnn/config.py
+++ b/returnn/config.py
@@ -190,7 +190,11 @@ class Config:
       if value_type == str:
         pass  # keep as-is
       else:
-        value = eval(value)
+        try:
+          value = eval(value)
+        except:
+          from returnn.log import log
+          print("WARNING: can't evaluate config param '{}' to previous type: {}. Keeping as string.".format(value, value_type),file=log.v1)
       self.typed_dict[key] = value
       return
     if value.find(',') > 0:

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -192,9 +192,10 @@ class Config:
       else:
         try:
           value = eval(value)
-        except:
+        except SyntaxError:
           from returnn.log import log
-          print("WARNING: can't evaluate config param '{}' to previous type: {}. Keeping as string.".format(value, value_type),file=log.v1)
+          print("WARNING: can't evaluate config param '%s' to previous type: %s. Keeping as string."
+                % (value, value_type), file=log.v1)
       self.typed_dict[key] = value
       return
     if value.find(',') > 0:

--- a/returnn/config.py
+++ b/returnn/config.py
@@ -194,8 +194,9 @@ class Config:
           value = eval(value)
         except SyntaxError:
           from returnn.log import log
-          print("WARNING: can't evaluate config param '%s' to previous type: %s. Keeping as string."
-                % (value, value_type), file=log.v1)
+          print(
+            "WARNING: can't evaluate config param %r to previous type: %s. Keeping as string." % (value, value_type),
+            file=log.v1)
       self.typed_dict[key] = value
       return
     if value.find(',') > 0:


### PR DESCRIPTION
### Why:

Overwriting a config param "++param" with a function tag from the current config (e.g.: `++search_data "config:get_sprint_dataset('dev')"` ) fails if the param was already set in the config, and had a different type.

### What:

Adding a warning; so user knows that the evaluation failed because the param was previously set in the config.
Also if the evaluation fails, it will use the param as-is. ( Optional )