### PR TITLE
fix SyntaxWarning

### DIFF
--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -1380,7 +1380,7 @@ class LayerBase(object):
       c += self.spatial_smoothing * self.get_output_spatial_smoothing_energy()
     if self.darc1:
       c += self.darc1 * self.get_darc1()
-    if c is 0:
+    if c == 0:
       return None
     return c
 

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1618,7 +1618,7 @@ class TFNetwork(object):
     if should_train or should_eval:
       # These values are cached internally and the graph nodes are created on the first call.
       loss = self.get_objective()
-      if loss is 0:
+      if loss == 0:
         loss = tf_util.global_tensor(lambda: tf.constant(0.0), name="zero_loss")
       else:  # non-constant-zero loss
         assert self.losses_dict

--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -2021,7 +2021,7 @@ def expand_dims_unbroadcast(x, axis, dim, name="expand_dims_unbroadcast"):
   with tf.name_scope(name):
     x = tf.convert_to_tensor(x)
     x = tf.expand_dims(x, axis)
-    if dim is not 1:
+    if dim != 1:
       new_ndim = x.get_shape().ndims
       assert new_ndim is not None, "not implemented otherwise yet"
       assert isinstance(axis, int), "not implemented otherwise yet"
@@ -5547,7 +5547,7 @@ def tensor_array_stack(ta, start=0, stop=None, name="TensorArrayStack"):
   :param str name:
   :rtype: tf.Tensor
   """
-  if start is 0 and stop is None:
+  if start == 0 and stop is None:
     return ta.stack(name=name)
   with tf_compat.v1.colocate_with(_tensor_array_ref(ta)):
     with tf.name_scope(name):


### PR DESCRIPTION
When running RETURNN, I get
```
/.../returnn/returnn/tf/network.py:1621: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if loss is 0:
/.../returnn/returnn/tf/util/basic.py:2024: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if dim is not 1:
/.../returnn/returnn/tf/util/basic.py:5550: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if start is 0 and stop is None:
/.../returnn/returnn/tf/layers/base.py:1383: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if c is 0:
```

I don't see a reason to do it the way it is currently done, so we could just fix it like proposed here.