### PR TITLE
Allow unspecified out dim

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6476,8 +6476,6 @@ class PostfixInTimeLayer(_ConcatInputLayer):
       seq_mask = tf.less(idx_range, size_ext.placeholder)
       assert seq_mask.get_shape().ndims == self.output.batch_ndim
       self.output.placeholder = tf_util.where_bc(seq_mask, x, c)
-      out_dim = self.output.dim_tags[axis_int]
-      out_dim.dyn_size = in_dim.dyn_size + repeat
 
   @classmethod
   def get_out_data_from_opts(cls, name, sources, axis="T", out_dim=None, postfix=0.0, repeat=1, **kwargs):
@@ -6493,13 +6491,10 @@ class PostfixInTimeLayer(_ConcatInputLayer):
     x = get_concat_sources_data_template(sources, name="%s_output" % name)
     axis_int = x.get_axis_from_description(axis, allow_int=False)
     in_dim = x.dim_tags[axis_int]
-    out_dim_int = None
-    if in_dim.dimension:
-      out_dim_int = in_dim.dimension + repeat
-    if not out_dim:
-      out_dim = in_dim + repeat
-    assert out_dim.dimension == out_dim_int
-    x = x.copy_template_replace_dim_tag(axis=axis_int, new_dim_tag=out_dim)
+    out_dim_ = in_dim + repeat
+    if out_dim:
+      out_dim_.declare_same_as(out_dim)
+    x = x.copy_template_replace_dim_tag(axis=axis_int, new_dim_tag=out_dim_)
     return x
 
   @classmethod

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1007,7 +1007,9 @@ class SliceLayer(_ConcatInputLayer):
     axis = self.input_data.get_axis_from_description(axis)
     dim_slice = slice(slice_start, slice_end, slice_step)
     slices = [slice(None, None)] * axis + [dim_slice]
-    self.output.placeholder = self.input_data.placeholder[slices]
+    y = self.input_data.placeholder[slices]
+    y.set_shape(self.output.batch_shape)  # can be necessary for slice_end>0
+    self.output.placeholder = y
 
   @classmethod
   def get_out_data_from_opts(

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6008,10 +6008,10 @@ class ReduceOutLayer(_ConcatInputLayer):
     assert not out.sparse
     assert out.dim % num_pieces == 0
     dim = out.dim // num_pieces
-    if not out_dim:
-      out_dim = out.feature_dim_or_sparse_dim // num_pieces
-    assert out_dim.dimension == dim
-    return out.copy_template_replace_dim_tag(axis=out.feature_dim_axis, new_dim_tag=out_dim)
+    out_dim_ = out.feature_dim_or_sparse_dim // num_pieces
+    if out_dim:
+      out_dim_.declare_same_as(out_dim)
+    return out.copy_template_replace_dim_tag(axis=out.feature_dim_axis, new_dim_tag=out_dim_)
 
 
 class SqueezeLayer(_ConcatInputLayer):

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -7192,16 +7192,16 @@ class ResizeLayer(_ConcatInputLayer):
     super(ResizeLayer, self).__init__(**kwargs)
     # self.output.shape and self.output.batch_dim_axis are already set here via self.get_out_data_from_opts().
     input_data = self.input_data.copy_as_batch_major()
-    axis = self.input_data.get_axis_from_description(axis)
+    axis = input_data.get_axis_from_description(axis)
     assert axis > 0, "batch-dim resize not supported"
     input_data = input_data.copy_move_axis(old_axis=axis, new_axis=1)
     axis = 1
 
     # images expected shape: [batch, height, width, channels]
     remaining_axes = [i for i in range(self.output.batch_ndim) if i not in (0, axis)]
-    x = dimshuffle(self.output.placeholder, [0, axis, 'x'] + remaining_axes)  # [batch,height,width] + remaining_axes
+    x = dimshuffle(input_data.placeholder, [0, axis, 'x'] + remaining_axes)  # [batch,height,width] + remaining_axes
     from returnn.tf.util.basic import get_shape, optional_mul
-    shape = get_shape(self.output.placeholder)
+    shape = get_shape(input_data.placeholder)
     remaining_shape = [shape[i] for i in remaining_axes]
     remaining_dim = optional_mul(*remaining_shape) if remaining_axes else 1
     x = tf.reshape(x, [shape[0], shape[axis], 1, remaining_dim])  # [batch,height,width,channels]

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6128,11 +6128,11 @@ class StackLayer(LayerBase):
     if axis is None:
       axis = axis_
     out = common_source.copy_template(name="%s_output" % name)
-    if not out_spatial_dim:
-      out_spatial_dim = Dim(
-        kind=Dim.Types.Spatial, description="%s:stack" % name, dimension=len(sources), auto_generated=True)
-    assert out_spatial_dim.dimension == len(sources)
-    out = out.copy_add_dim_by_tag(axis=axis, dim_tag=out_spatial_dim, unbroadcast=True)
+    out_spatial_dim_ = Dim(
+      kind=Dim.Types.Spatial, description="%s:stack" % name, dimension=len(sources), auto_generated=True)
+    if out_spatial_dim:
+      out_spatial_dim_.declare_same_as(out_spatial_dim)
+    out = out.copy_add_dim_by_tag(axis=axis, dim_tag=out_spatial_dim_, unbroadcast=True)
     return out
 
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5043,7 +5043,9 @@ class ConvLayer(_ConcatInputLayer):
       assert output.feature_dim_axis == output.batch_ndim - 1
       out_spatial_dims_ = output.dim_tags[num_batch_dims:-1]
     if out_spatial_dims:
-      assert list(out_spatial_dims_) == list(out_spatial_dims)
+      assert len(out_spatial_dims_) == len(out_spatial_dims)
+      for i, (out_spatial_dim_, out_spatial_dim) in enumerate(zip(out_spatial_dims_, out_spatial_dims)):
+        out_spatial_dim_.declare_same_as(out_spatial_dim)
     assert len(out_spatial_dims_) == len(in_spatial_dims) == len(filter_size) == len(strides) == len(dilation_rate)
     for i, in_tag in enumerate(in_spatial_dims):
       out_tag = out_spatial_dims_[i]

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4352,12 +4352,13 @@ class RepeatLayer(_ConcatInputLayer):
     original_axis = data.get_axis_from_description(axis, allow_int=False)
     tag = data.dim_tags[original_axis]
     data = data.copy_move_axis(original_axis, data.get_batch_axis(0))
-    if not out_dim:
-      if isinstance(repetitions, int):
-        out_dim = tag * repetitions
-      else:
-        out_dim = Dim(description="repeated:%s" % name, kind=tag.kind, derived_from_tag=tag, auto_generated=True)
-    return data.copy_template_replace_dim_tag(axis=data.get_batch_axis(0), new_dim_tag=out_dim)
+    if isinstance(repetitions, int):
+      out_dim_ = tag * repetitions
+    else:
+      out_dim_ = Dim(description="repeated:%s" % name, kind=tag.kind, derived_from_tag=tag, auto_generated=True)
+    if out_dim:
+      out_dim_.declare_same_as(out_dim)
+    return data.copy_template_replace_dim_tag(axis=data.get_batch_axis(0), new_dim_tag=out_dim_)
 
 
 class TileLayer(_ConcatInputLayer):

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5165,7 +5165,7 @@ class ConvLayer(_ConcatInputLayer):
       if isinstance(in_dim, Dim):
         filter_left_dilated = (filter_size - 1) * dilation_rate // 2
         filter_right_dilated = (filter_size - 1) * dilation_rate - filter_left_dilated
-        valid_part = (-filter_left_dilated) + in_dim + (-filter_right_dilated)
+        valid_part = in_dim.sub_left(filter_left_dilated).sub_right(filter_right_dilated)
         return valid_part.ceildiv_right(stride)
       return tf_util.simplify_non_negative_seq_length(
         ceildiv(

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6001,7 +6001,6 @@ class ReduceOutLayer(_ConcatInputLayer):
     assert out.have_feature_axis()
     assert not out.sparse
     assert out.dim % num_pieces == 0
-    dim = out.dim // num_pieces
     out_dim_ = out.feature_dim_or_sparse_dim // num_pieces
     if out_dim:
       out_dim_.declare_same_as(out_dim)

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3005,6 +3005,7 @@ class WindowLayer(_ConcatInputLayer):
     :param int stride: return only each Nth window
     :param kwargs:
     """
+    out_spatial_dim  # noqa  # via get_out_data_from_opts
     super(WindowLayer, self).__init__(**kwargs)
     if not window_size:
       assert window_dim and window_dim.dimension

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3030,25 +3030,6 @@ class WindowLayer(_ConcatInputLayer):
     else:
       axis = data.get_axis_from_description(axis)
       new_dim_axis = axis + 1  # new axis will be added right after
-      in_spatial_dim = data.dim_tags[axis]
-      out_spatial_dim_ = self.output.dim_tags[axis]
-      if out_spatial_dim:
-        assert out_spatial_dim_ == out_spatial_dim
-        if (padding.lower() == "same" or window_size == 1) and stride == 1:  # no change in spatial dim
-          assert in_spatial_dim == out_spatial_dim
-      if in_spatial_dim != out_spatial_dim_ and out_spatial_dim_.dimension is None:
-        if not out_spatial_dim_.dyn_size_ext:
-          out_spatial_dim_.dyn_size_ext = in_spatial_dim.dyn_size_ext.copy_template(name="%s:spatial-size" % self.name)
-        if out_spatial_dim_.dyn_size_ext.placeholder is None:
-          from ..util.basic import same_control_flow_ctx
-          from ..util.data import Dim
-          assert in_spatial_dim.dyn_size is not None
-          size = in_spatial_dim.dyn_size
-          with same_control_flow_ctx(size):
-            size = ConvLayer.calc_out_dim(
-              in_dim=size,
-              filter_size=window_size, stride=stride, dilation_rate=1, padding=padding)
-          out_spatial_dim_.dyn_size_ext.placeholder = size
 
       from returnn.tf.util.basic import windowed_nd
       self.output.placeholder = windowed_nd(

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4400,13 +4400,9 @@ class TileLayer(_ConcatInputLayer):
     dim_tags = list(data.dim_tags)
     for axis, multiple in multiples.items():
       axis_int = data.get_axis_from_description(axis, allow_int=False)
-      tag = dim_tags[axis_int]
-      dim = None if tag.dimension is None else (tag.dimension * multiple)
+      tag = multiple * dim_tags[axis_int]
       if out_dims and axis in out_dims:
-        tag = out_dims[axis]
-        assert tag.dimension == dim
-      else:
-        tag = multiple * tag
+        tag.declare_same_as(out_dims[axis])
       dim_tags[axis_int] = tag
     return data.copy_template_new_dim_tags(dim_tags, keep_special_axes=True)
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2944,18 +2944,16 @@ class GatingLayer(_ConcatInputLayer):
     input_data = get_concat_sources_data_template(sources)
     assert not input_data.sparse
     assert input_data.dim % 2 == 0
-    dim = input_data.dim // 2
+    out_dim_ = input_data.dim_tags[input_data.feature_dim_axis] // 2
     if out_dim:
-      assert out_dim.dimension == dim
-    else:
-      out_dim = FeatureDim("%s:gating" % name, dimension=dim, auto_generated=True)
+      out_dim_.declare_same_as(out_dim)
     if n_out is not NotSpecified:
-      assert n_out == dim
+      assert n_out == input_data.dim // 2
     return Data(
       name="%s_output" % name,
       dtype=input_data.dtype,
       dim_tags=[
-        out_dim if i == input_data.feature_dim_axis else d
+        out_dim_ if i == input_data.feature_dim_axis else d
         for (i, d) in enumerate(input_data.dim_tags)],
       sparse=False,
       time_dim_axis=input_data.time_dim_axis,

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1218,13 +1218,14 @@ class SliceNdLayer(_ConcatInputLayer):
     else:
       # size might be None here in which case we set the dyn_size in __init__
       assert size is None or isinstance(size, int)
+      out_spatial_dim_ = Dim(
+        kind=Dim.Types.Spatial,
+        description="sliced-time:%s" % name,
+        dimension=size, auto_generated=True)
       if out_spatial_dim:
-        assert out_spatial_dim.dimension == size
+        out_spatial_dim_.declare_same_as(out_spatial_dim)
       else:
-        out_spatial_dim = Dim(
-          kind=Dim.Types.Spatial,
-          description="sliced-time:%s" % name,
-          dimension=size, auto_generated=True)
+        out_spatial_dim = out_spatial_dim_
     gather_positions_data = gather_positions_data.copy_add_dim_by_tag(
       out_spatial_dim, unbroadcast=True, axis=start_data.batch_ndim)
     position = InternalLayer(

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -899,6 +899,12 @@ class Dim(object):
     elif other_same_base.dyn_size_ext is None or not other_same_base._validate_in_current_graph():
       other_same_base.dyn_size_ext = self.get_dyn_size_ext_for_batch_ctx(
         other_same_base.batch, other_same_base.control_flow_ctx)
+    if self.is_dim_known() and other.is_dim_known():
+      assert self.dimension == other.dimension
+    elif self.is_dim_known() and not other.is_dim_known():
+      other.dimension = self.dimension
+    elif not self.is_dim_known() and other.is_dim_known():
+      self.dimension = other.dimension
     if self._vocab and not other_same_base._vocab:
       other_same_base._vocab = self._vocab
     elif other_same_base._vocab and not self._vocab:

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -657,7 +657,8 @@ class Dim(object):
             continue
           y.placeholder = _bin_op(y.placeholder, x.dimension)
           continue
-        x = x.get_for_batch_ctx(self.batch, self.control_flow_ctx)
+        if self.batch:
+          x = x.get_for_batch_ctx(self.batch, self.control_flow_ctx)
         x.complete_dyn_size()
         if not x.dyn_size_ext or x.dyn_size_ext.placeholder is None:
           return

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -617,11 +617,11 @@ class Dim(object):
       def _bin_op(a, b):
         with tf_util.same_control_flow_ctx([a, b]):
           if kind == "add":
-            return tf_util.simplify_add(a, b)
+            return tf.convert_to_tensor(tf_util.simplify_add(a, b))
           elif kind == "sub":
-            return tf_util.simplify_sub(a, b)
+            return tf.convert_to_tensor(tf_util.simplify_sub(a, b))
           elif kind == "mul":
-            return a * b
+            return tf.convert_to_tensor(tf_util.optional_mul(a, b))
           elif kind in ("floordiv", "truediv"):  # truediv assumes there is no remainder
             return a // b
           elif kind == "ceildiv":

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -614,12 +614,25 @@ class Dim(object):
       if kind.endswith("_left"):
         kind = kind[:-len("_left")]
 
+      def _is_negative(x__):
+        if isinstance(x__, (int, float)):
+          return x__ < 0
+        assert isinstance(x__, tf.Tensor)
+        from tensorflow.python.framework import tensor_util
+        x__ = tensor_util.constant_value(x__)
+        if x__ is not None:
+          return x__ < 0
+        return False
+
       def _bin_op(a, b):
         with tf_util.same_control_flow_ctx([a, b]):
           if kind == "add":
+            use_relu = _is_negative(a) or _is_negative(b)  # for dynamic tensors, assume all positive
+            if use_relu:
+              return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(tf_util.simplify_add(a, b)))
             return tf.convert_to_tensor(tf_util.simplify_add(a, b))
           elif kind == "sub":
-            return tf.convert_to_tensor(tf_util.simplify_sub(a, b))
+            return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(tf_util.simplify_sub(a, b)))
           elif kind == "mul":
             return tf.convert_to_tensor(tf_util.optional_mul(a, b))
           elif kind in ("floordiv", "truediv"):  # truediv assumes there is no remainder

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -614,14 +614,18 @@ class Dim(object):
       if kind.endswith("_left"):
         kind = kind[:-len("_left")]
 
+      import numpy
+      from tensorflow.python.framework import tensor_util
+
       def _is_negative(x__):
+        if isinstance(x__, numpy.ndarray):
+          return (x__ < 0).any()
         if isinstance(x__, (int, float)):
           return x__ < 0
         assert isinstance(x__, tf.Tensor)
-        from tensorflow.python.framework import tensor_util
         x__ = tensor_util.constant_value(x__)
         if x__ is not None:
-          return x__ < 0
+          return _is_negative(x__)
         return False
 
       def _bin_op(a, b):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -428,6 +428,9 @@ class Dim(object):
       If the dyn size can potentially be of a different shape, directly access dyn_size_ext.
     :rtype: tf.Tensor|None
     """
+    if self.dimension is None and (not self.dyn_size_ext or self.dyn_size_ext.placeholder is None):
+      # Try to complete.
+      self.complete_dyn_size()
     if self.dyn_size_ext:
       return self.dyn_size_ext.placeholder
     return None

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -2564,6 +2564,22 @@ def test_MergeDimsLayer_modified_time_dim():
     session.run(out.placeholder, feed_dict=make_feed_dict(net.extern_data))
 
 
+def test_MergeDimsLayer_unspecified_out_dim():
+  # https://github.com/rwth-i6/returnn/issues/955
+  # https://github.com/rwth-i6/returnn_common/issues/117
+  config = Config({
+    "extern_data": {"data": {"shape": (None, 3, 5)}},
+  })
+  out_dim = SpatialDim("out")
+  with make_scope() as session:
+    net = TFNetwork(config=config)
+    net.construct_from_dict({
+      "output": {
+        "class": "merge_dims", "from": "data", "axes": ["dim:3", "dim:5"], "keep_order": True,
+        "out_dim": out_dim},
+    })
+
+
 def test_FlattenBatchLayer():
   from returnn.tf.util.data import BatchInfo
   n_batch, n_time, n_in = 3, 4, 2


### PR DESCRIPTION
Fix #955 for most relevant layers, as an extension to #597.

- [x] `ConvLayer`
- [x] `PoolLayer`
- [x] `TransposedConvLayer`
- [x] `WindowLayer`
- [x] `PadLayer`
- [x] `ResizeLayer`
- [x] `PrefixInTimeLayer`
- [x] `PostfixInTimeLayer`
- [x] `SliceLayer`
- [x] `SliceNdLayer`
- [x] `MergeDimsLayer`
- [x] `SplitDimsLayer` (nothing needs to be done I think)
- [x] `UnflattenNdLayer` (nothing needs to be done I think)
- [x] `RepeatLayer`
- [x] `TimeChunkingLayer` (I think nothing needs to be done)
- [x] `RemoveLayer` (I think nothing needs to be done)
- [x] `RecLayer` (I think nothing needs to be done)
- [x] `EditDistanceTableLayer` (already done)
- [x] `MaskedComputationLayer` (I think nothing needs to be done)
- [x] `CumConcatLayer` (nothing needs to be done)
- [x] `RangeFromLengthLayer` (already done)
- [x] `RangeLayer` (already done)
- [x] `ScatterNdLayer` (nothing needs to be done)
- [x] `ReduceOutLayer`
- [x] `StackLayer`
- [x] `SplitLayer` (I think nothing needs to be done)
- [x] `TileLayer`
- [x] `ConcatLayer` (already done)
- [x] `GatingLayer`
