### PR TITLE
Update compile_tf_graph.py for new RASR decoder

### DIFF
--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -2836,12 +2836,13 @@ class _SubnetworkRecCell(object):
         return res
 
     # noinspection PyUnusedLocal
-    def cond(i, net_vars, acc_tas, seq_len_info=None):
+    def cond(i, net_vars, acc_tas, seq_len_info=None, allow_inf_max_len=False):
       """
       :param tf.Tensor i: loop counter, scalar
       :param net_vars: the accumulator values. see also self.get_init_loop_vars()
       :param list[tf.TensorArray] acc_tas: the output accumulator TensorArray
       :param (tf.Tensor,tf.Tensor)|None seq_len_info: tuple (end_flag, seq_len)
+      :param bool allow_inf_max_len:
       :return: True -> we should run the current loop-iteration, False -> stop loop
       :rtype: tf.Tensor
       """
@@ -2861,7 +2862,8 @@ class _SubnetworkRecCell(object):
           assert rec_layer._max_seq_len is None, "%r: unsupported max_seq_len %r" % (rec_layer, rec_layer._max_seq_len)
         # Check not considering seq_len_info because the dynamics of the network can also lead
         # to an infinite loop, so enforce that some maximum is specified.
-        assert res is not True, "%r: specify max_seq_len" % rec_layer
+        if not allow_inf_max_len:
+          assert res is not True, "%r: specify max_seq_len" % rec_layer
         if seq_len_info is not None:
           end_flag, _ = seq_len_info
           any_not_ended = tf.reduce_any(tf.logical_not(end_flag), name="any_not_ended")

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -501,6 +501,20 @@ class TFNetwork(object):
       s += " search"
     return "<%s>" % s
 
+  def get_network_hierarchy(self):
+    """
+    :return: list of all networks in the hierarchy, including self.
+    """
+    net = self
+    ret = []
+    while net:
+      ret.append(net)
+      while net.extra_parent_net:
+        net = net.extra_parent_net
+      net = net.parent_net
+    ret.reverse()
+    return ret
+
   def get_root_network(self):
     """
     :rtype: TFNetwork

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -78,7 +78,6 @@ network = {
         "embed": {"class": "linear", "from": "prev:output", "activation": "sigmoid", "n_out": 3},
         "prob": {"class": "softmax", "from": ["embed", "data:source"], "loss": "ce", "target": "classes"},
         "output": {"class": "choice", "beam_size": 4, "from": "prob", "target": "classes", "initial_output": 0},
-        "end": {"class": "compare", "from": "output", "value": 0}
       }
     },
 }
@@ -121,7 +120,6 @@ def test_compile_tf_graph_enc_dec_recurrent_step():
     os.path.join(tmp_dir, "returnn.config")
   ]
   run(*args)
-
 
 
 def test_compile_tf_graph_transducer_time_sync_recurrent_step():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -11,6 +11,8 @@ import os
 import sys
 
 
+my_dir = os.path.dirname(os.path.abspath(__file__))
+base_dir = os.path.dirname(my_dir)
 py = sys.executable
 print("Python:", py)
 
@@ -19,7 +21,7 @@ def run(*args):
   args = list(args)
   print("run:", args)
   # RETURNN by default outputs on stderr, so just merge both together
-  p = Popen(args, stdout=PIPE, stderr=STDOUT)
+  p = Popen(args, stdout=PIPE, stderr=STDOUT, cwd=base_dir)
   out, _ = p.communicate()
   if p.returncode != 0:
     print("Return code is %i" % p.returncode)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -55,7 +55,8 @@ network = {
       "class": "rec", "from": [], "target": "classes",
       "unit": {
         "embed": {"class": "linear", "from": "prev:output", "activation": "sigmoid", "n_out": 3},
-        "prob": {"class": "softmax", "from": ["embed", "base:enc1"], "loss": "ce", "target": "classes"},
+        "s": {"class": "rec", "unit": "lstm", "from": ["embed", "base:enc1"], "n_out": 3},
+        "prob": {"class": "softmax", "from": "s", "loss": "ce", "target": "classes"},
         "output": {"class": "choice", "beam_size": 4, "from": "prob", "target": "classes", "initial_output": 0},
         "end": {"class": "compare", "from": "output", "value": 0}
       }
@@ -76,7 +77,8 @@ network = {
       "class": "rec", "from": "encoder", "target": "classes",
       "unit": {
         "embed": {"class": "linear", "from": "prev:output", "activation": "sigmoid", "n_out": 3},
-        "prob": {"class": "softmax", "from": ["embed", "data:source"], "loss": "ce", "target": "classes"},
+        "s": {"class": "rec", "unit": "lstm", "from": ["embed", "data:source"], "n_out": 3},
+        "prob": {"class": "softmax", "from": "s", "loss": "ce", "target": "classes"},
         "output": {"class": "choice", "beam_size": 4, "from": "prob", "target": "classes", "initial_output": 0},
       }
     },

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -89,7 +89,7 @@ use_tensorflow = True
 """
 
 
-rec_transducer_time_sync_delayed_data_config = """
+rec_transducer_time_sync_delayed_config = """
 #!rnn.py
 network = {
     "encoder": {"class": "linear", "from": "data", "activation": "sigmoid", "n_out": 3},
@@ -100,7 +100,7 @@ network = {
         "prob": {"class": "softmax", "from": "s", "loss": "ce", "target": "classes"},
         "output": {"class": "choice", "beam_size": 4, "from": "prob", "target": "classes", "initial_output": 0},
         "embed": {"class": "linear", "from": "output", "activation": "sigmoid", "n_out": 3},
-        "s2": {"class": "rec", "unit": "lstm", "from": ["embed", "prev:embed", "data:source"], "n_out": 3},
+        "s2": {"class": "rec", "unit": "lstm", "from": ["embed", "prev:s"], "n_out": 3},
       }
     },
 }
@@ -160,10 +160,10 @@ def test_compile_tf_graph_transducer_time_sync_recurrent_step():
   run(*args)
 
 
-def test_compile_tf_graph_transducer_time_sync_delayed_data_recurrent_step():
+def test_compile_tf_graph_transducer_time_sync_delayed_recurrent_step():
   tmp_dir = tempfile.mkdtemp()
   with open(os.path.join(tmp_dir, "returnn.config"), "wt") as config:
-    config.write(rec_transducer_time_sync_delayed_data_config)
+    config.write(rec_transducer_time_sync_delayed_config)
   args = [
     "tools/compile_tf_graph.py",
     "--output_file",

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -106,7 +106,6 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
     """
     :param RecStepByStepLayer.StateVar state_var:
     :param Data output:
-    :param tf.Tensor x:
     :rtype: tf.Tensor
     """
     assert isinstance(state_var, RecStepByStepLayer.StateVar)

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -375,7 +375,7 @@ class RecStepByStepLayer(RecLayer):
 
       for hyp in current_hyps:  # (in practice, this is partially batched)
 
-        state_vars.assign(...)  # for current hyp
+        state_vars.assign(...)  # for current hyp (might be skipped in first decoder loop iteration)
         decoder_input_vars.assign(...)  # for current hyp, the previous choice
 
         update_ops(decoder_input_vars)  # -> assign/update potentially some loop state vars

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -265,6 +265,8 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
       rec_layer.set_state_var_final_value("cond", cond(i, net_vars, acc_tas, seq_len_info, allow_inf_max_len=True))
 
     with tf.name_scope("body"):
+      # The body function is locally defined in _SubnetworkRecCell.get_output().
+      # This function then calls _SubnetworkRecCell._construct() which will do the subnet construction.
       res = body(i, net_vars, acc_tas, seq_len_info)
       assert len(res) == len(loop_vars)
       if len(res) == 3:

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -407,11 +407,15 @@ class RecStepByStepLayer(RecLayer):
   The update calculation from "prev:layer" to "layer" would be jointly with decode_ops
   to avoid redundant computation.
   This should be the first decode_ops if there are multiple.
+  This makes the post_update_ops obsolete.
 
   For delayed state vars, before we do anything else,
   in the beginning of the iteration, we need to update "prev:prev:layer" to "prev:layer",
   or also set "prev:layer" based on the prev choices (e.g. "prev:output").
+  For this, we need to know which dependencies on the state are needed for "layer" ("prev:layer"),
+  and then all such dependencies are needed to be stored as delayed state vars as well.
   Then everything else in the iteration can be done as usual.
+  This first step will be the update_ops.
 
   ---
 

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -141,6 +141,8 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
     """
     if dim_tag.dimension is not None:
       return dim_tag  # as-is, not dynamic
+    if dim_tag.is_batch_dim():
+      return dim_tag  # as-is
     if dim_tag in self._parent_dim_tags:
       return self._parent_dim_tags[dim_tag]
     rec_layer = self.parent_rec_layer

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -330,7 +330,7 @@ class RecStepByStepLayer(RecLayer):
   - decoder_output_vars: Stochastic scores state vars, updated by the decoder loop.
   - (Deterministic) loop state vars, updated by the decoder loop.
 
-  RASR does the following logic::
+  RASR does the following logic (currently only a single stochastic var supported)::
 
     # initial state vars
     encode_ops(input_placeholders=...)  # -> assign (base and loop) state_vars
@@ -345,17 +345,11 @@ class RecStepByStepLayer(RecLayer):
 
         update_ops(decoder_input_vars)  # -> assign/update potentially some loop state vars
 
-        # Loop over stochastic vars, and call decode_ops for each.
-        for (choices, scores, decode_op) in zip(decoder_input_vars, decoder_output_vars, decode_ops):
+        # Assume only a single decode_ops here (single ChoiceLayer).
+        # decoder_input_vars contains prev choices
+        decode_ops(state_vars, decoder_input_vars)  # -> assign decoder_output_vars (scores)
 
-          for all_possible_succeeding_input_vars:  # loop not needed for first stochastic var
-
-            decoder_input_vars[:i].assign(...)  # ...
-
-            # decoder_input_vars contains prev choices
-            decode_ops(state_vars, decoder_input_vars)  # -> assign scores
-
-        decoder_input_vars.assign(...)  # for current hyp, (still!) the previous (!) choice
+        # note that decoder_input_vars for current hyp is still the previous (!) choice
 
         post_update_ops(state_vars, decoder_input_vars)  # -> assign new state_vars
 

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -358,7 +358,10 @@ class RecStepByStepLayer(RecLayer):
   Because RASR is the main application, we adopt the recurrence logic of the RecLayer to be compatible to RASR.
 
   Note that the update_ops, decode_ops and post_update_ops all depend on the previous state vars (obviously)
-  and on the previous (!) choice vars and not on the current choice vars.
+  or maybe decode_ops would depend on some updated state vars, updated by update_ops,
+  or maybe post_update_ops would depend on some updated state vars, updated by decode_ops or update_ops.
+  The logic flow is as outlined above.
+  And all ops depends on the previous (!) choice vars and not on the current choice vars.
   This is in contrast to RETURNN, where the final loop state vars are potentially based on the current choice var.
 
   One way to solve this is by delaying the state vars by one iteration.

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -249,10 +249,14 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
       seq_len_info = rec_layer.create_state_vars_recursive(["end_flag", "dyn_seq_len"], seq_len_info)
     i, _ = rec_layer.create_state_var("i", i)
     with tf.name_scope("state"):
-      # See _SubnetworkRecCell.GetOutput.body.
-      # net_vars is (prev_outputs_flat, prev_extra_flat), and prev_outputs_flat corresponds to self._initial_outputs,
+      # See _SubnetworkRecCell.get_output().body().
+      # net_vars is (prev_outputs_flat, prev_extra_flat).
+      # prev_outputs_flat corresponds to the dict self._initial_outputs, specifically sorted(self._initial_outputs)
       # where the keys are the layer names.
       # prev_extra is always expected to be batch-major.
+      # prev_extra_flat corresponds to the dict self._initial_extra_outputs,
+      # specifically sorted(self._initial_extra_outputs),
+      # where the keys are the layer names.
       prev_outputs_data = [self.layer_data_templates[k].output for k in sorted(self._initial_outputs.keys())]
       net_vars = rec_layer.create_state_vars_recursive(
         name_prefix="state", initial_values=net_vars, data_shape=(prev_outputs_data, None))

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -872,7 +872,7 @@ class RecStepByStepLayer(RecLayer):
     # We do not make use of global_vars anymore because this is redundant with the state vars.
     # We anyway create the collection here such that older RASR binaries still work fine.
     # See https://github.com/rwth-i6/returnn/pull/874.
-    tf_compat.v1.get_collection_ref("global_vars")
+    global_vars_coll = tf_compat.v1.get_collection_ref("global_vars")
 
     # Encoder and all decoder state initializers.
     encode_ops_coll = tf_compat.v1.get_collection_ref("encode_ops")
@@ -934,7 +934,10 @@ class RecStepByStepLayer(RecLayer):
       assert isinstance(name, str)
       assert isinstance(var, RecStepByStepLayer.StateVar)
       if not name.startswith("stochastic_var_") and not name.startswith("base_") and name != "cond":
-        state_vars_coll.append(var.var)
+        if var.orig_data_shape.have_batch_axis():
+          state_vars_coll.append(var.var)
+        else:
+          global_vars_coll.append(var.var)
 
     import json
     info_str = json.dumps(info, sort_keys=True, indent=2)

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -709,6 +709,8 @@ class RecStepByStepLayer(RecLayer):
     assert data_shape or initial_value is not None
     if data_shape:
       assert isinstance(data_shape, Data)
+      if data_shape.have_batch_axis() and initial_value is not None:
+        assert initial_value.shape.dims[data_shape.batch_dim_axis].value is None
     elif initial_value.shape.ndims == 0:
       data_shape = Data(name=name, batch_dim_axis=None, shape=(), dtype=initial_value.dtype.name)
     else:

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -933,7 +933,7 @@ class RecStepByStepLayer(RecLayer):
     for name, var in sorted(rec_layer.state_vars.items()):
       assert isinstance(name, str)
       assert isinstance(var, RecStepByStepLayer.StateVar)
-      if not name.startswith("stochastic_var_") and not name.startswith("base_"):
+      if not name.startswith("stochastic_var_") and not name.startswith("base_") and name != "cond":
         state_vars_coll.append(var.var)
 
     import json

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -294,6 +294,8 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
     # So we add tiling here.
     assert data is not None
     for key, value in list(data.items()):
+      if key != "source":
+        continue  # ignore other sources currently...
       assert key in self.net.extern_data.data
       data_ = self.net.extern_data.data[key]
       data[key] = self._tiled(data_, value)

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -529,8 +529,9 @@ class RecStepByStepLayer(RecLayer):
       # which replace references to variables in `initial_value` with references to the variable's initialized values.
       # This is not what we want. Also, it has a cycle check which is extremely inefficient and basically just hangs.
       # Instead, some dummy initializer. The shape should not matter.
+      dyn_one = tf_compat.v1.placeholder_with_default(tf.constant(1), ())
       zero_initializer = tf.zeros(
-        [d if (d is not None) else 1 for d in self.var_data_shape.batch_shape],
+        [d if (d is not None) else dyn_one for d in self.var_data_shape.batch_shape],
         dtype=self.var_data_shape.dtype)
       zero_initializer.set_shape(self.var_data_shape.batch_shape)
       with helper_variable_scope():

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -264,7 +264,7 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
       seq_len_info = None
     else:
       i, net_vars, acc_tas, seq_len_info = loop_vars
-      seq_len_info_ = rec_layer.create_state_vars_recursive(["end_flag", "dyn_seq_len"], seq_len_info)
+      seq_len_info_ = rec_layer.create_state_vars_recursive(("end_flag", "dyn_seq_len"), seq_len_info)
       seq_len_info = nest.map_structure(lambda state_var: state_var.read(), seq_len_info_)
     initial_i = i
     i = rec_layer.create_state_var("i", initial_i).read()
@@ -513,7 +513,7 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
       else:
         i, net_vars, acc_tas, seq_len_info = res
     if seq_len_info:
-      state_update_ops += rec_layer.assign_state_vars_recursive_flatten(["end_flag", "dyn_seq_len"], seq_len_info)
+      state_update_ops += rec_layer.assign_state_vars_recursive_flatten(("end_flag", "dyn_seq_len"), seq_len_info)
     state_update_ops.append(rec_layer.state_vars["i"].assign(i))
 
     # Assign new state.
@@ -1199,7 +1199,7 @@ class RecStepByStepLayer(RecLayer):
 
   def create_state_vars_recursive(self, name_prefix, initial_values, data_shapes=None):
     """
-    :param str|list[str] name_prefix: single or same structure as initial_values
+    :param str|tuple[str] name_prefix: single or same structure as initial_values
     :param T initial_values:
     :param data_shapes: same structure as initial_values or None, but values are of instance :class:`Data`
     :return: same as initial_values, but the state vars
@@ -1224,7 +1224,7 @@ class RecStepByStepLayer(RecLayer):
 
   def assign_state_vars_recursive_flatten(self, name_prefix, values):
     """
-    :param str|list[str] name_prefix:
+    :param str|tuple[str] name_prefix:
     :param T values:
     :rtype: list[tf.Operation]
     """

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -420,6 +420,12 @@ class RecStepByStepLayer(RecLayer):
   Then everything else in the iteration can be done as usual.
   This first step will be the update_ops.
 
+  So first we need to figure out which state vars are needed of what kind.
+  Then we must construct the update_ops for one part of layers.
+  Then we must construct the decode_ops (including merged post_update_ops) for another set of layers,
+  and there can be overlap both in the inputs and outputs,
+  so these must be two separate constructions.
+
   ---
 
   If you want to implement beam search in an external application which uses the compiled graph,

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -610,7 +610,7 @@ class RecStepByStepLayer(RecLayer):
         value = x.placeholder
       return tf_compat.v1.assign(self.var, value, name="final_state_var_%s" % self.name).op
 
-  def __init__(self, _orig_sources, sources, network, name, output, unit, axis, 
+  def __init__(self, _orig_sources, sources, network, name, output, unit, axis,
                reverse_stochastic_var_order=False, **kwargs):
     """
     :param str|list[str]|None _orig_sources:

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -254,13 +254,8 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
     self.net.get_global_batch_info().dim = rec_layer.get_batch_dim_from_state()
 
     with tf.name_scope("cond"):
-      # there is no max_seq_len limit for the step-by-step function, so the loop
-      # condition only depends on the end flags or is true if those do not exist
       rec_layer.create_state_var("cond", tf.constant(True))
-      if seq_len_info:
-        end_flag, _ = seq_len_info
-        res = tf.reduce_any(tf.logical_not(end_flag), name="any_not_ended")
-        rec_layer.set_state_var_final_value("cond", res)
+      rec_layer.set_state_var_final_value("cond", cond(i, net_vars, acc_tas, seq_len_info))
 
     with tf.name_scope("body"):
       res = body(i, net_vars, acc_tas, seq_len_info)

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -269,11 +269,14 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
       queue = [template_layer]
       visited = set()
       prev_frame_deps = set()
+      choice_deps = set()
       while queue:
         cur = queue.pop(0)
         if cur in visited:
           continue
         visited.add(cur)
+        if cur.layer_class_type is ChoiceStateVarLayer:
+          choice_deps.add(cur)
         for dep in cur.cur_frame_dependencies:
           if dep in visited:
             continue

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -767,7 +767,7 @@ class ChoiceStateVarLayer(LayerBase):
       name="stochastic_var_scores_%s" % self.name, data_shape=source.output)
     rec_layer.set_state_var_final_value(
       name="stochastic_var_scores_%s" % self.name, final_value=scores_in)
-    self.output.placeholder = rec_layer.create_state_var(
+    self.output.placeholder, _ = rec_layer.create_state_var(
       name="stochastic_var_choice_%s" % self.name, data_shape=self.output)
     rec_layer.add_stochastic_var(self.name)
 

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -291,7 +291,6 @@ class RecStepByStepLayer(RecLayer):
       - Set the stochastic state var `"stochastic_var_choice_%s" % name` to the selected values (label indices).
       - If the beam has multiple items, i.e. the batch dimension changed, you must make sure
         that all further used state variables will also have the same batch dim.
-      - You can use "select_src_beams" to select the new states given the choices.
     * Do a single session run for the next values of these state vars:
       "i", "end_flag" (if existing), "dyn_seq_len" (if existing), "state_*" (multiple vars).
       These are also the state vars which will get updated in every further recurrent step.
@@ -321,13 +320,7 @@ class RecStepByStepLayer(RecLayer):
   * "stochastic_var_order": list[str]. the order of the stochastic vars.
 
   * "init_op": str. op. the initializer for all state vars, including encoder.
-  * "tile_batch": dict[str, str]. might not be used by the decoder. dict with:
-    * "op": str. the op for tiling the batch dim.
-    * "repetitions_placeholder": str. placeholder for the number of repetitions.
   * "next_step_op: str. op. the update op for all state vars.
-  * "select_src_beams": dict[str, str]. might not be used by the decoder. dict with:
-    * "op": str. op name for selecting the beams.
-    * "src_beams_placeholder": str. placeholder for the number of source beams indices.
 
   """
 

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -544,7 +544,7 @@ class RecStepByStepLayer(RecLayer):
         feed_tensors.append(data.placeholder)
         feed_tensors.extend(data.size_placeholder.values())
       path = find_ops_path_output_to_input(fetches=value, tensors=feed_tensors)
-      assert not path, "There should be no path from extern data to this final op value, but there is: %r" % (path,)
+      assert not path, "There should be no path from extern data to %s final op value, but there is: %r" % (self, path)
       if self.orig_data_shape.batch_dim_axis not in (0, None):
         x = self.orig_data_shape.copy()
         x.placeholder = value

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -363,12 +363,18 @@ class RecStepByStepLayer(RecLayer):
     # initial state vars
     encode_ops(input_placeholders=...)  # -> assign (base and loop) state vars
 
+    # state_vars are only the loop state vars here, not the base state vars.
+    # Store initial loop state values.
+    # Note that this is not really necessary always (including the logic described here)
+    # because we anyway then assign them again in the first iteration of the decoder loop
+    # and never need them otherwise again.
+    state_vars.readout()
+
     # Main decoder loop
     while seq_not_ended(...):
 
       for hyp in current_hyps:  # (in practice, this is partially batched)
 
-        # state_vars are only the loop state vars here, not the base state vars
         state_vars.assign(...)  # for current hyp
         decoder_input_vars.assign(...)  # for current hyp, the previous choice
 

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -94,6 +94,7 @@ def helper_variable_scope():
 class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
   """
   Adapts :class:`_SubnetworkRecCell` such that we execute only a single step.
+  Used by :class:`RecStepByStepLayer`. See :class:`RecStepByStepLayer` for further documentation.
   """
 
   def __init__(self, **kwargs):
@@ -480,6 +481,16 @@ class RecStepByStepLayer(RecLayer):
   * "init_op": str. op. the initializer for all state vars, including encoder.
   * "next_step_op: str. op. the update op for all state vars.
 
+  ---
+
+  This layer class derives from :class:`RecLayer` and adopts the logic to be able
+  to construct the mentioned ops for step-by-step execution.
+
+  The final ops are constructed in :func:`post_compile`
+  and put into corresponding TF graph collections and the info json.
+
+  However, the main construction logic happens before, in :func:`__init__`,
+  and then further in :func:`SubnetworkRecCellSingleStep._while_loop`.
   """
 
   layer_class = "rec_step_by_step"
@@ -788,6 +799,7 @@ class RecStepByStepLayer(RecLayer):
     self.construction_state = self.ConstructionState.Init
     if self.have_base_state_vars():
       self._set_global_batch_dim(self.get_batch_dim_from_base_state_var())
+    # This will eventually get to SubnetworkRecCellSingleStep._while_loop.
     super(RecStepByStepLayer, self).__init__(
       sources=sources, network=network, name=name, output=output, unit=unit, axis=axis, **kwargs)
 

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -173,6 +173,7 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
     for i, dim_tag in enumerate(output.dim_tags):
       new_dim_tags.append(self._get_parent_dim_tag(dim_tag))
     output = output.copy_template_new_dim_tags(new_dim_tags=new_dim_tags, keep_special_axes=True)
+    output.placeholder = layer.output.placeholder
     x, state_var = rec_layer.create_state_var(
       name="base_value_%s" % layer_name, initial_value=output.placeholder, data_shape=output)
     self._maybe_delay_tiled(state_var, output)

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -29,7 +29,7 @@ from returnn.tf.network import TFNetwork
 from returnn.tf.layers.basic import LayerBase, register_layer_class
 from returnn.tf.layers.base import WrappedInternalLayer
 # noinspection PyProtectedMember
-from returnn.tf.layers.rec import RecLayer, _SubnetworkRecCell, ChoiceLayer
+from returnn.tf.layers.rec import RecLayer, _SubnetworkRecCell
 
 
 config = None  # type: typing.Optional[Config]

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -389,6 +389,8 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
       for layer_name in layers_cur_iteration:
         layers_prev[layer_name] = _LayerStateHelper(layer_name, "state")
 
+    # TODO create choice state vars now, so that we can use them in the loop below...
+
     # We are ignoring acc_tas (the tensor arrays).
 
     self._set_construction_state_in_loop()
@@ -407,6 +409,7 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
           prev_state={
             layer_name: layers_prev_prev[layer_name].get_reads()
             for layer_name in layers_delayed_prev_deps},
+          # TODO add prev:output ... always because the delayed state by definition depends on it
           cur_state={
             layer_name: layers_prev[layer_name].get_reads()
             for layer_name in layers_cur_iteration},

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -992,7 +992,9 @@ class RecStepByStepLayer(RecLayer):
       zero_initializer.set_shape(self.var_data_shape.batch_shape)
       with helper_variable_scope():
         self.var = tf_compat.v1.get_variable(
-          name=name, initializer=zero_initializer, validate_shape=False)  # type: tf.Variable
+          name=tf_util.get_valid_scope_name_from_str(name),
+          initializer=zero_initializer,
+          validate_shape=False)  # type: tf.Variable
       self.var.set_shape(self.var_data_shape.batch_shape)
       self._init_op = None
       print("New state var %r: %s, shape %s" % (name, self.var, self.var_data_shape))

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -676,7 +676,7 @@ class RecStepByStepLayer(RecLayer):
 
   def _set_global_batch_dim(self, batch_dim):
     """
-    :param tf.Tensor batch_dim
+    :param tf.Tensor batch_dim:
     """
     self.network.get_global_batch_info().dim = batch_dim
 

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -336,6 +336,8 @@ class RecStepByStepLayer(RecLayer):
     info_str = json.dumps(info, sort_keys=True, indent=2)
     if not output_file_name:
       print("No rec-step-by-step output file name specified, not storing this info.")
+      print("JSON:")
+      print(info_str)
     else:
       with open(output_file_name, "w") as f:
         f.write(info_str)


### PR DESCRIPTION
This is PR #266 cleaned up.

This will be ongoing.

Categorization (terminology) of state vars:

- base state vars: not updated during the decoder steps. e.g. the encoder network
- loop state vars: not base and not stochastic
- stochastic state vars:
  - scores
  - choice

Just some summary of changes from the old PR #266 and which need to be done here:

- [x] `helper_variable_scope` with `reuse_name_scope("IO", absolute=True)`. Needed for some layers which might not expect other variables in their name scope. This is a simple helper to make it in a separate name scope.
- [x] Introduce TF graph collections. These are used by Sprint. Namely:
   ```
    update_ops_coll = tf.get_collection_ref("update_ops")
    post_update_ops_coll = tf.get_collection_ref("post_update_ops")
    encode_ops_coll = tf.get_collection_ref("encode_ops")
    decode_ops_coll = tf.get_collection_ref("decode_ops")
    decoder_input_vars_coll = tf.get_collection_ref("decoder_input_vars")
    decoder_output_vars_coll = tf.get_collection_ref("decoder_output_vars")
    global_vars_coll = tf.get_collection_ref("global_vars")
   ```
   And also `CollectionKeys.STATE_VARS`.
- [x] Update JSON. (Currently not really used besides for debugging, so format is open.)
- [ ] (test_tools.py should ideally be extended to have a simple search test case for this. If this is doable.)
- [x] Some test case for just running the script given some simple encoder-decoder or transducer model.
- [x] `update_ops`:
  - `var.final_op()` for choice dependent loop state vars
  - `set_parent_tile_multiple_op(tile_batch_multiple)`
- [x] `post_update_ops`:
  - `var.final_op()` for non-choice dependent loop state vars
- [x] `encode_ops`: This is basically the first op to be executed by Sprint after param loading (earlier "init_op"). It contains:
  - `var.init_op()` for all base state vars
  - `parent_tile_multiples_var.initializer`, which is just `tf.ones_initializer()`. Some loop state var inits might depend on the base. I restructured this however that at this point, it would not use the tiling.
  - `var.init_op()` (depending on the previous inits) for all loop state vars
- [x] `decode_ops`:
  - `var.final_op()` for stochastic score state vars (in stochastic var order)
- [x] `decoder_input_vars`: List of vars. the stochastic choice state vars (in stochastic var order)
- [x] `decoder_output_vars`: List of vars. the stochastic scores state vars (in stochastic var order)
- [x] `global_vars`: List of vars., hypothesis independent, without batch dim. Currently not used.
- [x] `CollectionKeys.STATE_VARS`: List of vars. all non-choice dependent loop state vars
- [x] Tiling of base state vars when they are used elsewhere is done always on-the-fly via `parent_tile_multiples_var`