### PR TITLE
Use -std=c++11 for gcc v4 and lower

### DIFF
--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -2413,16 +2413,27 @@ class VariableAssigner(object):
     session.run(self.assign_op, feed_dict={self.assign_op.inputs[1]: value})
 
 
+def get_tf_gcc_version():
+  """
+  :return: gcc version, e.g. "4.8.5"
+  :rtype: str|None
+  """
+  tf_gcc_version = getattr(tf, "__compiler_version__", None)  # e.g. "4.8.5" or "5.4.0 20160609"
+  if not tf_gcc_version:
+    return None
+  if " " in tf_gcc_version:
+    tf_gcc_version = tf_gcc_version[:tf_gcc_version.find(" ")]  # just "5.4.0"
+  return tf_gcc_version
+
+
 def _get_tf_gcc_path(bin_name):
   """
   :param str bin_name: e.g. "gcc" or "g++"
   :rtype: str
   """
   gcc_candidates = []
-  tf_gcc_version = getattr(tf, "__compiler_version__", None)
-  if tf_gcc_version:  # e.g. "4.8.5" or "5.4.0 20160609"
-    if " " in tf_gcc_version:
-      tf_gcc_version = tf_gcc_version[:tf_gcc_version.find(" ")]  # just "5.4.0"
+  tf_gcc_version = get_tf_gcc_version()
+  if tf_gcc_version:
     tf_gcc_version = tf_gcc_version.split(".")  # ["5", "4", "0"]
     for i in range(len(tf_gcc_version), 0, -1):
       gcc_candidates.append("%s-%s" % (bin_name, ".".join(tf_gcc_version[:i])))

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -3563,7 +3563,13 @@ class NativeCodeCompiler(object):
       f.write(self.code)
     common_opts = ["-shared", "-O2"]
     if self.is_cpp:
-      common_opts += ["-std=c++14"]
+      cpp_version_opt = "-std=c++14"
+      if BackendEngine.is_tensorflow_selected():
+        from returnn.tf.util.basic import get_tf_gcc_version
+        tf_gcc_version = get_tf_gcc_version()
+        if tf_gcc_version and int(tf_gcc_version[0]) <= 4:
+          cpp_version_opt = "-std=c++11"  # gcc 4 does not support c++14, needed to support TF 1.14 and earlier
+      common_opts += [cpp_version_opt]
     if sys.platform == "darwin":
       common_opts += ["-undefined", "dynamic_lookup"]
     for include_path in self._include_paths:


### PR DESCRIPTION
To keep support for TF <=1.14, which use gcc 4.8.