### PR TITLE
Allow search output layers without target or with dense outputs 

### DIFF
--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -883,6 +883,8 @@ class Dataset(object):
 
   def serialize_data(self, key, data):
     """
+    Warning: this is deprecated. Directly use the corresponding Vocabulary to serialize the data
+
     :param str key: e.g. "classes". self.labels[key] should be set
     :param numpy.ndarray data: 0D or 1D
     :rtype: str

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -24,7 +24,7 @@ import typing
 
 from returnn.log import log
 from returnn.engine.batch import Batch, BatchSetGenerator
-from returnn.datasets.util.vocabulary import get_seq_labels_from_labels
+from returnn.datasets.util.vocabulary import Vocabulary
 from returnn.util.basic import try_run, NumbersDict, unicode, OptionalNotImplementedError
 
 
@@ -877,8 +877,6 @@ class Dataset(object):
 
   def can_serialize_data(self, key):
     """
-    Warning: Deprecated, use the corresponding vocabulary to serialize the data
-
     :param str key: e.g. "classes"
     :rtype: bool
     """
@@ -886,13 +884,16 @@ class Dataset(object):
 
   def serialize_data(self, key, data):
     """
-    Warning: Deprecated, use the corresponding vocabulary to serialize the data
+    In case you have a :class:`Vocabulary`, just use :func:`Vocabulary.get_seq_labels`.
 
     :param str key: e.g. "classes". self.labels[key] should be set
     :param numpy.ndarray data: 0D or 1D
     :rtype: str
     """
-    return get_seq_labels_from_labels(data, labels=self.labels[key])
+    vocab = Vocabulary.create_vocab_from_labels(self.labels[key])
+    if data.ndim == 0:
+      return vocab.labels[data]
+    return vocab.get_seq_labels(data)
 
   def calculate_priori(self, target="classes"):
     """

--- a/returnn/datasets/util/vocabulary.py
+++ b/returnn/datasets/util/vocabulary.py
@@ -334,6 +334,9 @@ class CharacterTargets(Vocabulary):
       seq = [self.vocab[k] for k in sentence]
     return seq + self.seq_postfix
 
+  def get_seq_labels(self, seq):
+    return "".join(map(self.labels.__getitem__, seq))
+
 
 class Utf8ByteTargets(Vocabulary):
   """
@@ -365,3 +368,10 @@ class Utf8ByteTargets(Vocabulary):
     else:
       seq = list(bytearray(sentence.encode("utf8")))
     return seq + self.seq_postfix
+
+  def get_seq_labels(self, seq):
+    """
+    :param list[int] seq:
+    :rtype: str
+    """
+    return bytearray(seq).decode(encoding="utf8")

--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -2447,8 +2447,9 @@ class Engine(EngineBase):
       elif output_file_format == "py":
         from returnn.util.basic import better_repr
         output_file.write("{\n")
-        for i in range(len(out_cache)):
-          output_file.write("%r: %s,\n" % (seq_idx_to_tag[i], better_repr(out_cache[i])))
+        with numpy.printoptions(threshold=sys.maxsize):
+          for i in range(len(out_cache)):
+            output_file.write("%r: %s,\n" % (seq_idx_to_tag[i], better_repr(out_cache[i])))
         output_file.write("}\n")
       else:
         raise Exception("invalid output_file_format %r" % output_file_format)

--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -2297,7 +2297,6 @@ class Engine(EngineBase):
       assert output_file_format in {"txt", "py"}
       if output_is_dict:
         assert output_file_format == "py", "Text format not supported in the case of multiple output layers."
-      assert all(dataset.can_serialize_data(target_key) for target_key in target_keys if target_key)
       assert not os.path.exists(output_file)
       print("Will write outputs to: %s" % output_file, file=log.v2)
       output_file = open(output_file, "w")

--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -2407,11 +2407,11 @@ class Engine(EngineBase):
               output_layer_names[output_layer_idx], outputs[output_layer_idx][batch_idx]), file=log.v4)
             out_idx = batch_idx
           else:
+            beam_start_idx = batch_idx * out_beam_sizes[output_layer_idx]
+            beam_end_idx = (batch_idx + 1) * out_beam_sizes[output_layer_idx]
             print("seq_idx: %i, seq_tag: %r, outputs %r: %r" % (
               seq_idx[batch_idx], seq_tag[batch_idx], output_layer_names[output_layer_idx],
-              outputs[output_layer_idx]
-              [batch_idx * out_beam_sizes[output_layer_idx]:(batch_idx + 1)*out_beam_sizes[output_layer_idx]]),
-                  file=log.v4)
+              outputs[output_layer_idx][beam_start_idx:beam_end_idx]), file=log.v4)
             out_idx = batch_idx * out_beam_sizes[output_layer_idx]
           if target_keys[output_layer_idx] and serialized_outputs[output_layer_idx]:
             if do_eval and serialized_targets[output_layer_idx]:

--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -2413,8 +2413,8 @@ class Engine(EngineBase):
               seq_idx[batch_idx], seq_tag[batch_idx], output_layer_names[output_layer_idx],
               outputs[output_layer_idx][beam_start_idx:beam_end_idx]), file=log.v4)
             out_idx = batch_idx * out_beam_sizes[output_layer_idx]
-          if target_keys[output_layer_idx] and serialized_outputs[output_layer_idx]:
-            if do_eval and serialized_targets[output_layer_idx]:
+          if serialized_outputs[output_layer_idx]:
+            if serialized_targets[output_layer_idx]:
               print("  ref:", serialized_targets[output_layer_idx][batch_idx], file=log.v4)
             if out_beam_sizes[output_layer_idx] is None:
               print("  hyp:", serialized_outputs[output_layer_idx][out_idx],

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4122,7 +4122,7 @@ class ReinterpretDataLayer(_ConcatInputLayer):
     :param bool enforce_batch_major:
     :param bool enforce_time_major:
     :param bool|None set_sparse: if bool, set sparse value to this
-    :param int|None|NotSpecified set_sparse_dim: set sparse dim to this. assumes that it is sparse
+    :param Dim|int|None|NotSpecified set_sparse_dim: set sparse dim to this. assumes that it is sparse
     :param int|None increase_sparse_dim: add this to the dim. assumes that it is sparse
     """
     from returnn.tf.util.basic import get_valid_scope_name_from_str
@@ -4193,7 +4193,7 @@ class ReinterpretDataLayer(_ConcatInputLayer):
     :param bool enforce_batch_major:
     :param bool enforce_time_major:
     :param bool|None set_sparse: if bool, set sparse value to this
-    :param int|None|NotSpecified set_sparse_dim: set sparse dim to this. assumes that it is sparse
+    :param Dim|int|None|NotSpecified set_sparse_dim: set sparse dim to this. assumes that it is sparse
     :param int|None increase_sparse_dim: add this to the dim. assumes that it is sparse
     """
     out = get_concat_sources_data_template(sources, name="%s_output" % name)
@@ -4251,15 +4251,20 @@ class ReinterpretDataLayer(_ConcatInputLayer):
         else:
           out_args = out.get_kwargs()
           out_args["sparse"] = True
-          out_args["dim"] = set_sparse_dim if set_sparse_dim is not NotSpecified else out.dim
+          if isinstance(set_sparse_dim, Dim):
+            out_args["sparse_dim"] = set_sparse_dim
+          else:
+            out_args["dim"] = set_sparse_dim if set_sparse_dim is not NotSpecified else out.dim
           out_args.pop("feature_dim_axis", None)
           out = Data(**out_args)
       else:
         out.sparse_dim = None
     if set_sparse_dim is not NotSpecified:
       assert out.sparse
-      assert set_sparse_dim is None or isinstance(set_sparse_dim, int)
-      if out.dim == set_sparse_dim:
+      assert set_sparse_dim is None or isinstance(set_sparse_dim, int) or isinstance(set_sparse_dim, Dim)
+      if isinstance(set_sparse_dim, Dim):
+        out.sparse_dim = set_sparse_dim
+      elif out.dim == set_sparse_dim:
         pass
       else:
         out.sparse_dim = Dim(

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -965,6 +965,8 @@ def better_repr(o):
     return "set([\n%s])" % "".join(map(lambda v: better_repr(v) + ",\n", o))
   if isinstance(o, float) and (math.isnan(o) or math.isinf(o)):
     return "float('%s')" % repr(o)
+  if isinstance(o, np.ndarray):
+    return better_repr(o.tolist())
   # fallback
   return repr(o)
 

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -965,8 +965,6 @@ def better_repr(o):
     return "set([\n%s])" % "".join(map(lambda v: better_repr(v) + ",\n", o))
   if isinstance(o, float) and (math.isnan(o) or math.isinf(o)):
     return "float('%s')" % repr(o)
-  if isinstance(o, np.ndarray):
-    return better_repr(o.tolist())
   # fallback
   return repr(o)
 

--- a/tests/test_TFEngine.py
+++ b/tests/test_TFEngine.py
@@ -3829,6 +3829,7 @@ def test_engine_search_output_file():
   # Validate generated output file
   with open(output_file) as fp:
     output_text = fp.read()
+    from numpy import array, float32
     output = eval(output_text)
     assert set(config.typed_value('search_output_layer')) == set(output['seq-0'].keys())
 


### PR DESCRIPTION
This change mainly allows to set layers with dense outputs as `search_output_layer` so that their output in included in the search output file. My main use case for this is a simple way to output confidence scores calculated in the network, but this also supports to output any other type of dense outputs like logits, hidden states, etc.

The main changes in `search` are:
- the target key does not default to `default_target` for dense outputs
- outputs without target key or that are not serialisable by the dataset are directly printed as output
