### PR TITLE
MaskedComputationLayer: allow sublayer to have different time dimension than mask

### DIFF
--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -7865,9 +7865,9 @@ class MaskedComputationLayer(LayerBase):
         # noinspection PyShadowingNames
         mask_data = mask.output.copy_template()
         masked_dim = mask_data.get_time_dim_tag()
-        if masked_dim not in layer.output.copy_template().dim_tags:
+        if masked_dim not in layer.output.dim_tags:
           return layer
-        axis = layer.output.copy_template().get_axis_from_description(masked_dim)
+        axis = layer.output.get_axis_from_description(masked_dim)
         source_data_ = layer.output.copy_template().copy_move_axis(old_axis=axis, new_axis=0)
         source_data_ = source_data_.copy_template_replace_dim_tag(axis=0, new_dim_tag=source.output.get_time_dim_tag())
         layer = WrappedInternalLayer(

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -7774,21 +7774,20 @@ class MaskedComputationLayer(LayerBase):
     else:
       d["masked_from"] = None
     super(MaskedComputationLayer, cls).transform_config_dict(d, network=network, get_layer=get_layer)
-    mask = get_layer(d["mask"])
     # Just call it for dep resolution.
     parent_layer_cache = d.setdefault("_parent_layer_cache", {})
-    d["_layer_class"], d["_layer_desc"] = cls._create_template(
-      name=d["_name"], network=network, sources=d["sources"],
-      masked_from=masked_from,
-      mask=mask,
-      unit=d["unit"],
-      out_spatial_dim=d.get("out_spatial_dim", None),
-      get_layer=get_layer, _parent_layer_cache=parent_layer_cache)
     if masked_from and not parent_layer_cache:
       # We explicitly do not want to have these as deps.
       d["mask"] = None
     else:
       d["mask"] = get_layer(d["mask"])
+    d["_layer_class"], d["_layer_desc"] = cls._create_template(
+      name=d["_name"], network=network, sources=d["sources"],
+      masked_from=masked_from,
+      mask=d["mask"],
+      unit=d["unit"],
+      out_spatial_dim=d.get("out_spatial_dim", None),
+      get_layer=get_layer, _parent_layer_cache=parent_layer_cache)
 
   # noinspection PyUnusedLocal
   @classmethod


### PR DESCRIPTION
Previously, this would lead to an error because the MaskedComputationLayer would check whether all sublayers have the same time dimension as the mask.