### PR TITLE
Fix MaskedComputationLayer for RETURNN principles

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3126,7 +3126,16 @@ class CumsumLayer(_ConcatInputLayer):
       self.output.placeholder = next_state
     else:
       axis = data.get_axis_from_description(axis)
-      self.output.placeholder = tf.cumsum(x, axis=axis, reverse=reverse)
+      y = tf.cumsum(x, axis=axis, reverse=reverse)
+      if self._initial_output is not None:
+        init_state = self.get_rec_initial_output(
+          name=self.name, output=self.output,
+          network=self.network, batch_dim=self.get_batch_dim(),
+          rec_layer=self.network.get_rec_parent_layer(inside_loop=False),  # should actually not matter
+          axis=axis, sources=self.sources,
+          initial_output=self._initial_output)
+        y = init_state + y
+      self.output.placeholder = y
     self.output.placeholder.set_shape(data.placeholder.get_shape())
     self.output.placeholder.set_shape(tf.TensorShape(self.output.batch_shape))
     self.output.size_placeholder = self.input_data.size_placeholder.copy()

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3157,7 +3157,9 @@ class CumsumLayer(_ConcatInputLayer):
     from returnn.tf.util.basic import is_axis_from_description_recurrent
     if is_axis_from_description_recurrent(axis=axis, network=network, data=data):
       assert all(data.shape)
-      return {"state": tf.zeros(data.get_batch_shape(batch_dim=batch_dim), dtype=data.dtype)}
+      init_state = cls.get_rec_initial_output(
+        network=network, batch_dim=batch_dim, rec_layer=rec_layer, axis=axis, sources=sources, **kwargs)
+      return {"state": init_state}
     return {}
 
 

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -7959,9 +7959,11 @@ class MaskedComputationLayer(LayerBase):
     assert isinstance(output, Data)
     assert issubclass(layer_class, LayerBase)
     with layer_class.cls_setup_scope(**kwargs):
-      d = layer_class.get_rec_initial_extra_outputs(batch_dim=batch_dim, rec_layer=rec_layer, **layer_desc)
+      output = output.copy_as_batch_major()
+      d = layer_class.get_rec_initial_extra_outputs(
+        batch_dim=batch_dim, rec_layer=rec_layer, output=output, **layer_desc)
       initial_out = layer_class.get_rec_initial_output(
-        batch_dim=batch_dim, rec_layer=rec_layer, output=output.copy_as_batch_major(), **layer_desc)
+        batch_dim=batch_dim, rec_layer=rec_layer, output=output, **layer_desc)
       assert "_output" not in d
       d["_output"] = initial_out
       return d

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5331,14 +5331,6 @@ class Data(object):
     if BehaviorVersion.get() < 11:
       is_equal_opts["broadcast_matches"] = True
     all_dim_tags, tags_dict = Dim.get_all_dimension_tags(sources, is_equal_opts=is_equal_opts)
-    # Check for potential undefined tags, and replace those with defined tags if possible.
-    for axis, dim_tag in enumerate(common.dim_tags):
-      if dim_tag.undefined:
-        other = Dim.get_existing_tag_from_collection(dim_tag, all_dim_tags, is_equal_opts=is_equal_opts)
-        if other and not other.undefined:
-          # We found another dim tag which matches and which is defined.
-          # Replace it.
-          common = common.copy_template_replace_dim_tag(axis=axis, new_dim_tag=other)
     # Check for missing tags, and add those.
     for dim_tag in all_dim_tags:
       common_tag = Dim.get_existing_tag_from_collection(dim_tag, common.dim_tags, is_equal_opts=is_equal_opts)

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5341,7 +5341,14 @@ class Data(object):
           common = common.copy_template_replace_dim_tag(axis=axis, new_dim_tag=other)
     # Check for missing tags, and add those.
     for dim_tag in all_dim_tags:
-      if not Dim.get_existing_tag_from_collection(dim_tag, common.dim_tags, is_equal_opts=is_equal_opts):
+      common_tag = Dim.get_existing_tag_from_collection(dim_tag, common.dim_tags, is_equal_opts=is_equal_opts)
+      if common_tag:
+        # Already have this tag. However, maybe we have a better one.
+        # Dim.get_all_dimension_tags() would have selected that.
+        if dim_tag != common_tag:
+          axis = common.dim_tags.index(common_tag)
+          common = common.copy_template_replace_dim_tag(axis=axis, new_dim_tag=dim_tag)
+      else:
         axis = common.get_default_new_axis_for_dim_tag(dim_tag)
         common = common.copy_add_dim_by_tag(dim_tag, unbroadcast=True, axis=axis)
     if all(s.batch_ndim < common.batch_ndim for s in sources):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5336,7 +5336,8 @@ class Data(object):
 
     :param Dim dim_tag:
     :param dict[str,bool]|None is_equal_opts: passed to Dim.is_equal
-    :rtype: list[int] a list of matching axes, counted with batch dim. Sorted in ascending order
+    :rtype: list[int]
+    :return: a list of matching axes, counted with batch dim. Sorted in ascending order
     """
     return [axis for axis in range(self.batch_ndim) if self.get_dim_tag(axis).is_equal(dim_tag, **is_equal_opts)]
 

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -6211,6 +6211,67 @@ def test_MaskedComputationLayer_UnmaskLayer_in_loop_opt():
         x = y
 
 
+def test_MaskedComputationLayer_in_loop_auto_unmask():
+  # https://github.com/rwth-i6/returnn/issues/769
+  from test_TFNetworkLayer import make_feed_dict
+  from returnn.tf.layers.rec import _SubnetworkRecCell
+  for opt in [False, True]:
+    print("*** using rec optimization:", opt)
+    with make_scope() as session:
+      config = Config({"debug_print_layer_output_template": True})
+      net = TFNetwork(
+        extern_data=ExternData({"data": {"dim": 20, "sparse": True}}),
+        config=config)
+      net_dict = {
+        "output": {
+          "class": "rec",
+          "from": "data",
+          "optimize_move_layers_out": opt,  # test both variants
+          "unit": {
+            "const1": {"class": "constant", "value": 1, "with_batch_dim": True},  # just to broadcast mask
+            "mask": {
+              "class": "eval", "from": [":i", "const1"], "out_type": {"dtype": "bool"},
+              "eval": "tf.equal(source(0) % 2, source(1))"},
+            "in": {"class": "reinterpret_data", "from": "data:source", "set_sparse": False},
+            "masked": {
+              "class": "masked_computation", "from": "in", "mask": "mask",
+              "unit": {"class": "cumsum", "from": "data", "initial_output": 1}},
+            "masked_out": {"class": "copy", "from": "masked"},
+            "output": {"class": "eval", "from": ["masked_out", "in"], "eval": "source(0) + source(1) ** 2"},
+          }
+        }
+      }
+      net.construct_from_dict(net_dict)
+      rec_layer = net.get_layer("output")
+      assert isinstance(rec_layer, RecLayer)
+      rec_cell = rec_layer.cell
+      assert isinstance(rec_cell, _SubnetworkRecCell)
+      if opt:
+        assert not rec_cell.layers_in_loop  # all moved out
+      else:
+        assert not rec_cell.input_layers_moved_out and not rec_cell.output_layers_moved_out  # none moved out
+      in_data = net.get_layer("data").output
+      out_data = net.get_layer("output").output.copy_as_batch_major()
+      print("out:", out_data)
+      assert in_data.get_time_dim_tag() == out_data.get_time_dim_tag()
+      in_v, out_v, out_seq_lens_v = session.run(
+        (in_data.placeholder, out_data.placeholder, out_data.get_sequence_lengths()),
+        feed_dict=make_feed_dict(net.extern_data))
+      print(in_v)
+      print(out_v)
+      print("seq lens:", out_seq_lens_v)
+      assert_equal(in_v.shape, out_v.shape)
+      for b in range(in_v.shape[0]):
+        x = 1
+        for t in range(in_v.shape[1]):
+          if t >= out_seq_lens_v[b]:
+            continue
+          if t % 2 == 1:
+            x = x + in_v[b, t]
+          y = x + in_v[b, t] ** 2
+          numpy.testing.assert_almost_equal(y, out_v[b, t])
+
+
 def test_att_train_search_loss_prev_beam():
   beam_size = 1
   num_ner_labels = 13

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -4865,6 +4865,17 @@ def test_reclayer_optimize_out_cumsum_step_by_step():
     feat_dim=feat_dim, time_dim=time_dim)
 
 
+def test_reclayer_optimize_out_cumsum_step_by_step_initial():
+  from returnn.tf.util.data import batch_dim, Dim
+  time_dim = SpatialDim("time")
+  feat_dim = FeatureDim("feat", dimension=11)
+  check_reclayer_optimize_out(
+    subnet_layer_dict={
+      "class": "cumsum", "initial_output": 1,
+      "axis": time_dim, "out_shape": {batch_dim, feat_dim}, "out_dim": feat_dim},
+    feat_dim=feat_dim, time_dim=time_dim)
+
+
 def test_reclayer_optimize_out_cumsum_unrelated_axis():
   from returnn.tf.util.data import batch_dim, Dim
   time_dim = SpatialDim("time")

--- a/tests/test_TFUtil.py
+++ b/tests/test_TFUtil.py
@@ -401,6 +401,27 @@ def test_Data_get_all_dimension_tags_same_spatial_dim_twice():
   assert all_dim_tags == [batch_dim, time_dim, in_dim, out_dim]
 
 
+def test_Dim_get_all_dimension_tags_one_derived_time():
+  from returnn.tf.util.data import batch_dim
+  time_dim = SpatialDim("time")
+  feat_dim = FeatureDim("feature", 3)
+  a = Data(name="a", dim_tags=[batch_dim, time_dim, feat_dim])
+  print("a:", a)
+  derived_time_dim = SpatialDim("derived_time", derived_from_tag=time_dim)
+  b = Data(name="b", dim_tags=[batch_dim, derived_time_dim, feat_dim])
+  print("b:", b)
+  # Data.get_common_data defaults:
+  is_equal_opts = dict(
+    ignore_feature_dim=False, treat_feature_as_spatial=True,
+    allow_same_spatial_dim=True,
+    undefined_matches=True, derived_matches=True)
+  all_dim_tags, _ = DimensionTag.get_all_dimension_tags([b, a], is_equal_opts=is_equal_opts)
+  print("all_dim_tags:", all_dim_tags)
+  # The is_equal_opts with derived_matches should match time_dim with derived_time_dim.
+  # We explicitly want that the time_dim is returned here.
+  assert derived_time_dim not in all_dim_tags and all_dim_tags == [batch_dim, time_dim, feat_dim]
+
+
 def test_Data_sparse_int32_with_dim_kwargs_init():
   data = Data(name="classes_with_dim", shape=(None,), dim=10, sparse=True, dtype="int32")
   assert data.sparse and data.have_time_axis() and data.shape == (None,) and data.dim == 10


### PR DESCRIPTION
Fix #769. Specifically, it fixes the problem that the behavior when optimized out of a rec loop is not consistent and opaque to the user.

The `masked_from` option still is an exception though.