### PR TITLE
ReinterpretDataLayer, complete incomplete dim tags

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4333,6 +4333,9 @@ class ReinterpretDataLayer(_ConcatInputLayer):
     if set_dim_tags:
       for axis, tag in set_dim_tags.items():
         axis_int = out.get_axis_from_description(axis)
+        if tag.dimension is None and tag.dyn_size_ext is None:
+          # new, user-specified tag is incomplete, maybe copy its dynamic sizes.
+          tag.dyn_size_ext = out.dim_tags[axis_int].dyn_size_ext
         out = out.copy_template_replace_dim_tag(axis=axis_int, new_dim_tag=tag)
     if set_sparse is not None:
       assert isinstance(set_sparse, bool)

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -2016,6 +2016,23 @@ def test_out_shape():
       raise Exception("Expected an exception but did not get any.")
 
 
+def test_ReinterpretDataLayer_complete_incomplete_dim_tags():
+  from returnn.tf.util.data import batch_dim
+  with make_scope():
+    time_dim = SpatialDim("time")
+    other_time_dim = SpatialDim("other-time")
+    feat_dim = FeatureDim("feature", dimension=10)
+    config = Config({"extern_data": { "data": {"dim_tags": [batch_dim, time_dim, feat_dim]}}})
+    net = TFNetwork(config=config)
+    net.construct_from_dict({
+      "output": {
+        'class': 'reinterpret_data', 'from': 'data',
+        'set_dim_tags': {time_dim: other_time_dim},
+        "out_shape": {batch_dim, other_time_dim, feat_dim}}})
+    assert time_dim.dyn_size_ext is not None  # via extern_data
+    assert other_time_dim.dyn_size_ext == time_dim.dyn_size_ext  # completed by ReinterpretDataLayer
+
+
 def _check_MergeDimsLayer(session, in_data_opts, in_static_shape, opts, out_data_shape, out_static_shape,
                           in_sizes=None, out_sizes=None):
   """


### PR DESCRIPTION
I think in most cases if the user does something like this:
```
  other_time_dim = SpatialDim("other-time")
  ..
  net_dict = { # ..
    'reinterpret': {'from': 'input', 'set_dim_tags': {time_dim: other_time_dim}}
  .. }
```
they'd want `other_time_dim.dyn_size_ext == time_dim.dyn_size_ext`.
This PR adds this.