### PR TITLE
Fixes PostfixInTimeLayer to support postfix layer inputs without a batch dim

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6017,7 +6017,7 @@ class PostfixInTimeLayer(_ConcatInputLayer):
     if isinstance(postfix, LayerBase):
       self.postfix_layer = postfix
       assert in_dim not in postfix.output.dim_tags, 'Postfix layer with time axis not implemented yet'
-      postfix = postfix.output.copy_compatible_to(self.output)
+      postfix = postfix.output.copy_compatible_to(self.output, unbroadcast=True, except_axis=axis)
       c = postfix.placeholder
       c_ = tf.tile(c, [1 if i != axis_int else repeat for i in range(self.output.batch_ndim)])
     else:

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -2643,7 +2643,7 @@ class Data(object):
         data.placeholder = x
     return data
 
-  def copy_compatible_to(self, data, add_dims=True, unbroadcast=False, except_feature=False,
+  def copy_compatible_to(self, data, add_dims=True, unbroadcast=False, except_feature=False, except_axis=None,
                          check_sparse=True, check_dtype=True):
     """
     :param Data data: other data which the returned tensor should be compatible to
@@ -2652,6 +2652,7 @@ class Data(object):
     :param bool add_dims: whether to add (broadcast, or unbroadcasted) dims. throws error if missing dim
     :param bool unbroadcast: if True, all added broadcast axes (axes with dim 1) will be tiled such that they match
     :param bool except_feature: if unbroadcast, do not unbroadcast the feature dim
+    :param Dim|int|None except_axis: if unbroadcast, do not unbroadcast this axis
     :param bool check_sparse:
     :param bool check_dtype:
     :returns: Data, might add broadcast dimensions
@@ -2673,6 +2674,8 @@ class Data(object):
     mapped_axes = data.find_matching_dim_map(v, list(range(v.batch_ndim)), is_equal_opts)  # maps v -> data
     assert len(mapped_axes) == v.batch_ndim
 
+    except_axis_int = data.get_axis_from_description(except_axis, allow_int=True) if except_axis is not None else None
+
     for target_axis in range(data.batch_ndim):
       new_v_axis = min(target_axis, v.batch_ndim)
       if target_axis not in mapped_axes.values():
@@ -2681,7 +2684,9 @@ class Data(object):
             "%s.copy_compatible_to(%s) not allowed, axis %i (%s) not in source" % (
               self, data, target_axis, data.dim_tags[target_axis]))
         # Dim in data, but not in v
-        unbroadcast_axis = unbroadcast and not (except_feature and data.feature_dim_axis == target_axis)
+        unbroadcast_axis = unbroadcast and not (
+          except_feature and data.feature_dim_axis == target_axis) and not (
+          except_axis_int is not None and except_axis_int == target_axis)
         v = v.copy_add_dim_by_tag(data.get_dim_tag(target_axis), axis=new_v_axis, unbroadcast=unbroadcast_axis)
         # Keep mapped_axes consistent
         mapped_axes = {v_ax + (1 if v_ax >= new_v_axis else 0): trg_ax for v_ax, trg_ax in mapped_axes.items()}


### PR DESCRIPTION
Currently, PostfixInTimeLayer does not work if the postfix layer input does not have a batch dim.

The problem is that using `copy_compatible_to` the batch dim is added with dim 1 and then the concatenation fails since there is a mismatch between the two batch dimension.

This change uses the unbroadcast option to expand all axes with dim 1 to the required dim.
Since we want to include the time dim (what is currently not supported by copy_compatible_to), is added the option to exclude an arbitrary axis from unbroadcasting.