### PR TITLE
LengthLayer: copy dim.dyn_size_ext before using as output

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1959,7 +1959,7 @@ class LengthLayer(LayerBase):
         name="%s_length" % name,
         shape=(), batch_dim_axis=0, time_dim_axis=None,
         dtype=dtype, sparse=sparse, dim=None if sparse else NotSpecified)
-    return dim.dyn_size_ext
+    return dim.dyn_size_ext.copy()
 
 
 class SoftmaxOverSpatialLayer(_ConcatInputLayer):


### PR DESCRIPTION
I had the really peculiar issue that enabling `debug_print_layer_output_shape` would change the time dimension tag of my decoder 🙆‍♂️

That happened when using a LengthLayer (`"target_length": {"class": "length", "from": "data:classes"}`).

When `debug_print_layer_output_shape` the layer output placeholder is reset via:
```
layer.output.placeholder = py_print(
          layer.output.placeholder,
          ...)
```

But in case of LengthLayer, `layer.output is Dim.dyn_size_ext` and thus the placeholder can have an attribute `_is_size_of_dim_tag`. This attribute however does not survive the `tf.identity()` in `py_print()`. And in the end
```
        time_dim_tag = Dim.get_tag_from_size_tensor(fixed_seq_len)
        assert time_dim_tag == self.time_dim_tag
```
in `_SubnetworkRecCell.get_ouput()` failed because `time_dim_tag is None`.

Making `layer.output` a copy of `dyn_size_ext` solves the issue for me, but I'm not sure whether identity is needed for other reasons...

In general, adding new attributes to `tf.Tensor` is bad style in my opinion and will likely lead to more bugs like this.