### PR TITLE
Solution for ambiguous dim tags

### DIFF
--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -80,7 +80,9 @@ class Dim(object):
       the behavior is to consider them as equal,
       and assume that the chain of operations (e.g. padding + valid conv) results in the same dim.
     :param Dim.Op|None derived_from_op:
-    :param int match_priority: when there is ambiguity between multiple dim tags, this can be used to resolve it.
+    :param int match_priority: when there is ambiguity between multiple dim tags, this value defines the order
+      in which the dimension are assigned to their matching counterparts.
+      A dimension tag with a higher priority value is assigned first.
       E.g. for a square matrix used for a linear transformation, the reduce dim tag should have a higher priority.
     :param BatchInfo|None batch: for batch-dim, or dynamic dims per batch
     :param ControlFlowContext|None control_flow_ctx:
@@ -4375,7 +4377,9 @@ class Data(object):
       if len(dims) > 1:
         max_match_priority = max(self.dim_tags[i].match_priority for i in dims)
         dims = [i for i in dims if self.dim_tags[i].match_priority == max_match_priority]
-      assert len(dims) <= 1, "%s: matching dim %s must be unique" % (self, axes)
+      assert len(dims) <= 1, (
+        "%s: matching dim %s must be unique,"
+        " use `match_priority` to resolve the matching order of ambiguous dimensions" % (self, axes))
       return dims
     if isinstance(axes, int):
       self._verify_axis_int_from_description(allow_int=allow_int)

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -4293,6 +4293,41 @@ def test_DotLayer2():
     assert_equal(out.shape, (S1, S2, B, V))
 
 
+def test_DotLayer_linear_square_matrix():
+  from returnn.tf.util.data import batch_dim
+  time_dim = SpatialDim("time")
+  feat_dim = FeatureDim("feature", dimension=3)
+  config = Config({
+    "extern_data": {
+      "data": {"dim_tags": [batch_dim, time_dim, feat_dim]},
+      "matrix_ambiguous": {"dim_tags": [feat_dim, feat_dim], "available_for_inference": True},
+      "matrix_non_ambiguous": {
+        "dim_tags": [feat_dim.copy(match_priority=1), feat_dim], "available_for_inference": True},
+    },
+  })
+  with make_scope() as session:
+    net = TFNetwork(config=config)
+    try:
+      net.construct_from_dict({
+        "output": {
+          "class": "dot", "from": ["data:data", "data:matrix_ambiguous"], "reduce": feat_dim
+        },
+      })
+    except Exception as exc:
+      print("Expected exception: %r" % exc)
+      assert "must be unique" in str(exc)
+    else:
+      raise Exception("Expected exception but constructed layer: %s" % net.get_default_output_layer())
+    net.construct_from_dict({
+      "output": {
+        "class": "dot", "from": ["data:data", "data:matrix_non_ambiguous"], "reduce": feat_dim
+      },
+    })
+    out = net.get_default_output_layer().output
+    assert out.dim_tags == (batch_dim, time_dim, feat_dim)
+    session.run(out.placeholder, feed_dict=make_feed_dict(net.extern_data))
+
+
 def test_DotLayer_mask_dyn_seq():
   batch = Dim(kind=Dim.Types.Batch, description="batch")
   time = SpatialDim("time")


### PR DESCRIPTION
Consider the example (also in the test) to use `DotLayer` using a square matrix, so its two dimensions are the same.

```
from returnn.tf.util.data import batch_dim
time_dim = SpatialDim("time")
feat_dim = FeatureDim("feature", dimension=3)
config = Config({
  "extern_data": {
    "data": {"dim_tags": [batch_dim, time_dim, feat_dim]},
    "matrix_ambiguous": {"dim_tags": [feat_dim, feat_dim], "available_for_inference": True},
  },
})
```

Here, `{"class": "dot", "from": ["data:data", "data:matrix_ambiguous"], "reduce": feat_dim}` does not work because it is ambiguous.

Introducing the `Dim.match_priority` solves this problem, by having:
```
"matrix_non_ambiguous": {
  "dim_tags": [feat_dim.copy(match_priority=1), feat_dim], "available_for_inference": True},
```

This was suggested here: https://github.com/rwth-i6/returnn_common/issues/17#issuecomment-997463222

While maybe not the nicest solution, I don't really see any better solution at the moment.

This PR is also a test if anything else breaks.
