### PR TITLE
HDFDataset: add get_data_by_seq_tag

### DIFF
--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -48,6 +48,7 @@ class HDFDataset(CachedDataset):
     self.data_dtype = {}  # type: typing.Dict[str,str]
     self.data_sparse = {}  # type: typing.Dict[str,bool]
     self._num_codesteps = None  # type: typing.Optional[typing.List[int]]  # accumulated sequence length per target
+    self._tag_to_real_idx_map = None  # type: typing.Optional[typing.Dict[str,int]]
 
     if files:
       for fn in files:
@@ -273,6 +274,27 @@ class HDFDataset(CachedDataset):
 
     # Otherwise, directly read it from file now.
     real_seq_idx = self._seq_index[seq_idx]
+    return self._get_data_by_real_seq_idx(real_seq_idx, key)
+
+  def get_data_by_seq_tag(self, seq_tag, key):
+    """
+    :param str seq_tag:
+    :param str key:
+    :rtype: numpy.ndarray
+    """
+    if self.cache_byte_size_total_limit > 0:  # Use the cache?
+      assert False  # what should we do here?
+
+    # Otherwise, directly read it from file now.
+    real_seq_idx = self._get_real_idx_by_tag(seq_tag)
+    return self._get_data_by_real_seq_idx(real_seq_idx, key)
+
+  def _get_data_by_real_seq_idx(self, real_seq_idx, key):
+    """
+    :param int real_seq_idx:
+    :param str key:
+    :rtype: numpy.ndarray
+    """
     file_idx = self._get_file_index(real_seq_idx)
     fin = self.h5_files[file_idx]
 
@@ -354,6 +376,33 @@ class HDFDataset(CachedDataset):
     s = self.cached_h5_datasets[file_idx]["#seqTags"][real_file_seq_idx]
     s = self._decode(s)
     return s
+
+  def _get_real_idx_by_tag(self, seq_tag):
+    """
+    :param str seq_tag:
+    :rtype: int
+    """
+    if self._tag_to_real_idx_map is None:
+      self._build_tag_to_real_idx_map()
+
+    return self._tag_to_real_idx_map[seq_tag]
+
+  def _build_tag_to_real_idx_map(self):
+    if self._tag_to_real_idx_map is None:
+      self._tag_to_real_idx_map = {}
+
+      for file_idx in range(len(self.cached_h5_datasets)):
+        if "#seqTags" not in self.cached_h5_datasets[file_idx]:
+          self.cached_h5_datasets[file_idx]["#seqTags"] = self.h5_files[file_idx]["seqTags"]
+
+      for real_seq_idx in range(self.num_seqs):
+        file_idx = self._get_file_index(real_seq_idx)
+        real_file_seq_idx = real_seq_idx - self.file_start[file_idx]
+
+        s = self.cached_h5_datasets[file_idx]["#seqTags"][real_file_seq_idx]
+        s = self._decode(s)
+
+        self._tag_to_real_idx_map[s] = real_seq_idx
 
   def get_tag(self, sorted_seq_idx):
     """


### PR DESCRIPTION
For a use case that I have in mind, I need to be able to get data from an `HDFDataset` based on the sequence tag. I added `HDFDataset.get_data_by_seq_tag()` for that purpose.

It is very similar to `HDFDataset.get_data()` which has a special case `if self.cache_byte_size_total_limit > 0`. I'm not familiar with that and not sure how to handle this here, that's why I mark this PR as draft.