### PR TITLE
MaskedComputationLayer, fix over_rec_time_dim for sub layers

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -9937,7 +9937,8 @@ class CtcLoss(Loss):
   @classmethod
   def get_auto_output_layer_dim(cls, target_dim):
     """
-    :rtype: int
+    :param returnn.tf.util.data.Dim target_dim:
+    :rtype: returnn.tf.util.data.Dim
     """
     return target_dim + 1  # one added for blank
 

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -7704,8 +7704,13 @@ class MaskedComputationLayer(LayerBase):
       sub_layers[sub_layer_name] = source
       return source
 
+    inside_rec_time_dim = self.network.get_inside_rec_time_dim(inside_loop=True)
+    over_rec_time_dim = self.network.get_inside_rec_time_dim(inside_loop=False)
     extra_net = self.network.make_extra_net(
       prefix_name="extra._internal.masked(%s)" % self.name, boundary=True)
+    if in_spatial_dim == over_rec_time_dim and over_rec_time_dim and not inside_rec_time_dim:
+      # Optimized out, so any sub layers will effectively operate on the out spatial dim.
+      extra_net._over_rec_time_dim = out_spatial_dim
     layer_desc = unit.copy()
     class_name = layer_desc.pop("class")
     layer_class = get_layer_class(class_name)
@@ -7834,6 +7839,7 @@ class MaskedComputationLayer(LayerBase):
     if not get_layer:
       get_layer = network.get_layer
 
+    inside_rec_time_dim = network.get_inside_rec_time_dim(inside_loop=True)
     over_rec_time_dim = network.get_inside_rec_time_dim(inside_loop=False)
     if over_rec_time_dim and not in_spatial_dim:
       in_spatial_dim = over_rec_time_dim
@@ -7916,6 +7922,9 @@ class MaskedComputationLayer(LayerBase):
       # Also, any subnet here must be only a template construction.
       # We will redo the full construction including transform_config_dict on the sub layer in __init__.
       only_template=True, boundary=True)
+    if _Locals.in_spatial_dim_ == over_rec_time_dim and over_rec_time_dim and not inside_rec_time_dim:
+      # Optimized out, so any sub layers will effectively operate on the out spatial dim.
+      extra_net._over_rec_time_dim = _Locals.out_spatial_dim_
     layer_desc = unit.copy()
     class_name = layer_desc.pop("class")
     layer_class = get_layer_class(class_name)

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -2423,7 +2423,7 @@ class CollectionReadCheckCovered:
     """
     :param str item:
     :param T default:
-    :rtype: T|object|None
+    :rtype: T|typing.Any|None
     """
     try:
       return self[item]

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -4073,6 +4073,18 @@ def test_reclayer_optimize_out_masked_computation_unmask():
     })
 
 
+def test_reclayer_optimize_out_masked_computation():
+  check_reclayer_optimize_out(
+    {"class": "linear", "activation": None, "from": "masked"},
+    other_subnet_layers={
+      "sum": {"class": "reduce", "mode": "sum", "from": "data:source", "axis": "f"},  # [B]
+      "mask": {"class": "compare", "from": "sum", "value": 0.0, "kind": "greater"},  # [B]
+      "masked": {
+        "class": "masked_computation", "mask": "mask", "from": "data:source",
+        "unit": {"class": "rec", "unit": "NativeLstm2", "n_out": 17, "from": "data"}},
+    })
+
+
 def test_reclayer_optimize_out_access_split():
   check_reclayer_optimize_out(
     subnet_layer_dict={"class": "copy", "from": "split/0", "n_out": 5},


### PR DESCRIPTION
This fixes specifically `test_reclayer_optimize_out_masked_computation_out_shape` introduced in the PR.

This fixes `out_shape` usage in sub layers of the masked computation because of this logic:
```python
    if "out_shape" in d:
      inside_rec_time_dim = network.get_inside_rec_time_dim(inside_loop=True)
      over_rec_time_dim = network.get_inside_rec_time_dim(inside_loop=False)
      if over_rec_time_dim and not inside_rec_time_dim:  # moved out of loop
        from returnn.tf.util.data import OptionalDim
        out_shape = d["out_shape"]
        if not isinstance(out_shape, set):
          assert not out_shape, "out_shape %r must be empty if not a set" % (out_shape,)
          out_shape = set()
        out_shape.add(OptionalDim(over_rec_time_dim))
        d["out_shape"] = out_shape
```
`over_rec_time_dim` is added when optimized out, however, this is not the masked time dim without this fix.
