### PR TITLE
Add UnflattenBatchLayer

### DIFF
--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1958,6 +1958,60 @@ def test_FlattenBatchLayer():
     assert_equal(out_v.tolist(), [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [10, 11], [12, 13], [14, 15], [18, 19]])
 
 
+def test_UnflattenBatchLayer():
+  n_batch, n_time, n_in = 3, 4, 2
+  config = Config({
+    "extern_data": {"data": {"dim": n_in, "dtype": "int32"}},
+    "debug_print_layer_output_template": True,
+  })
+  with make_scope() as session:
+    net = TFNetwork(config=config)
+    net.construct_from_dict({
+      "flatten": {"class": "flatten_batch", "from": "data:data"},
+      "output": {"class": "unflatten_batch", "from": "flatten"}})
+    in_data = net.extern_data.data["data"]
+    out_data = net.get_default_output_layer().output
+    assert out_data.batch_shape == (None, None, n_in) and out_data.size_placeholder is not None
+    out_t = net.get_default_output_layer().output.placeholder
+    assert out_t.shape.as_list() == [None, None, n_in]
+    in_v = numpy.arange(0, n_batch * n_time * n_in).reshape((n_time, n_batch, n_in)).transpose(1, 0, 2)
+    in_seq_lens = [4, 3, 2]
+    out_v = session.run(out_t, feed_dict={
+      in_data.placeholder: in_v,
+      in_data.size_placeholder[0]: in_seq_lens})
+    for b, seq_len in enumerate(in_seq_lens):
+      in_v[b, seq_len:, :] = 0
+    assert isinstance(out_v, numpy.ndarray)
+    numpy.testing.assert_equal(out_v, in_v)
+
+
+def test_UnflattenBatchLayer_time_major():
+  n_batch, n_time, n_in = 3, 4, 2
+  config = Config({
+    "extern_data": {"data": {"dim": n_in, "dtype": "int32"}},
+    "debug_print_layer_output_template": True,
+  })
+  with make_scope() as session:
+    net = TFNetwork(config=config)
+    net.construct_from_dict({
+      "flatten": {"class": "flatten_batch", "batch_major": False, "from": "data:data"},
+      "output": {"class": "unflatten_batch", "from": "flatten"}})
+    in_data = net.extern_data.data["data"]
+    out_data = net.get_default_output_layer().output
+    assert out_data.batch_shape == (None, None, n_in) and out_data.size_placeholder is not None
+    out_t = net.get_default_output_layer().output.placeholder
+    assert out_t.shape.as_list() == [None, None, n_in]
+    in_v = numpy.arange(0, n_batch * n_time * n_in).reshape((n_time, n_batch, n_in)).transpose(1, 0, 2)
+    in_seq_lens = [4, 3, 2]
+    out_v = session.run(out_t, feed_dict={
+      in_data.placeholder: in_v,
+      in_data.size_placeholder[0]: in_seq_lens})
+    for b, seq_len in enumerate(in_seq_lens):
+      in_v[b, seq_len:, :] = 0
+    assert isinstance(out_v, numpy.ndarray)
+    numpy.testing.assert_equal(out_v, in_v.transpose(1, 0, 2))
+
+
 def test_SwitchLayer_const_no_time():
   config = Config({
     "extern_data": {


### PR DESCRIPTION
This PR adds `UnflattenBatchLayer` which is the inverse of the `FlattenBatchLayer`. It should undo the flattening and restore the original data in batch major/time major format as it was input to the `FlattenBatchLayer`.