### PR TITLE
Fix dim tags equality

### DIFF
--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -614,31 +614,14 @@ class Dim(object):
       if kind.endswith("_left"):
         kind = kind[:-len("_left")]
 
-      import numpy
-      from tensorflow.python.framework import tensor_util
-
-      def _is_negative(x__):
-        if isinstance(x__, numpy.ndarray):
-          return (x__ < 0).any()
-        if isinstance(x__, (int, float)):
-          return x__ < 0
-        assert isinstance(x__, tf.Tensor)
-        x__ = tensor_util.constant_value(x__)
-        if x__ is not None:
-          return _is_negative(x__)
-        return False
-
       def _bin_op(a, b):
         with tf_util.same_control_flow_ctx([a, b]):
           if kind == "add":
-            use_relu = _is_negative(a) or _is_negative(b)  # for dynamic tensors, assume all positive
-            if use_relu:
-              return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(tf_util.simplify_add(a, b)))
-            return tf.convert_to_tensor(tf_util.simplify_add(a, b))
+            return a + b
           elif kind == "sub":
-            return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(tf_util.simplify_sub(a, b)))
+            return a - b
           elif kind == "mul":
-            return tf.convert_to_tensor(tf_util.optional_mul(a, b))
+            return a * b
           elif kind in ("floordiv", "truediv"):  # truediv assumes there is no remainder
             return a // b
           elif kind == "ceildiv":

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -614,14 +614,31 @@ class Dim(object):
       if kind.endswith("_left"):
         kind = kind[:-len("_left")]
 
+      import numpy
+      from tensorflow.python.framework import tensor_util
+
+      def _is_negative(x__):
+        if isinstance(x__, numpy.ndarray):
+          return (x__ < 0).any()
+        if isinstance(x__, (int, float)):
+          return x__ < 0
+        assert isinstance(x__, tf.Tensor)
+        x__ = tensor_util.constant_value(x__)
+        if x__ is not None:
+          return _is_negative(x__)
+        return False
+
       def _bin_op(a, b):
         with tf_util.same_control_flow_ctx([a, b]):
           if kind == "add":
-            return a + b
+            use_relu = _is_negative(a) or _is_negative(b)  # for dynamic tensors, assume all positive
+            if use_relu:
+              return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(tf_util.simplify_add(a, b)))
+            return tf.convert_to_tensor(tf_util.simplify_add(a, b))
           elif kind == "sub":
-            return a - b
+            return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(tf_util.simplify_sub(a, b)))
           elif kind == "mul":
-            return a * b
+            return tf.convert_to_tensor(tf_util.optional_mul(a, b))
           elif kind in ("floordiv", "truediv"):  # truediv assumes there is no remainder
             return a // b
           elif kind == "ceildiv":

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -633,12 +633,12 @@ class Dim(object):
           if kind == "add":
             use_relu = _is_negative(a) or _is_negative(b)  # for dynamic tensors, assume all positive
             if use_relu:
-              return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(tf_util.simplify_add(a, b)))
-            return tf.convert_to_tensor(tf_util.simplify_add(a, b))
+              return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(a + b))
+            return a + b
           elif kind == "sub":
-            return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(tf_util.simplify_sub(a, b)))
+            return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(a - b))
           elif kind == "mul":
-            return tf.convert_to_tensor(tf_util.optional_mul(a, b))
+            return tf.convert_to_tensor(a * b)
           elif kind in ("floordiv", "truediv"):  # truediv assumes there is no remainder
             return a // b
           elif kind == "ceildiv":

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -638,7 +638,7 @@ class Dim(object):
           elif kind == "sub":
             return tf.convert_to_tensor(tf_util.simplify_non_negative_seq_length(a - b))
           elif kind == "mul":
-            return tf.convert_to_tensor(a * b)
+            return a * b
           elif kind in ("floordiv", "truediv"):  # truediv assumes there is no remainder
             return a // b
           elif kind == "ceildiv":


### PR DESCRIPTION
Fix #1017.

1 + x - 1 != x for dim tags, but using tf_util.simplify_* would make them equal.

Note that this might change the behavior of some older configs where the resulting dim tags would have been equal. I'm not really sure that we hit this case.
