### PR TITLE
TopKLayer conditional k-dim fix

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 filterwarnings =
 	ignore:::keras_preprocessing:
 	ignore:::flatbuffers:
+	ignore:::tensorflow:
 

--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -1022,7 +1022,11 @@ class LayerBase(object):
 
      * the param sharing logic, to reuse existing variables from elsewhere
      * variational noise
-     * Note: :func:`default_control_flow_ctx` should not be needed, as tf.get_variable should always work
+     * Note: :func:`default_control_flow_ctx` is not needed for tf.get_variable.
+       But it might be needed for other code which uses custom inits and tf.Variable,
+       e.g. tf.random.Generator.
+       However, always using this could be a problem if we use other input tensors inside this scope,
+       so we do not enable this here.
 
     :param kwargs: passed to variable_scope
     :return: yields the variable_scope

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5876,7 +5876,7 @@ class ReduceLayer(_ConcatInputLayer):
 
           zeros = tf.zeros((), dtype=x.placeholder.dtype)
           # Cannot call x.placeholder.dtype.{min,max} in case input is e.g. a bool
-          if x.placeholder.dtype.is_floating:
+          if x.placeholder.dtype.is_floating or x.placeholder.dtype.is_integer:
             replacement_value = {
               tf.reduce_mean: zeros,
               tf.reduce_sum: zeros,
@@ -5888,7 +5888,7 @@ class ReduceLayer(_ConcatInputLayer):
               tf.reduce_any: zeros,
               tf.reduce_all: tf.ones((), dtype=x.placeholder.dtype)}[f]
           else:
-            assert False
+            raise TypeError("reduce: unexpected input type %r from input %s" % (x.placeholder.dtype, input_data))
 
           x_ = tf_util.where_bc(mask, x_, replacement_value, name="x_masked_axis_%i" % axis)
           if f == tf.reduce_mean:

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -2450,7 +2450,7 @@ class RandomLayer(LayerBase):
       if static is None or static is False:
         assert auto_update_state is None or auto_update_state is True, (
           "%s: without explicit state, we always auto-update" % self)
-        with self.var_creation_scope():
+        with self.var_creation_scope(), tf_util.default_control_flow_ctx():
           if seed is None:
             seed = self.network.random.randint(2 ** 31, size=[32], dtype="uint32")
           gen = tf.random.Generator.from_seed(seed=seed, alg=algorithm_int)

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -7947,6 +7947,7 @@ class CondLayer(LayerBase):
     if isinstance(layer_desc, LayerBase):
       return layer_desc
     layer_desc = layer_desc.copy()
+    layer_desc["encapsulate"] = True
     layer_class = layer_desc.pop("class")
     assert issubclass(layer_class, LayerBase)
     extra_net = self.network.make_extra_net(
@@ -7987,6 +7988,7 @@ class CondLayer(LayerBase):
     layer_class = get_layer_class(class_name)
     layer_desc["_network"] = extra_net
     layer_desc["_name"] = name
+    layer_desc["encapsulate"] = True
     layer_class.transform_config_dict(layer_desc, network=extra_net, get_layer=get_layer)
     layer_desc["class"] = layer_class  # will later pop again
     d[key] = layer_desc

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -4373,8 +4373,12 @@ class RecLastOutputLayer(LayerBase):
     :param str sub_layer_name:
     :rtype: Data
     """
-    assert isinstance(rec_layer, RecLayer)
-    cell = rec_layer.cell
+    if isinstance(rec_layer, _TemplateLayer):
+      assert issubclass(rec_layer.layer_class_type, RecLayer)
+      cell = rec_layer.kwargs["unit"]
+    else:
+      assert isinstance(rec_layer, RecLayer)
+      cell = rec_layer.cell
     assert isinstance(cell, _SubnetworkRecCell)
     return cell.layer_data_templates[sub_layer_name].output
 

--- a/returnn/util/better_exchook.py
+++ b/returnn/util/better_exchook.py
@@ -1146,6 +1146,10 @@ def format_tb(tb=None, limit=None, allLocals=None, allGlobals=None, withTitle=Fa
                 lineno = f.f_lineno
             co = f.f_code
             filename = co.co_filename
+            if not os.path.isfile(filename):
+                alt_fn = fallback_findfile(filename)
+                if alt_fn:
+                    filename = alt_fn
             name = get_func_str_from_code_object(co)
             file_descr = "".join([
                 '  ',
@@ -1153,13 +1157,6 @@ def format_tb(tb=None, limit=None, allLocals=None, allGlobals=None, withTitle=Fa
                 color("line ", color.fg_colors[0]), color("%d" % lineno, color.fg_colors[4]), ", ",
                 color("in ", color.fg_colors[0]), name])
             with output.fold_text_ctx(file_descr):
-                if not os.path.isfile(filename):
-                    alt_fn = fallback_findfile(filename)
-                    if alt_fn:
-                        output(
-                            color("    -- couldn't find file, trying this instead: ", color.fg_colors[0]) +
-                            format_filename(alt_fn))
-                        filename = alt_fn
                 source_code = get_source_code(filename, lineno, f.f_globals)
                 if source_code:
                     source_code = remove_indent_lines(replace_tab_indents(source_code)).rstrip()

--- a/tests/_setup_test_env.py
+++ b/tests/_setup_test_env.py
@@ -47,7 +47,8 @@ def setup():
   better_exchook.replace_traceback_format_tb()
 
   from returnn.log import log
-  log.initialize(verbosity=[5], propagate=True)
+  # No propagate, use stdout directly.
+  log.initialize(verbosity=[5], propagate=False)
 
   # TF is optional.
   # Note that importing TF still has a small side effect:
@@ -141,10 +142,6 @@ def _try_hook_into_tests():
     # Multiple tests are being run. Do not hook into this.
     # We only want to install the hook if there is only a single test case.
     return
-
-  from returnn.log import log
-  # No propagate, use stdout directly.
-  log.initialize(verbosity=[5], propagate=False)
 
   # Skip this if we are not in a debugger.
   if test_program and in_debugger:  # nosetest, unittest

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -2803,6 +2803,688 @@ def test_TopKLayer_two_axes():
     assert (indices1_np == numpy.array([4, 3])[None]).all()
 
 
+def test_specaugment_pure_returnn():
+  from returnn.tf.util.data import (
+    batch_dim, SpatialDim, FeatureDim, ImplicitDynSizeDim, ImplicitSparseDim)
+
+  time_dim = SpatialDim('time')
+  feat_dim = FeatureDim('feat', 50)
+
+  config = Config(dict(
+    extern_data={
+      'data': {
+        'dim_tags': (batch_dim, time_dim, feat_dim),
+        'dtype': 'float32',
+        'available_for_inference': True
+      }
+    },
+    debug_runtime_sanity_checks=True,
+  ))
+
+  specaugment_v2_cond_true_time_masking_top_k_k_dim = SpatialDim('specaugment_v2/cond/true/time_masking:top_k:k_dim')
+  specaugment_v2_cond_true_feature_masking_top_k_k_dim = SpatialDim(
+    'specaugment_v2/cond/true/feature_masking:top_k:k_dim')
+  random_state_dim = FeatureDim('random-state', 3)
+
+  net_dict = {
+    'specaugment_v2': {
+      'class': 'subnetwork',
+      'from': [],
+      'subnetwork': {
+        'ones': {'class': 'constant', 'value': True, 'shape': (), 'dtype': 'bool'},
+        'cond': {
+          'class': 'cond',
+          'from': [],
+          'condition': 'ones',
+          'true_layer': {
+            'class': 'subnetwork',
+            'from': [],
+            'subnetwork': {
+              'dim_value': {
+                'class': 'subnetwork',
+                'from': [],
+                'subnetwork': {
+                  'length': {
+                    'class': 'length',
+                    'from': 'base:base:base:data:data',
+                    'axis': time_dim,
+                    'out_shape': {batch_dim}
+                  },
+                  'reduce': {
+                    'class': 'reduce',
+                    'from': 'length',
+                    'mode': 'max',
+                    'axis': (batch_dim,),
+                    'out_shape': {}
+                  },
+                  'output': {
+                    'class': 'copy',
+                    'from': 'reduce',
+                    'out_shape': {}
+                  }
+                },
+                'out_shape': {}
+              },
+              'constant': {'class': 'constant', 'value': 2},
+              'minimum': {
+                'class': 'combine',
+                'from': ['constant', 'dim_value'],
+                'kind': 'minimum',
+                'out_shape': {}
+              },
+              'constant_0': {'class': 'constant', 'value': 100},
+              'floordiv': {
+                'class': 'combine',
+                'from': ['dim_value', 'constant_0'],
+                'kind': 'floordiv',
+                'out_shape': {}
+              },
+              'constant_1': {'class': 'constant', 'value': 2},
+              'maximum': {
+                'class': 'combine',
+                'from': ['floordiv', 'constant_1'],
+                'kind': 'maximum',
+                'out_shape': {}
+              },
+              'constant_2': {'class': 'constant', 'value': 4},
+              'mul': {
+                'class': 'combine',
+                'from': ['maximum', 'constant_2'],
+                'kind': 'mul',
+                'out_shape': {}
+              },
+              'minimum_0': {
+                'class': 'combine',
+                'from': ['mul', 'dim_value'],
+                'kind': 'minimum',
+                'out_shape': {}
+              },
+              'time_masking': {
+                'class': 'subnetwork',
+                'from': [],
+                'subnetwork': {
+                  'constant': {'class': 'constant', 'value': 1},
+                  'add': {
+                    'class': 'combine',
+                    'from': ['base:minimum_0', 'constant'],
+                    'kind': 'add',
+                    'out_shape': {}
+                  },
+                  'random': {
+                    'class': 'subnetwork',
+                    'from': [],
+                    'subnetwork': {
+                      'random': {
+                        'class': 'random',
+                        'shape': [
+                          batch_dim
+                        ],
+                        'distribution': 'uniform',
+                        'minval': 'base:base:minimum',
+                        'maxval': 'base:add',
+                        'dtype': 'int32',
+                        'explicit_state': 'base:base:base:random_state_var0_1',
+                        'auto_update_state': True
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'random',
+                        'out_shape': {batch_dim}
+                      }
+                    },
+                    'out_shape': {batch_dim}
+                  },
+                  'random_0': {
+                    'class': 'subnetwork',
+                    'from': [],
+                    'subnetwork': {
+                      'random': {
+                        'class': 'random',
+                        'shape': [
+                          batch_dim,
+                          time_dim
+                        ],
+                        'distribution': 'uniform',
+                        'minval': 0.0,
+                        'maxval': 1.0,
+                        'explicit_state': 'base:base:base:random_0_state_var0_0',
+                        'auto_update_state': True
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'random',
+                        'out_shape': {batch_dim, time_dim}
+                      }
+                    },
+                    'out_shape': {batch_dim, time_dim}
+                  },
+                  'log': {
+                    'class': 'activation',
+                    'from': 'random_0',
+                    'activation': 'log',
+                    'out_shape': {batch_dim, time_dim}
+                  },
+                  'negative': {
+                    'class': 'activation',
+                    'from': 'log',
+                    'activation': 'negative',
+                    'out_shape': {batch_dim, time_dim}
+                  },
+                  'log_0': {
+                    'class': 'activation',
+                    'from': 'negative',
+                    'activation': 'log',
+                    'out_shape': {batch_dim, time_dim}
+                  },
+                  'negative_0': {
+                    'class': 'activation',
+                    'from': 'log_0',
+                    'activation': 'negative',
+                    'out_shape': {batch_dim, time_dim}
+                  },
+                  'reduce': {
+                    'class': 'reduce',
+                    'from': 'random',
+                    'mode': 'max',
+                    'axis': (batch_dim,),
+                    'out_shape': {}
+                  },
+                  'top_k': {
+                    'class': 'top_k',
+                    'from': 'negative_0',
+                    'axis': time_dim,
+                    'k': 'reduce',
+                    'k_dim': specaugment_v2_cond_true_time_masking_top_k_k_dim,
+                    'sorted': True,
+                    'out_shape': {batch_dim, specaugment_v2_cond_true_time_masking_top_k_k_dim}
+                  },
+                  'loop': {
+                    'class': 'rec',
+                    'from': [],
+                    'unit': {
+                      'rec_unstack': {
+                        'class': 'rec_unstack',
+                        'from': 'base:range_in_axis',
+                        'axis': specaugment_v2_cond_true_time_masking_top_k_k_dim,
+                        'out_shape': {}
+                      },
+                      'gather': {
+                        'class': 'gather',
+                        'from': 'base:top_k/indices',
+                        'position': 'rec_unstack',
+                        'axis': specaugment_v2_cond_true_time_masking_top_k_k_dim,
+                        'out_shape': {batch_dim, ImplicitSparseDim(time_dim)}
+                      },
+                      '_mask_v2': {
+                        'class': 'subnetwork',
+                        'from': [],
+                        'subnetwork': {
+                          'length': {
+                            'class': 'length',
+                            'from': 'base:prev:_mask_v2',
+                            'axis': time_dim,
+                            'out_shape': {batch_dim}
+                          },
+                          'random': {
+                            'class': 'subnetwork',
+                            'from': [],
+                            'subnetwork': {
+                              'random': {
+                                'class': 'random',
+                                'shape': (batch_dim,),
+                                'distribution': 'uniform',
+                                'minval': 1,
+                                'maxval': 21,
+                                'dtype': 'int32',
+                                'explicit_state': 'base:base:base:base:base:random_state_var0_2',
+                                'auto_update_state': True
+                              },
+                              'output': {
+                                'class': 'copy',
+                                'from': 'random',
+                                'out_shape': {batch_dim}
+                              }
+                            },
+                            'out_shape': {batch_dim}
+                          },
+                          'add': {
+                            'class': 'combine',
+                            'from': ['base:gather', 'random'],
+                            'kind': 'add',
+                            'out_shape': {batch_dim, ImplicitSparseDim(time_dim)}
+                          },
+                          'minimum': {
+                            'class': 'combine',
+                            'from': ['add', 'length'],
+                            'kind': 'minimum',
+                            'out_shape': {batch_dim, ImplicitSparseDim(time_dim)}
+                          },
+                          'range_in_axis': {
+                            'class': 'range_in_axis',
+                            'from': 'base:prev:_mask_v2',
+                            'axis': time_dim,
+                            'out_shape': {ImplicitDynSizeDim(batch_dim), time_dim}
+                          },
+                          'greater_equal': {
+                            'class': 'compare',
+                            'from': ['range_in_axis', 'base:gather'],
+                            'kind': 'greater_equal',
+                            'allow_broadcast_all_sources': True,
+                            'out_shape': {batch_dim, time_dim}
+                          },
+                          'less': {
+                            'class': 'compare',
+                            'from': ['range_in_axis', 'minimum'],
+                            'kind': 'less',
+                            'allow_broadcast_all_sources': True,
+                            'out_shape': {batch_dim, time_dim}
+                          },
+                          'logical_and': {
+                            'class': 'combine',
+                            'from': ['greater_equal', 'less'],
+                            'kind': 'logical_and',
+                            'out_shape': {batch_dim, time_dim}
+                          },
+                          'where': {
+                            'class': 'switch',
+                            'condition': 'logical_and',
+                            'true_from': 0.0,
+                            'false_from': 'base:prev:_mask_v2',
+                            'out_shape': {batch_dim, time_dim, feat_dim}
+                          },
+                          'output': {
+                            'class': 'copy',
+                            'from': 'where',
+                            'out_shape': {batch_dim, time_dim, feat_dim}
+                          }
+                        },
+                        'initial_output': 'base:base:base:base:data:data',
+                        'need_last': True,
+                        'out_shape': {batch_dim, time_dim, feat_dim}
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'rec_unstack',
+                        'out_shape': {}
+                      }
+                    },
+                    'axis': specaugment_v2_cond_true_time_masking_top_k_k_dim,
+                    'out_shape': {specaugment_v2_cond_true_time_masking_top_k_k_dim},
+                    'name_scope': ''
+                  },
+                  'range_in_axis': {
+                    'class': 'range_in_axis',
+                    'from': 'top_k/indices',
+                    'axis': specaugment_v2_cond_true_time_masking_top_k_k_dim,
+                    'out_shape': {specaugment_v2_cond_true_time_masking_top_k_k_dim}
+                  },
+                  '_mask_v2': {
+                    'class': 'rec_last_output',
+                    'rec_layer': 'loop',
+                    'sub_layer_name': '_mask_v2',
+                    'out_shape': {batch_dim, time_dim, feat_dim}
+                  },
+                  'output': {
+                    'class': 'copy',
+                    'from': '_mask_v2',
+                    'out_shape': {batch_dim, time_dim, feat_dim}
+                  }
+                },
+                'out_shape': {batch_dim, time_dim, feat_dim}
+              },
+              'feature_masking': {
+                'class': 'subnetwork',
+                'from': [],
+                'subnetwork': {
+                  'random': {
+                    'class': 'subnetwork',
+                    'from': [],
+                    'subnetwork': {
+                      'random': {
+                        'class': 'random',
+                        'shape': [
+                          batch_dim
+                        ],
+                        'distribution': 'uniform',
+                        'minval': 2,
+                        'maxval': 6,
+                        'dtype': 'int32',
+                        'explicit_state': 'base:base:base:random_state_var0',
+                        'auto_update_state': True
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'random',
+                        'out_shape': {batch_dim}
+                      }
+                    },
+                    'out_shape': {batch_dim}
+                  },
+                  'random_0': {
+                    'class': 'subnetwork',
+                    'from': [],
+                    'subnetwork': {
+                      'random': {
+                        'class': 'random',
+                        'shape': [
+                          batch_dim,
+                          feat_dim
+                        ],
+                        'distribution': 'uniform',
+                        'minval': 0.0,
+                        'maxval': 1.0,
+                        'explicit_state': 'base:base:base:random_0_state_var0',
+                        'auto_update_state': True
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'random',
+                        'out_shape': {batch_dim, feat_dim}
+                      }
+                    },
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'log': {
+                    'class': 'activation',
+                    'from': 'random_0',
+                    'activation': 'log',
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'negative': {
+                    'class': 'activation',
+                    'from': 'log',
+                    'activation': 'negative',
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'log_0': {
+                    'class': 'activation',
+                    'from': 'negative',
+                    'activation': 'log',
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'negative_0': {
+                    'class': 'activation',
+                    'from': 'log_0',
+                    'activation': 'negative',
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'reduce': {
+                    'class': 'reduce',
+                    'from': 'random',
+                    'mode': 'max',
+                    'axis': (batch_dim,),
+                    'out_shape': {}
+                  },
+                  'top_k': {
+                    'class': 'top_k',
+                    'from': 'negative_0',
+                    'axis': feat_dim,
+                    'k': 'reduce',
+                    'k_dim': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                    'sorted': True,
+                    'out_shape': {batch_dim, specaugment_v2_cond_true_feature_masking_top_k_k_dim}
+                  },
+                  'loop': {
+                    'class': 'rec',
+                    'from': [],
+                    'unit': {
+                      'rec_unstack': {
+                        'class': 'rec_unstack',
+                        'from': 'base:range_in_axis',
+                        'axis': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                        'out_shape': {}
+                      },
+                      'gather': {
+                        'class': 'gather',
+                        'from': 'base:top_k/indices',
+                        'position': 'rec_unstack',
+                        'axis': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                        'out_shape': {batch_dim, ImplicitSparseDim(feat_dim)}
+                      },
+                      '_mask_v2': {
+                        'class': 'subnetwork',
+                        'from': [],
+                        'subnetwork': {
+                          'length': {
+                            'class': 'length',
+                            'from': 'base:prev:_mask_v2',
+                            'axis': feat_dim,
+                            'out_shape': {}
+                          },
+                          'random': {
+                            'class': 'subnetwork',
+                            'from': [],
+                            'subnetwork': {
+                              'random': {
+                                'class': 'random',
+                                'shape': (batch_dim,),
+                                'distribution': 'uniform',
+                                'minval': 1,
+                                'maxval': 11,
+                                'dtype': 'int32',
+                                'explicit_state': 'base:base:base:base:base:random_state_var0_0',
+                                'auto_update_state': True
+                              },
+                              'output': {
+                                'class': 'copy',
+                                'from': 'random',
+                                'out_shape': {batch_dim}
+                              }
+                            },
+                            'out_shape': {batch_dim}
+                          },
+                          'add': {
+                            'class': 'combine',
+                            'from': ['base:gather', 'random'],
+                            'kind': 'add',
+                            'out_shape': {batch_dim, ImplicitSparseDim(feat_dim)}
+                          },
+                          'minimum': {
+                            'class': 'combine',
+                            'from': ['add', 'length'],
+                            'kind': 'minimum',
+                            'out_shape': {batch_dim, ImplicitSparseDim(feat_dim)}
+                          },
+                          'range_in_axis': {
+                            'class': 'range_in_axis',
+                            'from': 'base:prev:_mask_v2',
+                            'axis': feat_dim,
+                            'out_shape': {feat_dim}
+                          },
+                          'greater_equal': {
+                            'class': 'compare',
+                            'from': ['range_in_axis', 'base:gather'],
+                            'kind': 'greater_equal',
+                            'allow_broadcast_all_sources': True,
+                            'out_shape': {batch_dim, feat_dim}
+                          },
+                          'less': {
+                            'class': 'compare',
+                            'from': ['range_in_axis', 'minimum'],
+                            'kind': 'less',
+                            'allow_broadcast_all_sources': True,
+                            'out_shape': {batch_dim, feat_dim}
+                          },
+                          'logical_and': {
+                            'class': 'combine',
+                            'from': ['greater_equal', 'less'],
+                            'kind': 'logical_and',
+                            'out_shape': {batch_dim, feat_dim}
+                          },
+                          'where': {
+                            'class': 'switch',
+                            'condition': 'logical_and',
+                            'true_from': 0.0,
+                            'false_from': 'base:prev:_mask_v2',
+                            'out_shape': {batch_dim, time_dim, feat_dim}
+                          },
+                          'output': {
+                            'class': 'copy',
+                            'from': 'where',
+                            'out_shape': {batch_dim, time_dim, feat_dim}
+                          }
+                        },
+                        'initial_output': 'base:base:time_masking',
+                        'need_last': True,
+                        'out_shape': {batch_dim, time_dim, feat_dim}
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'rec_unstack',
+                        'out_shape': {}
+                      }
+                    },
+                    'axis': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                    'out_shape': {specaugment_v2_cond_true_feature_masking_top_k_k_dim},
+                    'name_scope': ''
+                  },
+                  'range_in_axis': {
+                    'class': 'range_in_axis',
+                    'from': 'top_k/indices',
+                    'axis': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                    'out_shape': {specaugment_v2_cond_true_feature_masking_top_k_k_dim}
+                  },
+                  '_mask_v2': {
+                    'class': 'rec_last_output',
+                    'rec_layer': 'loop',
+                    'sub_layer_name': '_mask_v2',
+                    'out_shape': {batch_dim, time_dim, feat_dim}
+                  },
+                  'output': {
+                    'class': 'copy',
+                    'from': '_mask_v2',
+                    'out_shape': {batch_dim, time_dim, feat_dim}
+                  }
+                },
+                'out_shape': {batch_dim, time_dim, feat_dim}
+              },
+              'output': {
+                'class': 'copy',
+                'from': 'feature_masking',
+                'out_shape': {batch_dim, time_dim, feat_dim}
+              }
+            }
+          },
+          'false_layer': {
+            'class': 'subnetwork',
+            'from': [],
+            'subnetwork': {
+              'output': {
+                'class': 'copy',
+                'from': 'base:base:data:data',
+                'out_shape': {batch_dim, time_dim, feat_dim}
+              }
+            }
+          },
+          'out_shape': {batch_dim, time_dim, feat_dim},
+          'name_scope': ''
+        },
+        'random_state_init': {
+          'class': 'random_state_init',
+          'out_dim': random_state_dim,
+          'out_shape': {random_state_dim}
+        },
+        'random_state_init_0': {
+          'class': 'random_state_init',
+          'out_dim': random_state_dim,
+          'out_shape': {random_state_dim}
+        },
+        'random_state_init_1': {
+          'class': 'random_state_init',
+          'out_dim': random_state_dim,
+          'out_shape': {random_state_dim}
+        },
+        'random_state_init_2': {
+          'class': 'random_state_init',
+          'out_dim': random_state_dim,
+          'out_shape': {random_state_dim}
+        },
+        'random_state_init_3': {
+          'class': 'random_state_init',
+          'out_dim': random_state_dim,
+          'out_shape': {random_state_dim}
+        },
+        'random_state_init_4': {
+          'class': 'random_state_init',
+          'out_dim': random_state_dim,
+          'out_shape': {random_state_dim}
+        },
+        'output': {
+          'class': 'copy',
+          'from': 'cond',
+          'out_shape': {batch_dim, time_dim, feat_dim}
+        },
+        'random_state_var0': {
+          'class': 'variable',
+          'shape': [
+            random_state_dim
+          ],
+          'param_name': 'param',
+          'dtype': 'int64',
+          'init_by_layer': 'random_state_init_2'
+        },
+        'random_state_var0_0': {
+          'class': 'variable',
+          'shape': [
+            random_state_dim
+          ],
+          'param_name': 'param',
+          'dtype': 'int64',
+          'init_by_layer': 'random_state_init_4'
+        },
+        'random_0_state_var0': {
+          'class': 'variable',
+          'shape': [
+            random_state_dim
+          ],
+          'param_name': 'param',
+          'dtype': 'int64',
+          'init_by_layer': 'random_state_init_3'
+        },
+        'random_state_var0_1': {
+          'class': 'variable',
+          'shape': [
+            random_state_dim
+          ],
+          'param_name': 'param',
+          'dtype': 'int64',
+          'init_by_layer': 'random_state_init'
+        },
+        'random_state_var0_2': {
+          'class': 'variable',
+          'shape': [
+            random_state_dim
+          ],
+          'param_name': 'param',
+          'dtype': 'int64',
+          'init_by_layer': 'random_state_init_1'
+        },
+        'random_0_state_var0_0': {
+          'class': 'variable',
+          'shape': [
+            random_state_dim
+          ],
+          'param_name': 'param',
+          'dtype': 'int64',
+          'init_by_layer': 'random_state_init_0'
+        }
+      },
+      'out_shape': {batch_dim, time_dim, feat_dim}
+    },
+    'output': {
+      'class': 'copy',
+      'from': 'specaugment_v2',
+      'out_shape': {batch_dim, time_dim, feat_dim}
+    }
+  }
+
+  with make_scope() as session:
+    net = TFNetwork(config=config)
+    net.construct_from_dict(net_dict)
+    net.initialize_params(session)
+    session.run(net.get_default_output_layer().output.placeholder, feed_dict=make_feed_dict(net.extern_data))
+
+
 def test_SearchSortedLayer():
   n_batch, n_time, n_in, n_out = 2, 10, 3, 5
   random = numpy.random.RandomState(seed=1)

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -2803,6 +2803,358 @@ def test_TopKLayer_two_axes():
     assert (indices1_np == numpy.array([4, 3])[None]).all()
 
 
+def test_specaugment_pure_returnn_reduced_with_cond():
+  from returnn.tf.util.data import batch_dim, SpatialDim, FeatureDim, ImplicitSparseDim
+
+  time_dim = SpatialDim('time')
+  feat_dim = FeatureDim('feat', 50)
+
+  config = Config(dict(
+    extern_data={
+      'data': {
+        'dim_tags': (batch_dim, time_dim, feat_dim),
+        'dtype': 'float32',
+        'available_for_inference': True
+      }
+    },
+    debug_runtime_sanity_checks=True,
+    debug_print_layer_output_shape=True,
+  ))
+
+  specaugment_v2_cond_true_feature_masking_top_k_k_dim = SpatialDim('feature_masking:num')
+
+  net_dict = {
+    'specaugment_v2': {
+      'class': 'subnetwork',
+      'from': [],
+      'subnetwork': {
+        'ones': {'class': 'constant', 'value': True, 'shape': (), 'dtype': 'bool'},
+        'cond': {
+          'class': 'cond',
+          'from': [],
+          'condition': 'ones',
+          'true_layer': {
+            'class': 'subnetwork',
+            'from': [],
+            'subnetwork': {
+              'dim_value': {
+                'class': 'subnetwork',
+                'from': [],
+                'subnetwork': {
+                  'length': {
+                    'class': 'length',
+                    'from': 'base:base:base:data:data',
+                    'axis': time_dim,
+                    'out_shape': {batch_dim}
+                  },
+                  'reduce': {
+                    'class': 'reduce',
+                    'from': 'length',
+                    'mode': 'max',
+                    'axis': (batch_dim,),
+                    'out_shape': {}
+                  },
+                  'output': {
+                    'class': 'copy',
+                    'from': 'reduce',
+                    'out_shape': {}
+                  }
+                },
+                'out_shape': {}
+              },
+              'constant': {'class': 'constant', 'value': 2},
+              'minimum': {
+                'class': 'combine',
+                'from': ['constant', 'dim_value'],
+                'kind': 'minimum',
+                'out_shape': {}
+              },
+              'constant_0': {'class': 'constant', 'value': 100},
+              'floordiv': {
+                'class': 'combine',
+                'from': ['dim_value', 'constant_0'],
+                'kind': 'floordiv',
+                'out_shape': {}
+              },
+              'constant_1': {'class': 'constant', 'value': 2},
+              'maximum': {
+                'class': 'combine',
+                'from': ['floordiv', 'constant_1'],
+                'kind': 'maximum',
+                'out_shape': {}
+              },
+              'constant_2': {'class': 'constant', 'value': 4},
+              'mul': {
+                'class': 'combine',
+                'from': ['maximum', 'constant_2'],
+                'kind': 'mul',
+                'out_shape': {}
+              },
+              'minimum_0': {
+                'class': 'combine',
+                'from': ['mul', 'dim_value'],
+                'kind': 'minimum',
+                'out_shape': {}
+              },
+              'feature_masking': {
+                'class': 'subnetwork',
+                'from': [],
+                'subnetwork': {
+                  'random': {
+                    'class': 'subnetwork',
+                    'from': [],
+                    'subnetwork': {
+                      'random': {
+                        'class': 'random',
+                        'shape': [
+                          batch_dim
+                        ],
+                        'distribution': 'uniform',
+                        'minval': 2,
+                        'maxval': 6,
+                        'dtype': 'int32',
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'random',
+                        'out_shape': {batch_dim}
+                      }
+                    },
+                    'out_shape': {batch_dim}
+                  },
+                  'random_0': {
+                    'class': 'subnetwork',
+                    'from': [],
+                    'subnetwork': {
+                      'random': {
+                        'class': 'random',
+                        'shape': [
+                          batch_dim,
+                          feat_dim
+                        ],
+                        'distribution': 'uniform',
+                        'minval': 0.0,
+                        'maxval': 1.0,
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'random',
+                        'out_shape': {batch_dim, feat_dim}
+                      }
+                    },
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'log': {
+                    'class': 'activation',
+                    'from': 'random_0',
+                    'activation': 'log',
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'negative': {
+                    'class': 'activation',
+                    'from': 'log',
+                    'activation': 'negative',
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'log_0': {
+                    'class': 'activation',
+                    'from': 'negative',
+                    'activation': 'log',
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'negative_0': {
+                    'class': 'activation',
+                    'from': 'log_0',
+                    'activation': 'negative',
+                    'out_shape': {batch_dim, feat_dim}
+                  },
+                  'reduce': {
+                    'class': 'reduce',
+                    'from': 'random',
+                    'mode': 'max',
+                    'axis': (batch_dim,),
+                    'out_shape': {}
+                  },
+                  'top_k': {
+                    'class': 'top_k',
+                    'from': 'negative_0',
+                    'axis': feat_dim,
+                    'k': 'reduce',
+                    'k_dim': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                    'sorted': True,
+                    'out_shape': {batch_dim, specaugment_v2_cond_true_feature_masking_top_k_k_dim}
+                  },
+                  'loop': {
+                    'class': 'rec',
+                    'from': [],
+                    'unit': {
+                      'rec_unstack': {
+                        'class': 'rec_unstack',
+                        'from': 'base:range_in_axis',
+                        'axis': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                        'out_shape': {}
+                      },
+                      'gather': {
+                        'class': 'gather',
+                        'from': 'base:top_k/indices',
+                        'position': 'rec_unstack',
+                        'axis': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                        'out_shape': {batch_dim, ImplicitSparseDim(feat_dim)}
+                      },
+                      '_mask_v2': {
+                        'class': 'subnetwork',
+                        'from': [],
+                        'subnetwork': {
+                          'length': {
+                            'class': 'length',
+                            'from': 'base:prev:_mask_v2',
+                            'axis': feat_dim,
+                            'out_shape': {}
+                          },
+                          'random': {
+                            'class': 'subnetwork',
+                            'from': [],
+                            'subnetwork': {
+                              'random': {
+                                'class': 'random',
+                                'shape': (batch_dim,),
+                                'distribution': 'uniform',
+                                'minval': 1,
+                                'maxval': 11,
+                                'dtype': 'int32',
+                              },
+                              'output': {
+                                'class': 'copy',
+                                'from': 'random',
+                                'out_shape': {batch_dim}
+                              }
+                            },
+                            'out_shape': {batch_dim}
+                          },
+                          'add': {
+                            'class': 'combine',
+                            'from': ['base:gather', 'random'],
+                            'kind': 'add',
+                            'out_shape': {batch_dim, ImplicitSparseDim(feat_dim)}
+                          },
+                          'minimum': {
+                            'class': 'combine',
+                            'from': ['add', 'length'],
+                            'kind': 'minimum',
+                            'out_shape': {batch_dim, ImplicitSparseDim(feat_dim)}
+                          },
+                          'range_in_axis': {
+                            'class': 'range_in_axis',
+                            'from': 'base:prev:_mask_v2',
+                            'axis': feat_dim,
+                            'out_shape': {feat_dim}
+                          },
+                          'greater_equal': {
+                            'class': 'compare',
+                            'from': ['range_in_axis', 'base:gather'],
+                            'kind': 'greater_equal',
+                            'allow_broadcast_all_sources': True,
+                            'out_shape': {batch_dim, feat_dim}
+                          },
+                          'less': {
+                            'class': 'compare',
+                            'from': ['range_in_axis', 'minimum'],
+                            'kind': 'less',
+                            'allow_broadcast_all_sources': True,
+                            'out_shape': {batch_dim, feat_dim}
+                          },
+                          'logical_and': {
+                            'class': 'combine',
+                            'from': ['greater_equal', 'less'],
+                            'kind': 'logical_and',
+                            'out_shape': {batch_dim, feat_dim}
+                          },
+                          'where': {
+                            'class': 'switch',
+                            'condition': 'logical_and',
+                            'true_from': 0.0,
+                            'false_from': 'base:prev:_mask_v2',
+                            'out_shape': {batch_dim, time_dim, feat_dim}
+                          },
+                          'output': {
+                            'class': 'copy',
+                            'from': 'where',
+                            'out_shape': {batch_dim, time_dim, feat_dim}
+                          }
+                        },
+                        'initial_output': 'base:base:base:base:data',
+                        'need_last': True,
+                        'out_shape': {batch_dim, time_dim, feat_dim}
+                      },
+                      'output': {
+                        'class': 'copy',
+                        'from': 'rec_unstack',
+                        'out_shape': {}
+                      }
+                    },
+                    'axis': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                    'out_shape': {specaugment_v2_cond_true_feature_masking_top_k_k_dim},
+                    'name_scope': ''
+                  },
+                  'range_in_axis': {
+                    'class': 'range_in_axis',
+                    'from': 'top_k/indices',
+                    'axis': specaugment_v2_cond_true_feature_masking_top_k_k_dim,
+                    'out_shape': {specaugment_v2_cond_true_feature_masking_top_k_k_dim}
+                  },
+                  '_mask_v2': {
+                    'class': 'rec_last_output',
+                    'rec_layer': 'loop',
+                    'sub_layer_name': '_mask_v2',
+                    'out_shape': {batch_dim, time_dim, feat_dim}
+                  },
+                  'output': {
+                    'class': 'copy',
+                    'from': '_mask_v2',
+                    'out_shape': {batch_dim, time_dim, feat_dim}
+                  }
+                },
+                'out_shape': {batch_dim, time_dim, feat_dim}
+              },
+              'output': {
+                'class': 'copy',
+                'from': 'feature_masking',
+                'out_shape': {batch_dim, time_dim, feat_dim}
+              }
+            }
+          },
+          'false_layer': {
+            'class': 'subnetwork',
+            'from': [],
+            'subnetwork': {
+              'output': {
+                'class': 'copy',
+                'from': 'base:base:data:data',
+                'out_shape': {batch_dim, time_dim, feat_dim}
+              }
+            }
+          },
+          'out_shape': {batch_dim, time_dim, feat_dim},
+          'name_scope': ''
+        },
+        "output": {"class": "copy", "from": "cond"},
+      },
+      'out_shape': {batch_dim, time_dim, feat_dim}
+    },
+    'output': {
+      'class': 'copy',
+      'from': 'specaugment_v2',
+      'out_shape': {batch_dim, time_dim, feat_dim}
+    }
+  }
+
+  with make_scope() as session:
+    net = TFNetwork(config=config)
+    net.construct_from_dict(net_dict)
+    net.initialize_params(session)
+    session.run(net.get_default_output_layer().output.placeholder, feed_dict=make_feed_dict(net.extern_data))
+
+
 def test_specaugment_pure_returnn_reduced():
   from returnn.tf.util.data import batch_dim, SpatialDim, FeatureDim, ImplicitSparseDim
 


### PR DESCRIPTION
Currently it's not entirely clear what the problem is but some of the added test cases here fail.

It seems the `k_dim` is broken when the `TopKLayer` is inside a `CondLayer`.

**Edit** It was actually a bug in `CondLayer` together with subnet logic. The subnet layers were actually constructed twice because the template construction was not correctly triggered. See `test_CondLayer_subnet_template_construct`.

This PR fixes that.

---

There are some partly unrelated commits in here as well, so this PR should be rebased to keep individual commits.
