### PR TITLE
Descriptive error, If no matching dim-tag was found

### DIFF
--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -4800,6 +4800,8 @@ class Data(object):
     :rtype: int
     """
     matching_dim_tags = self.get_axes_by_tag_name(name, spatial_only)
+    assert len(matching_dim_tags) > 0, "%r: no %stag found with name %r" % (
+      self, "spatial " if spatial_only else "", name)
     assert len(matching_dim_tags) == 1, "%r: tag name %r is not unique in dim tags %r" % (
       self, name, self.get_batch_shape_dim_tags())
     return matching_dim_tags[0]


### PR DESCRIPTION
When user defines a `"stag:<tag>"` but the `<tag>` is not a spatial dimension.

Return will throw: `tag name <tag> is not unique in dim tags`.

Which only makes sense if there where several matched dim tags, but in this case there is no matched dim tag.

This adds an assertion `len(matching_dim_tags) > 0`. Might help debugging `"in_spatial_dims"`.

Will either say "no spatial tag found with name", or "no tag found with name" if `spatial_only=False`
