### PR TITLE
Use -std=c++11 for GCC 5 and lower

### DIFF
--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -2786,6 +2786,19 @@ class OpCodeCompiler(NativeCodeCompiler):
       return nvcc_opts
     return super(OpCodeCompiler, self)._transform_compiler_opts(opts)
 
+  def _extra_common_opts(self):
+    if self.is_cpp:
+      tf_gcc_version = get_tf_gcc_version()
+      if tf_gcc_version and int(tf_gcc_version[0]) <= 5:
+        # GCC4 does not support c++14, needed to support TF 1.14 and earlier
+        #   https://github.com/rwth-i6/returnn/pull/875
+        # GCC5 also has problems. https://github.com/rwth-i6/returnn/issues/890
+        cpp_version_opt = "-std=c++11"
+      else:
+        cpp_version_opt = "-std=c++14"
+      return [cpp_version_opt]
+    return []
+
   def load_tf_module(self):
     """
     :return: module
@@ -2825,6 +2838,9 @@ class TFNativeUtilCompiler(NativeCodeCompiler):
       **kwargs)
 
   _relevant_info_keys = NativeCodeCompiler._relevant_info_keys + ("tf_version",)
+
+  # noinspection PyProtectedMember
+  _extra_common_opts = OpCodeCompiler._extra_common_opts
 
   def _make_info_dict(self):
     from returnn.util.basic import describe_tensorflow_version

--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -2413,16 +2413,27 @@ class VariableAssigner(object):
     session.run(self.assign_op, feed_dict={self.assign_op.inputs[1]: value})
 
 
+def get_tf_gcc_version():
+  """
+  :return: gcc version, e.g. "4.8.5"
+  :rtype: str|None
+  """
+  tf_gcc_version = getattr(tf, "__compiler_version__", None)  # e.g. "4.8.5" or "5.4.0 20160609"
+  if not tf_gcc_version:
+    return None
+  if " " in tf_gcc_version:
+    tf_gcc_version = tf_gcc_version[:tf_gcc_version.find(" ")]  # just "5.4.0"
+  return tf_gcc_version
+
+
 def _get_tf_gcc_path(bin_name):
   """
   :param str bin_name: e.g. "gcc" or "g++"
   :rtype: str
   """
   gcc_candidates = []
-  tf_gcc_version = getattr(tf, "__compiler_version__", None)
-  if tf_gcc_version:  # e.g. "4.8.5" or "5.4.0 20160609"
-    if " " in tf_gcc_version:
-      tf_gcc_version = tf_gcc_version[:tf_gcc_version.find(" ")]  # just "5.4.0"
+  tf_gcc_version = get_tf_gcc_version()
+  if tf_gcc_version:
     tf_gcc_version = tf_gcc_version.split(".")  # ["5", "4", "0"]
     for i in range(len(tf_gcc_version), 0, -1):
       gcc_candidates.append("%s-%s" % (bin_name, ".".join(tf_gcc_version[:i])))

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -3542,6 +3542,12 @@ class NativeCodeCompiler(object):
     """
     return opts
 
+  def _extra_common_opts(self):
+    """
+    :rtype: list[str]
+    """
+    return []
+
   @classmethod
   def _transform_ld_flag(cls, opt):
     """
@@ -3562,14 +3568,7 @@ class NativeCodeCompiler(object):
     with open(self._c_filename, "w") as f:
       f.write(self.code)
     common_opts = ["-shared", "-O2"]
-    if self.is_cpp:
-      cpp_version_opt = "-std=c++14"
-      if BackendEngine.is_tensorflow_selected():
-        from returnn.tf.util.basic import get_tf_gcc_version
-        tf_gcc_version = get_tf_gcc_version()
-        if tf_gcc_version and int(tf_gcc_version[0]) <= 4:
-          cpp_version_opt = "-std=c++11"  # gcc 4 does not support c++14, needed to support TF 1.14 and earlier
-      common_opts += [cpp_version_opt]
+    common_opts += self._extra_common_opts()
     if sys.platform == "darwin":
       common_opts += ["-undefined", "dynamic_lookup"]
     for include_path in self._include_paths:

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -3563,7 +3563,13 @@ class NativeCodeCompiler(object):
       f.write(self.code)
     common_opts = ["-shared", "-O2"]
     if self.is_cpp:
-      common_opts += ["-std=c++14"]
+      cpp_version_opt = "-std=c++14"
+      if BackendEngine.is_tensorflow_selected():
+        from returnn.tf.util.basic import get_tf_gcc_version
+        tf_gcc_version = get_tf_gcc_version()
+        if tf_gcc_version and int(tf_gcc_version[0]) <= 4:
+          cpp_version_opt = "-std=c++11"  # gcc 4 does not support c++14, needed to support TF 1.14 and earlier
+      common_opts += [cpp_version_opt]
     if sys.platform == "darwin":
       common_opts += ["-undefined", "dynamic_lookup"]
     for include_path in self._include_paths:


### PR DESCRIPTION
Updated PR #875, resolving the concerns, and also fixing #890.
