### PR TITLE
ActivationLayer: out dtype fix for angle

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -723,7 +723,7 @@ class ActivationLayer(_ConcatInputLayer):
     # Use CopyLayer.get_out_data_from_opts for potential extra logic for out_type.
     out = CopyLayer.get_out_data_from_opts(**kwargs)
     # Modify dtype if needed based on activation function
-    if activation == "abs" and out.dtype == "complex64":
+    if activation in ["abs", "angle"] and out.dtype == "complex64":
       out.dtype = "float32"
     if "softmax" in activation:
       # Make sure we use the right axis.


### PR DESCRIPTION
If we use the `ActivationLayer` to get the angle of a complex input, the output dtype is not set correctly. See #537 which already fixed this issue for abs activation.