### PR TITLE
Issues in SplitDimsLayer

### DIFF
--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -2066,6 +2066,19 @@ def test_SplitDimsLayer_dim_tags():
     })
 
 
+def test_SplitDimsLayer_dim_tags_split_batch():
+  from returnn.tf.util.data import batch_dim
+  time_dim = SpatialDim("in-time")
+  feat_dim = FeatureDim("feat", 3)
+  config = Config({
+    "extern_data": {"data": {"dim_tags": [batch_dim, time_dim, feat_dim]}}})
+  net = TFNetwork(config=config)
+  net.construct_from_dict({
+    "output": {
+      'class': 'split_dims', 'from': 'data', 'axis': batch_dim, 'dims': [1, -1]}
+  })
+
+
 def test_out_shape():
   # https://github.com/rwth-i6/returnn/issues/706
   # Note: Using SplitDimsLayer would also be nice to test out_shape. Or any layer which creates a new dim.


### PR DESCRIPTION
https://github.com/rwth-i6/returnn/commit/dbaa97a9d9cfd90d073d743786b6a233cdb5eeeb from #845 introduces an issue when unflattening the batch dim axis. All resulting axes now get a batch dim `dim_tag`, which was previously not the case.

I added a test case to demonstrate the issue.