### PR TITLE
get_dataset_class: allow Dataset input

### DIFF
--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -1221,9 +1221,13 @@ class DatasetSeq:
 
 def get_dataset_class(name):
   """
-  :param str name:
+  :param str|type name:
   :rtype: type[Dataset]
   """
+  if isinstance(name, type):
+    assert issubclass(name, Dataset)
+    return name
+
   from importlib import import_module
   # Only those modules which make sense to be loaded by the user,
   # because this function is only used for such cases.


### PR DESCRIPTION
I have a custom `Dataset` class that I would like to use in a config. The idea is to do it like
```
class MyCustomDataset(Dataset):
  ...


train = {"class": MyCustomDataset, ...}
```

To allow this, I added this small change of `get_dataset_class` to also allow `Dataset` inputs instead of just strings.