### PR TITLE
Data ext seq mask, use non-zero sizes for padded ext dyn size

### DIFF
--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -250,26 +250,44 @@ def set_padding_info(x, dim, pad_value):
 def mask_dyn_seq_len_nd(x, pad_value, axes):
   """
   :param Data x:
-  :param float|int pad_value:
+  :param float|int|tf.Tensor pad_value:
   :param list[int]|tuple[int] axes:
   :return: masked x
   :rtype: tf.Tensor
   """
-  x_ = x.placeholder
-  dim_tags = [x.dim_tags[i] for i in axes]
-  d = get_padding_info_dict_ref(x_)
-  existing_pad_values = [d.get(tag) for tag in dim_tags]
-  if set(existing_pad_values) == {pad_value}:
-    return x.placeholder  # nothing to do
+  # Filter out some axes which should not be used for masking.
+  axes_ = []
+  for axis in axes:
+    tag = x.dim_tags[axis]
+    assert tag.dyn_size_ext
+    # It only makes sense to apply for this axis if the dyn size dims are all existing in x itself.
+    # E.g. if the dyn_size_ext shape is [B] but the shape of x is just [T] (without B),
+    # then we do not need masking.
+    if set(tag.dyn_size_ext.dim_tags).issubset(x.dim_tags):
+      axes_.append(axis)
+  axes = axes_
 
-  mask = tf.ones([1] * x.batch_ndim, dtype=tf.bool)
+  x_ = x.placeholder
+  if not axes:
+    return x_
+
+  pad_value_is_const = isinstance(pad_value, (int, float))
+  if pad_value_is_const:
+    d = get_padding_info_dict_ref(x_)
+    existing_pad_values = [d.get(x.dim_tags[axis]) for axis in axes]
+    if set(existing_pad_values) == {pad_value}:
+      return x_  # nothing to do
+
+  mask = None
   for axis in axes:
     mask_ = x.get_sequence_mask_broadcast(axis=axis)
-    mask = tf.logical_and(mask, mask_)
-  x_ = where_bc(mask, x_, tf.cast(tf.constant(pad_value, name="pad_value"), dtype=x_.dtype))
-  d = get_padding_info_dict_ref(x_)
-  d.clear()
-  d.update({k: pad_value for k in dim_tags})
+    mask = tf.logical_and(mask, mask_) if mask is not None else mask_
+  assert isinstance(mask, tf.Tensor)
+  x_ = where_bc(mask, x_, tf.cast(tf.convert_to_tensor(pad_value, name="pad_value"), dtype=x_.dtype))
+  if pad_value_is_const:
+    d = get_padding_info_dict_ref(x_)
+    d.clear()
+    d.update({x.dim_tags[axis]: pad_value for axis in axes})
   return x_
 
 

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5053,7 +5053,7 @@ class Data(object):
       We assert here that the axis is dynamic (:func:`is_axis_dynamic`), i.e. we have the size.
     :rtype: tf.Tensor
     """
-    from .basic import sequence_mask_time_major, sequence_mask
+    from .basic import sequence_mask_time_major, sequence_mask, mask_dyn_seq_len_nd
     if axis is None:
       assert self.time_dim_axis is not None
       axis = self.time_dim_axis
@@ -5080,14 +5080,20 @@ class Data(object):
         shape[axis] = placeholder_shape[axis]
         seq_mask = tf.reshape(seq_mask, shape, name="seq_mask_reshape")
         assert seq_mask.get_shape().ndims == self.batch_ndim
-      else:  # size is something unusual
+      else:  # size is something unusual, not just [B], but e.g. [B,S] or so
         max_idx = tf.reduce_max(tag.dyn_size)
         # We use the assumption that self.placeholder.shape[axis] == max_idx.
         idx_range = tf.range(max_idx)
         idx_range = tf.reshape(idx_range, [1] * axis + [max_idx] + [1] * (self.batch_ndim - axis - 1))
         assert set(tag.dyn_size_ext.dim_tags).issubset(self.dim_tags)  # https://github.com/rwth-i6/returnn/issues/721
         size_ext = tag.dyn_size_ext.copy_compatible_to(self, check_sparse=False, check_dtype=False)
-        seq_mask = tf.less(idx_range, size_ext.placeholder)
+        # size_ext might have invalid (zero) sizes when it itself has some padding, e.g. when its own shape is dynamic.
+        # A zero size can lead to problems in some cases, e.g. in SoftmaxOverSpatialLayer,
+        # when everything is masked to -inf, it results in nan, and this likely produces nan in backprop or elsewhere.
+        # Thus, mask size_ext itself, and set the padded values to 1.
+        # This assumes that max_idx >= 1.
+        size = mask_dyn_seq_len_nd(size_ext, 1, size_ext.get_dynamic_axes())
+        seq_mask = tf.less(idx_range, size)
         assert seq_mask.get_shape().ndims == self.batch_ndim
     return seq_mask
 

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5053,7 +5053,7 @@ class Data(object):
       We assert here that the axis is dynamic (:func:`is_axis_dynamic`), i.e. we have the size.
     :rtype: tf.Tensor
     """
-    from .basic import sequence_mask_time_major, sequence_mask, mask_dyn_seq_len_nd
+    from .basic import sequence_mask_time_major, sequence_mask
     if axis is None:
       assert self.time_dim_axis is not None
       axis = self.time_dim_axis


### PR DESCRIPTION
size_ext might have invalid (zero) sizes when it itself has some padding, e.g. when its own shape is dynamic.

A zero size can lead to problems in some cases, e.g. in SoftmaxOverSpatialLayer, when everything is masked to -inf, it results in nan, and this likely produces nan in backprop or elsewhere.

Thus, mask size_ext itself, and set the padded values to 1.

---

This is somewhat an unrelated or orthogonal follow-up to #1019, resulting from [this config](https://gist.github.com/albertz/3de318fca54b76518e24cde024913585).

@robin-p-schmitt This probably should fix the problem you showed me with nan when you disable attention dropout.
