### PR TITLE
ConvLayer and PoolLayer, in_dim, in_spatial_dims, out_dim, out_spatial_dims

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4592,8 +4592,11 @@ class ConvLayer(_ConcatInputLayer):
       input_expand_dims=input_expand_dims,
       input_split_feature_dim=input_split_feature_dim,
       input_add_feature_dim=input_add_feature_dim)
-    data = input_data.copy_with_feature_dim_axis(-1)  # just to have the dim tags in order [B,S...,D]
     # Be relaxed about incorrect input data. Throw errors later. This can also work during template construction.
+    if input_data.have_feature_axis():
+      data = input_data.copy_with_feature_dim_axis(-1)  # just to have the dim tags in order [B,S...,D]
+    else:
+      data = input_data.copy_add_feature_dim(-1)
     old_spatial_dim_tags = data.dim_tags[num_batch_dims:-1]
     dim_tags = list(data.dim_tags[:num_batch_dims])  # [B]
     if out_spatial_dims:

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4795,7 +4795,7 @@ class PoolLayer(_ConcatInputLayer):
     :param bool use_channel_first:
     :rtype: Data
     """
-    data = get_concat_sources_data_template(sources, name="%s_output" % name)
+    data = get_concat_sources_data_template(sources)
     if in_dim and out_dim:
       assert in_dim == out_dim
     elif in_dim:

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1727,8 +1727,9 @@ class Data(object):
     :param tf.Tensor x:
     :rtype: Data
     """
-    assert x.get_shape().ndims == 0, "currently only scalars supported"
-    return Data(name=str(x.op.name), shape=(), batch_dim_axis=None, dtype=x.dtype.name, placeholder=x)
+    assert x.get_shape().is_fully_defined()
+    x_shape = x.get_shape().as_list()
+    return Data(name=str(x.op.name), shape=x_shape, batch_dim_axis=None, dtype=x.dtype.name, placeholder=x)
 
   @classmethod
   def template_from_constant(cls, x, name, dtype=None, shape=None, with_batch_dim=False):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -2355,6 +2355,10 @@ class Data(object):
     v = self.copy_add_dim_by_tag(dim_tag, axis=axis)
     if v.feature_dim_axis_or_unspecified is not NotSpecified:
       v.feature_dim_axis = NotSpecified
+    if axis < 0:
+      axis += v.batch_ndim
+      assert axis >= 0
+    assert 0 <= axis < v.batch_ndim
     if v.feature_dim_axis != axis:
       v.feature_dim_axis = axis
     return v

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -3541,6 +3541,26 @@ def test_reclayer_optimize_out_conv1d():
     feat_dim=input_feat_dim)
 
 
+def test_reclayer_optimize_out_pool1d():
+  # https://github.com/rwth-i6/returnn/issues/573
+  # https://github.com/rwth-i6/returnn/pull/789
+  input_feat_dim = DimensionTag(kind=DimensionTag.Types.Feature, description="in-feature", dimension=15)
+  new_feat_dim = DimensionTag(kind=DimensionTag.Types.Feature, description="split-feature", dimension=3)
+  spatial_dim = DimensionTag(kind=DimensionTag.Types.Spatial, description="split-spatial", dimension=5)
+  check_reclayer_optimize_out(
+    {"class": "linear", "from": "pool"},
+    {
+      "split": {
+        "class": "split_dims", "from": "data:source", "axis": input_feat_dim, "dims": (spatial_dim, new_feat_dim)},
+      # This is the test.
+      "pool": {
+        "class": "pool", "from": "split",
+        "in_spatial_dims": [spatial_dim], "pool_size": [3], "padding": "same", "mode": "max"},
+    },
+    feat_dim=input_feat_dim)
+
+
+
 def test_reclayer_optimize_out_rnncell():
   check_reclayer_optimize_out({"class": "rnn_cell", "unit": "BasicLSTM"})
 

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -3527,6 +3527,8 @@ def test_reclayer_optimize_out_linear():
 
 
 def test_reclayer_optimize_out_conv1d():
+  # https://github.com/rwth-i6/returnn/issues/573
+  # https://github.com/rwth-i6/returnn/pull/789
   input_feat_dim = DimensionTag(kind=DimensionTag.Types.Feature, description="in-feature", dimension=15)
   new_feat_dim = DimensionTag(kind=DimensionTag.Types.Feature, description="split-feature", dimension=3)
   spatial_dim = DimensionTag(kind=DimensionTag.Types.Spatial, description="split-spatial", dimension=5)

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -3526,6 +3526,19 @@ def test_reclayer_optimize_out_linear():
   check_reclayer_optimize_out({"class": "linear", "activation": "relu"})
 
 
+def test_reclayer_optimize_out_conv1d():
+  input_feat_dim = DimensionTag(kind=DimensionTag.Types.Feature, description="in-feature", dimension=15)
+  new_feat_dim = DimensionTag(kind=DimensionTag.Types.Feature, description="split-feature", dimension=3)
+  spatial_dim = DimensionTag(kind=DimensionTag.Types.Spatial, description="split-spatial", dimension=5)
+  check_reclayer_optimize_out(
+    {"class": "conv", "from": "split", "in_spatial_dims": [spatial_dim], "filter_size": [3], "padding": "same"},
+    {
+      "split": {
+        "class": "split_dims", "from": "data:source", "axis": input_feat_dim, "dims": (spatial_dim, new_feat_dim)}
+    },
+    feat_dim=input_feat_dim)
+
+
 def test_reclayer_optimize_out_rnncell():
   check_reclayer_optimize_out({"class": "rnn_cell", "unit": "BasicLSTM"})
 


### PR DESCRIPTION
#597

Fix 2D/3D convolution/pooling (`ConvLayer`/`PoolLayer`) depends on order of axes (#594), when `in_spatial_dims` is used. There should be a follow-up maybe where this is required (for 2D/3D), with new behavior version.

Fix handling of unrelated dims, and also rec automatic optimization (#573).
