### PR TITLE
fix for Data.copy_template_unpack_batch

### DIFF
--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -2956,7 +2956,7 @@ class Data(object):
             dim_tags.append(virtual_dim.dim_tag)
             batch = batch.copy_remove_dim(virtual_dim)
           elif not new_batch_dim_tag:
-            new_batch_dim_tag = Dim(kind=Dim.Types.Batch)
+            new_batch_dim_tag = batch_dim
             dim_tags.append(new_batch_dim_tag)
         assert new_batch_dim_tag
         new_batch_dim_tag.batch = batch


### PR DESCRIPTION
I have a case in the PyTorch-to-RETURNN converter, where `Data.get_axes_by_tag_name` runs into a problem when checking `tag.description.lower()` because the `DimensionTag` that is created in `Data.copy_template_unpack_batch` does not have a `description`. This fixes the error for me, but I'm not sure if it should be fixed in a more generic way since creating a `DimensionTag` with `description=None` is allowed in general and could maybe lead to this error in other cases as well.