### PR TITLE
tf.util: backwards compatibility for DimensionTag import

### DIFF
--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -16,7 +16,7 @@ import typing
 from returnn.util.basic import NotSpecified, NativeCodeCompiler
 import returnn.tf.compat as tf_compat
 # noinspection PyUnresolvedReferences
-from .data import Data, SearchBeam, Dim
+from .data import Data, SearchBeam, Dim, DimensionTag
 
 
 class CollectionKeys:


### PR DESCRIPTION
To support old configs using `from TFUtil import DimensionTag`. The problem is that `TFUtil` is mapped to `tf.util.basic`, but `DimensionTag` is only defined in `tf.util.data`.

Of course it is trivial to fix the config, just wanted to make you aware.