### PR TITLE
Simplify search flag logic

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -10684,7 +10684,7 @@ class SearchScoreLoss(Loss):
     """
     assert self.layer
     search_choices = self.layer.get_search_choices()
-    assert self.layer.network.search_flag and search_choices, "no search?"
+    assert search_choices, "no search?"
     # Negative score, because we minimize the loss, i.e. maximize the score.
     return self.reduce_func(-search_choices.beam_scores)
 

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -2745,8 +2745,6 @@ class _SubnetworkRecCell(object):
           :param LayerBase layer:
           :rtype: LayerBase
           """
-          if not self.parent_net.search_flag:
-            return layer
           if layer in transformed_cache:
             return transformed_cache[layer]
           assert not RecLayer.is_prev_step_layer(layer)  # this layer is from current frame

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3410,7 +3410,7 @@ class _SubnetworkRecCell(object):
       assert isinstance(layer, _TemplateLayer)
       if layer.name in [":i", "end"]:  # currently not fully implemented
         return False
-      if self.parent_net.search_flag and layer.search_choices:
+      if layer.search_choices:
         return False  # need to perform the search inside the loop currently
       layer_deps = layer.dependencies
       # We depend on other layers from this sub-network?

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -5860,12 +5860,9 @@ class DecideLayer(BaseChoiceLayer):
     :rtype: Data
     """
     assert len(sources) == 1
-    if network.search_flag:
-      data = sources[0].output.copy_template(name="%s_output" % name).copy_as_batch_major()
-      data.beam = None
-      return data
-    else:
-      return sources[0].output
+    data = sources[0].output.copy_template(name="%s_output" % name).copy_as_batch_major()
+    data.beam = None
+    return data
 
 
 class DecideKeepBeamLayer(BaseChoiceLayer):

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -12,7 +12,7 @@ try:
   from tensorflow.python.ops.nn import rnn_cell
 except ImportError:
   from tensorflow.python.ops import rnn_cell
-from returnn.tf.network import LayerNotFound
+from returnn.tf.network import LayerNotFound, TFNetwork
 from .basic import LayerBase, _ConcatInputLayer, SearchChoices, get_concat_sources_data_template, Loss
 from returnn.tf.util.data import Data, Dim, SpatialDim, FeatureDim, SearchBeam
 from returnn.tf.util.basic import reuse_name_scope
@@ -5719,6 +5719,7 @@ class ChoiceLayer(BaseChoiceLayer):
     sources = parent_layer_kwargs["sources"]
     network = parent_layer_kwargs["network"]
     beam_size = parent_layer_kwargs["beam_size"]
+    assert isinstance(network, TFNetwork)
 
     # The sub-layer with index n will output the n-th target. The out_data is taken directly
     # from the target as it is done in self.get_out_data_from_opts().

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -1806,18 +1806,17 @@ class _SubnetworkRecCell(object):
       # noinspection PyBroadException
       try:
         layer = self.net.construct_layer(self.net_dict, name=name, get_layer=get_layer)
-        if self.net.search_flag:
-          # Some layers are buggy to determine the right beam size at template construction time.
-          # Usually this is because they ignore some of the dependencies in get_out_data_from_opts.
-          # If that is the case, this will likely crash at some later point with mismatching shape.
-          # Do an explicit check here now, to easier localize such problems.
-          layer_template = self.layer_data_templates[name]
-          layer_choices = layer.get_search_choices()
-          if not layer.search_choices and layer_choices:
-            assert (layer.output.beam == layer_template.output.beam and
-                    layer_choices.beam_size == layer.output.beam.beam_size == layer_template.output.beam.beam_size), (
-              "Layer %r has buggy search choices resolution." % layer,
-              self.net.debug_search_choices(layer) or "see search choices debug output")
+        # Some layers are buggy to determine the right beam size at template construction time.
+        # Usually this is because they ignore some of the dependencies in get_out_data_from_opts.
+        # If that is the case, this will likely crash at some later point with mismatching shape.
+        # Do an explicit check here now, to easier localize such problems.
+        layer_template = self.layer_data_templates[name]
+        layer_choices = layer.get_search_choices()
+        if not layer.search_choices and layer_choices:
+          assert (layer.output.beam == layer_template.output.beam and
+                  layer_choices.beam_size == layer.output.beam.beam_size == layer_template.output.beam.beam_size), (
+            "Layer %r has buggy search choices resolution." % layer,
+            self.net.debug_search_choices(layer) or "see search choices debug output")
         if name == "end":
           # Special logic for the end layer, to always logical_or to the prev:end layer.
           assert layer.output.shape == (), "%s: 'end' layer %r unexpected shape" % (self.parent_rec_layer, layer)

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -4993,13 +4993,15 @@ class BaseChoiceLayer(LayerBase):
 
   # noinspection PyMethodOverriding
   @classmethod
-  def get_rec_initial_extra_outputs(cls, network, beam_size, **kwargs):
+  def get_rec_initial_extra_outputs(cls, network, beam_size, search=NotSpecified, **kwargs):
     """
     :param returnn.tf.network.TFNetwork network:
     :param int beam_size:
+    :param NotSpecified|bool search:
     :rtype: dict[str,tf.Tensor]
     """
-    if not network.search_flag:  # independent from option search, because we still need the search_choices
+    search = NotSpecified.resolve(search, network.search_flag)
+    if not search:
       return {}
     batch_dim = network.get_data_batch_dim()
     # Note: Use beam_size 1 for the initial as there are no competing hypotheses yet.

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -5879,17 +5879,17 @@ class DecideKeepBeamLayer(BaseChoiceLayer):
     beam_size = src.output.beam.beam_size if src.output.beam else 1
     super(DecideKeepBeamLayer, self).__init__(beam_size=beam_size, sources=sources, **kwargs)
     self.output.placeholder = src.output.placeholder
-    if self.network.search_flag:
-      base_search_choices = src.get_search_choices()
-      if base_search_choices:
-        self.search_choices = SearchChoices(owner=self, beam_size=beam_size, keep_raw=True)
-        assert base_search_choices.beam_size == beam_size == self.search_choices.beam_size
-        net_batch_dim = self.network.get_data_batch_dim()
-        from returnn.tf.util.basic import expand_dims_unbroadcast
-        self.search_choices.set_src_beams(expand_dims_unbroadcast(
-          tf.range(base_search_choices.beam_size), axis=0, dim=net_batch_dim))
-        self.search_choices.set_beam_scores(base_search_choices.beam_scores)
-      else:
+    base_search_choices = src.get_search_choices()
+    if base_search_choices:
+      self.search_choices = SearchChoices(owner=self, beam_size=beam_size, keep_raw=True)
+      assert base_search_choices.beam_size == beam_size == self.search_choices.beam_size
+      net_batch_dim = self.network.get_data_batch_dim()
+      from returnn.tf.util.basic import expand_dims_unbroadcast
+      self.search_choices.set_src_beams(expand_dims_unbroadcast(
+        tf.range(base_search_choices.beam_size), axis=0, dim=net_batch_dim))
+      self.search_choices.set_beam_scores(base_search_choices.beam_scores)
+    else:
+      if self.network.search_flag:
         print("%s: Warning: decide-keep-beam on %r, there are no search choices" % (self, src), file=log.v3)
 
   @classmethod
@@ -5934,7 +5934,7 @@ class DecideKeepBeamLayer(BaseChoiceLayer):
     from returnn.tf.util.basic import SearchBeam
     assert len(sources) == 1
     out = sources[0].output.copy_template(name="%s_output" % name)
-    if network.search_flag and out.beam:
+    if out.beam:
       out.beam = SearchBeam(
         beam_size=out.beam.beam_size, dependency=out.beam,
         name="%s%s" % (network.get_absolute_name_prefix(), name))

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -5110,8 +5110,6 @@ class ChoiceLayer(BaseChoiceLayer):
     from returnn.tf.util.basic import optional_add, optional_mul, batch_gather, expand_dims_unbroadcast
     search = NotSpecified.resolve(search, default=self.network.search_flag)
     assert isinstance(search, bool)
-    if search:
-      assert self.network.search_flag, "%s: cannot use search if network.search_flag disabled" % self
     self.search_flag = search
     self.input_type = input_type
     self.length_normalization = length_normalization
@@ -5361,8 +5359,6 @@ class ChoiceLayer(BaseChoiceLayer):
         available_for_inference=True)
 
     else:  # no search, and no scheduled-sampling
-      if not self.network.search_flag:
-        assert len(self.sources) == 0  # will be filtered out in transform_config_dict
       # Note: If you want to do forwarding, without having the reference,
       # that wont work. You must do search in that case.
       # Put all targets in a list.

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3368,7 +3368,7 @@ class _SubnetworkRecCell(object):
       # Special case: end-layer, which is added if the seq-len is unknown, cannot be moved out.
       if layer.name == "end":
         return False
-      if self.parent_net.search_flag and layer.search_choices:
+      if layer.search_choices:
         return False  # need to perform the search inside the loop currently
       if layer in layer.dependencies:  # recursive on itself
         return False

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -4986,7 +4986,7 @@ class BaseChoiceLayer(LayerBase):
     :rtype: int|None
     """
     search = NotSpecified.resolve(search, network.search_flag)
-    if not search or not network.search_flag:
+    if not search:
       if _src_common_search_choices:
         return _src_common_search_choices.beam_size
       # Note: _src_common_search_choices might not be set during template construction,

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -4059,8 +4059,6 @@ class _TemplateLayer(LayerBase):
     :rtype: bool
     """
     # TODO: extend if this is a subnet or whatever
-    if not self.network.search_flag:
-      return False
     if issubclass(self.layer_class_type, BaseChoiceLayer):
       # Always has search_choices if we do search, even if search option is False explicitly.
       beam_size = self._get_search_choices_beam_size()

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -5372,6 +5372,43 @@ class ChoiceLayer(BaseChoiceLayer):
       # We use the labels of the first target as "normal" output.
       self.output = self.output_list[0]
 
+    if self.network.search_flag and not search and input_type != "regression":
+      # We perform search, but this layer does not do search.
+      # But we still add our scores to the beam scores.
+      net_batch_dim = self.network.get_data_batch_dim()
+      base_search_choices = self.network.get_search_choices(base_search_choice=self).search_choices
+      self.search_choices = SearchChoices(
+        owner=self,
+        beam_size=base_search_choices.beam_size)
+      assert self.search_choices.beam_size == self.output.beam.beam_size
+      scores_base = base_search_choices.beam_scores  # (batch, beam_in|1)
+      assert len(self.sources) == 1
+      scores_in = self._get_scores(self.sources[0])  # +log scores, (batch*beam_in, dim)
+      from returnn.tf.util.basic import filter_ended_scores
+      if self.network.have_rec_step_info():
+        scores_in_dim = self.sources[0].output.dim
+        if scores_in_dim is None:  # can happen if variable length
+          scores_in_dim = tf.shape(self.sources[0].output.placeholder)[self.sources[0].output.feature_dim_axis]
+        scores_in = filter_ended_scores(
+          scores_in,
+          end_flags=self.network.get_rec_step_info().get_prev_end_flag(target_search_choices=base_search_choices),
+          dim=scores_in_dim, batch_dim=tf.shape(scores_in)[0])  # (batch * beam_in, dim)
+        # We also assume that the ground truth output are 0 when the seq ended.
+      scores_in_ = batch_gather(scores_in, self.output.placeholder)  # (batch*beam_in,)
+      scores_in_ = tf.reshape(scores_in_, (net_batch_dim, base_search_choices.beam_size))  # (batch,beam_in)
+      self.search_choices.set_src_beams(expand_dims_unbroadcast(
+        tf.range(base_search_choices.beam_size), axis=0, dim=net_batch_dim))
+      assert not random_sample_scale
+      assert not length_normalization
+      assert not custom_score_combine
+      scores_comb = optional_add(
+        optional_mul(scores_in_, prob_scale),
+        optional_mul(scores_base, base_beam_score_scale))  # (batch, beam_in)
+      self.search_scores_in = scores_in_
+      self.search_scores_base = scores_base
+      self.search_scores_combined = scores_comb
+      self.search_choices.set_beam_scores(scores_comb)
+
   def _get_scores(self, source):
     """
     :param LayerBase source:

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -5771,16 +5771,16 @@ class DecideLayer(BaseChoiceLayer):
     :param bool length_normalization: performed on the beam scores
     """
     super(DecideLayer, self).__init__(beam_size=1, **kwargs)
-    # If not in search, this will already be set via self.get_out_data_from_opts().
-    if self.network.search_flag:
-      assert len(self.sources) == 1
-      src = self.sources[0]
+    assert len(self.sources) == 1
+    src = self.sources[0]
+    if src.output.beam:
       self.output, self.search_choices = self.decide(
         src=src, owner=self, output=self.output, length_normalization=length_normalization)
-      if not self.search_choices:
+      assert self.search_choices
+    else:
+      if self.network.search_flag:
         print("%s: Warning: decide on %r, there are no search choices" % (self, src), file=log.v3)
-        # As batch major, because we defined our output that way.
-        self.output = self.output.copy_as_batch_major()
+      self.output.placeholder = src.output.copy_as_batch_major().placeholder
 
   @classmethod
   def cls_get_search_beam_size(cls, sources, **kwargs):


### PR DESCRIPTION
Fix #946.

When the `ChoiceLayer` `search` option is not set, it will fall back to the old behavior of using the network search flag.

One small behavior change, without introducing new behavior version:

- `ChoiceLayer` with `search=True` option has ignored this option before when the parent network search flag was not set. Now it will use it, ignoring the parent network search flag.
