### PR TITLE
Update to C++14 (needed for TensorFlow 2.7)

### DIFF
--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -3563,7 +3563,7 @@ class NativeCodeCompiler(object):
       f.write(self.code)
     common_opts = ["-shared", "-O2"]
     if self.is_cpp:
-      common_opts += ["-std=c++11"]
+      common_opts += ["-std=c++14"]
     if sys.platform == "darwin":
       common_opts += ["-undefined", "dynamic_lookup"]
     for include_path in self._include_paths:


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/commit/f09d3e299752226f7a28c09a
https://github.com/tensorflow/tensorflow/issues/53313
https://github.com/tensorflow/tensorflow/blob/908e8010ff2c/.bazelrc#L320

The C++14 option is supported since a long time in most compilers,
and this is backward compatible,
so there shouldn't really be any issues.