### PR TITLE
Generic LayerBase in_dim and out_dim options

### DIFF
--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -472,7 +472,7 @@ class TFNetwork(object):
     self.extra_vars_to_save = []  # type: typing.List[tf.Variable]
     self.recurrent = False
     self._assigner_cache = {}  # type: typing.Dict[tf.Variable,VariableAssigner]
-    self.concat_sources_dropout_cache = {}  # type: typing.Dict[typing.Tuple[typing.Tuple[LayerBase,...],float,typing.Optional[typing.Tuple[typing.Optional[int],...]]],Data]  # nopep8
+    self.concat_sources_dropout_cache = {}  # type: typing.Dict[typing.Tuple[typing.Tuple[LayerBase,...],DimensionTag,float,typing.Optional[typing.Tuple[typing.Optional[int],...]]],Data]  # nopep8
     self._merge_all_summaries = None  # type: typing.Optional[tf.Tensor]
     self._graph_reset_callbacks = []  # type: typing.List[typing.Callable]
     self._run_opts = {}  # type: typing.Dict[str]

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3218,10 +3218,9 @@ class Data(object):
     """
     :rtype: int|None
     """
-    if self.sparse_dim:
-      return self.sparse_dim.dimension
-    if self.have_feature_axis():
-      return self.dim_tags[self.feature_dim_axis].dimension
+    tag = self.feature_dim_or_sparse_dim
+    if tag:
+      return tag.dimension
     return None
 
   @dim.setter
@@ -3234,6 +3233,18 @@ class Data(object):
     :param int|None dim:
     """
     assert dim == self.dim
+
+  @property
+  def feature_dim_or_sparse_dim(self):
+    """
+    :return: if we have a feature dim, return its dim tag. if we are sparse, return the sparse_dim. otherwise None
+    :rtype: DimensionTag|None
+    """
+    if self.have_feature_axis():
+      return self.dim_tags[self.feature_dim_axis]
+    if self.sparse_dim:
+      return self.sparse_dim
+    return None
 
   @property
   def sparse(self):


### PR DESCRIPTION
#597

`in_dim` is checked for many common cases for verification in `LayerBase` (just that the dim exists in the input, if there is a single input).

`in_dim` is also used in _ConcatInputLayer to define the concatenated feature dim.

`out_dim` is further used for verification in `LayerBase` (just that the dim exists in the output).

`out_dim` is used for layers which rely on `_base_get_out_data_from_opts`, e.g. `LinearLayer`, to define the output feature dim.

`out_dim` is used by `CopyLayer` to define a potential new concatenated output feature dim.
