### PR TITLE
Dim generic placeholder, any_feature_dim, any_spatial_dim

### DIFF
--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -195,8 +195,8 @@ class LayerBase(object):
       # Note that this check is somewhat incomplete
       # (does not check multiple sources, see _ConcatInputLayer)
       # and there is no guarantee that a specific layer really uses this correctly.
-      assert in_dim in sources[0].output.dim_tags_set_implicit, (
-        "%s: in_dim %s not found in input %s" % (self, in_dim, sources[0]))
+      assert sources[0].output.have_unique_dim_tag(in_dim), (
+        "%s: in_dim %s not found or unique in input %s" % (self, in_dim, sources[0]))
     self.params = {}  # type: typing.Dict[str,tf.Variable]
     self.saveable_param_replace = {}  # type:  typing.Dict[tf.Variable,typing.Union['tensorflow.python.training.saver.BaseSaverBuilder.SaveableObject',None]]  # see get_saveable_params_dict()  # nopep8
     self.reuse_params = reuse_params
@@ -339,7 +339,7 @@ class LayerBase(object):
       assert out_type["dim"] == n_out
     sources_data_list = [src.output for src in sources if src]
     if in_dim:
-      assert len(sources_data_list) == 1
+      assert len(sources_data_list) == 1, "%r: with specific in_dim %s, there must be a single source" % (name, in_dim)
       if sources_data_list[0].feature_dim_or_sparse_dim != in_dim:
         # Allow to specify some in_dim which is not the feature dim.
         # However, the follow-up code will expect it to be the feature dim, thus reassign it if possible.

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -56,7 +56,7 @@ class Dim(object):
     :param Data|None dyn_size_ext: seq_len or extended
     :param bool undefined: When this is specified as `None` by the user via `shape`.
     :param bool generic: This can not be a dim tag of :class:`Data` but it would match to other existing dim tags
-      :func:`Data.get_axis_from_description` and :func:`Dim.equal`.
+      :func:`Data.get_axis_from_description` and :func:`Dim.is_equal`.
     :param Dim|None derived_from_tag:
       Whether this new tag is reduced, down/up sampled, padded etc from this given other tag.
       In situations where dim tags are being matched (Data.get_common_data),

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3610,7 +3610,10 @@ class Data(object):
     if isinstance(axes, Dim):
       # Once we have not guaranteed unique dim tags, multiple axes could match.
       # https://github.com/rwth-i6/returnn/issues/632
-      return [i for (i, tag) in enumerate(self.dim_tags) if tag == axes]
+      dims = [i for (i, tag) in enumerate(self.dim_tags) if tag == axes]
+      if axes.generic:
+        assert len(dims) == 1, "%s: matching generic dim placeholder %s must be unique" % (self, axes)
+      return dims
     if isinstance(axes, int):
       self._verify_axis_int_from_description(allow_int=allow_int)
       return [self._make_valid_int_axis(axes)]


### PR DESCRIPTION
Some alternative to #586 which is purely on dim tag level.

When used via `get_axis_from_description`, this would also ensure that it is unique.

When used via `get_axes_from_description`, it currently would allow multiple matches. I'm not sure whether to disallow this or not. Opinions @Zettelkasten ? **Edit** I now changed it to require that it is unique. Otherwise it throws an error. If this does not work for the user, he should just use an explicit dim tag.
