### PR TITLE
Fixes the shape of output_flat in loss with a static time dimension

### DIFF
--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -2434,7 +2434,7 @@ class Loss(object):
             output_with_activation.x, self.output_seq_lens, time_major=output.is_time_major)
         else:
           self.output_flat = flatten_or_merge(output.placeholder, self.output_seq_lens, time_major=output.is_time_major)
-          self.output_flat.set_shape(tf.TensorShape(output.shape))
+          self.output_flat.set_shape(tf.TensorShape((None,) + output.shape[1:]))
         if target:
           assert target.have_time_axis()
           self.target_seq_lens = target.get_sequence_lengths()

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5721,6 +5721,48 @@ def test_CrossEntropyLoss_masked_inf_fake_upper_bound():
       last_var_v = var_v
 
 
+def test_MeanSquaredError():
+  with make_scope() as session:
+    n_out = 13
+    config = Config({
+      "debug_print_layer_output_template": True,
+      "extern_data": {
+        "data": {"dim": n_out},
+        "classes": {"dim": n_out, "sparse": False, "shape": (1, n_out), "time_dim_axis": 1},
+      }})
+    net = TFNetwork(config=config, train_flag=True)
+    net.construct_from_dict({
+      "var": {"class": "variable", "shape": (n_out,)},
+      "add": {"class": "combine", "kind": "add", "from": ["data", "var"]},
+      "reduce": {"class": "reduce", "mode": "mean", "axes": "T", "from": "add", "keep_dims": True},
+      "output": {
+        "class": "activation", "from": "reduce", "activation": "sigmoid",
+        "loss": "mse"},
+    })
+    losses_dict, total_loss, total_constraints = net.get_losses_initialized()
+    print("Losses:")
+    pprint(losses_dict)
+    assert set(losses_dict.keys()) == {"output"}
+    loss_holder = losses_dict["output"]
+    assert isinstance(loss_holder, LossHolder)
+    assert isinstance(loss_holder.loss, MeanSquaredError)
+    session.run(tf_compat.v1.global_variables_initializer())
+    print("Get loss:")
+    feed_dict = make_feed_dict(net.extern_data.data.values(), same_time=True, n_time=1)
+    print("random classes:", feed_dict[net.extern_data.data["classes"].placeholder])
+    loss_t = loss_holder.get_loss_value()
+    error_t = loss_holder.get_error_value()
+    opt = tf_compat.v1.train.GradientDescentOptimizer(learning_rate=0.1)
+    minimize_op = opt.minimize(loss_t)
+    last_loss_v = float("inf")
+    for step in range(3):
+      loss_v, error_v, _ = session.run((loss_t, error_t, minimize_op), feed_dict=feed_dict)
+      print("step %i, loss %f, error %f" % (step, loss_v, error_v))
+      assert numpy.isfinite(loss_v) and numpy.isscalar(loss_v)
+      assert loss_v <= last_loss_v
+      last_loss_v = loss_v
+
+
 def test_reduce_mean_in_time():
   with make_scope() as session:
     n_out = 5


### PR DESCRIPTION
Currently, the shape of output_flat is set to the original data shape (that does not include the batch dim), i.e. the length of the new batch x time dim is set to the length of the time dim (even if it is static).