### PR TITLE
Automatic flattening, fix for CopyLayer, comments

### DIFF
--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1444,7 +1444,7 @@ class TFNetwork(object):
         if isinstance(layer_, SubnetworkLayer):
           layer_ = layer_.subnetwork.layers["output"]
           continue
-        if isinstance(layer_, CopyLayer) and len(layer_.sources) == 1 and not isinstance(layer_, CastLayer):
+        if type(layer_) is CopyLayer and len(layer_.sources) == 1:
           layer_ = layer_.sources[0]
           continue
         return layer_

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1485,13 +1485,13 @@ class TFNetwork(object):
       if layer in end_points:
         continue
       layer_queue.append(layer)
-
     while layer_queue:
       layer = layer_queue.pop(0)
       if layer in blacklist:
         continue
       blacklist.add(layer)
       layer_queue.extend(_layer_deps(layer))
+
     # Collect back refs, starting from end points.
     deps_used_by_end_points = {layer: {layer} for layer in end_points}  # dep -> set(end points), direct and indirect
     deps_used_by = {layer: set() for layer in end_points}  # dep -> set(used by), direct dependencies only

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1437,7 +1437,7 @@ class TFNetwork(object):
       """
       Flattens the layer structure, removes irrelevant layers and returns next successor layer
       :param LayerBase layer_:
-      :return Next layer in succession
+      :return: next layer in succession
       :rtype: LayerBase
       """
       while True:

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1304,7 +1304,7 @@ class TFNetwork(object):
     # We are very restrictive here to not break anything in case of unrelated bugs of other layers.
 
     from .util.data import BatchInfo
-    from .layers.basic import SourceLayer, InternalLayer, SubnetworkLayer, CopyLayer, CastLayer, FlattenBatchLayer
+    from .layers.basic import SourceLayer, InternalLayer, SubnetworkLayer, CopyLayer, FlattenBatchLayer
     from tensorflow.python.util import nest
 
     def _relevant_dims_for_layer(layer_):
@@ -1338,6 +1338,7 @@ class TFNetwork(object):
     def _make_layer(layer_cls, layer_dict, map_opts=True):
       """
       Creates the flattened layer
+
       :param type[LayerBase]|LayerBase layer_cls:
       :param dict[str] layer_dict:
       :param bool map_opts:
@@ -1368,6 +1369,7 @@ class TFNetwork(object):
     def _should_flatten_layer_output(layer_):
       """
       Decides whether layer output has right properties for flattening
+
       :param LayerBase layer_:
       :rtype: bool
       """
@@ -1385,6 +1387,7 @@ class TFNetwork(object):
     def _check_push_flattening_to_inputs_for_layer_simple(layer_):
       """
       Checks preconditions for input flattening
+
       :param LayerBase layer_:
       :rtype: bool
       """
@@ -1403,6 +1406,7 @@ class TFNetwork(object):
     def _check_push_flattening_to_inputs_for_layer(layer_):
       """
       Checks whether the inputs to the layer should be flattened aswell
+
       :param LayerBase layer_:
       :rtype: bool
       """
@@ -1436,6 +1440,7 @@ class TFNetwork(object):
     def _resolve_layer(layer_):
       """
       Flattens the layer structure, removes irrelevant layers and returns next successor layer
+
       :param LayerBase layer_:
       :return: next layer in succession
       :rtype: LayerBase
@@ -1480,6 +1485,7 @@ class TFNetwork(object):
       if layer in end_points:
         continue
       layer_queue.append(layer)
+
     while layer_queue:
       layer = layer_queue.pop(0)
       if layer in blacklist:

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1337,6 +1337,7 @@ class TFNetwork(object):
 
     def _make_layer(layer_cls, layer_dict, map_opts=True):
       """
+      Creates the flattened layer
       :param type[LayerBase]|LayerBase layer_cls:
       :param dict[str] layer_dict:
       :param bool map_opts:
@@ -1366,6 +1367,7 @@ class TFNetwork(object):
 
     def _should_flatten_layer_output(layer_):
       """
+      Decides whether layer output has right properties for flattening
       :param LayerBase layer_:
       :rtype: bool
       """
@@ -1382,6 +1384,7 @@ class TFNetwork(object):
 
     def _check_push_flattening_to_inputs_for_layer_simple(layer_):
       """
+      Checks preconditions for input flattening
       :param LayerBase layer_:
       :rtype: bool
       """
@@ -1399,6 +1402,7 @@ class TFNetwork(object):
 
     def _check_push_flattening_to_inputs_for_layer(layer_):
       """
+      Checks whether the inputs to the layer should be flattened aswell
       :param LayerBase layer_:
       :rtype: bool
       """
@@ -1431,7 +1435,9 @@ class TFNetwork(object):
 
     def _resolve_layer(layer_):
       """
+      Flattens the layer structure, removes irrelevant layers and returns next successor layer
       :param LayerBase layer_:
+      :return Next layer in succession
       :rtype: LayerBase
       """
       while True:

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1304,7 +1304,7 @@ class TFNetwork(object):
     # We are very restrictive here to not break anything in case of unrelated bugs of other layers.
 
     from .util.data import BatchInfo
-    from .layers.basic import SourceLayer, InternalLayer, SubnetworkLayer, CopyLayer, FlattenBatchLayer
+    from .layers.basic import SourceLayer, InternalLayer, SubnetworkLayer, CopyLayer, CastLayer, FlattenBatchLayer
     from tensorflow.python.util import nest
 
     def _relevant_dims_for_layer(layer_):
@@ -1438,7 +1438,7 @@ class TFNetwork(object):
         if isinstance(layer_, SubnetworkLayer):
           layer_ = layer_.subnetwork.layers["output"]
           continue
-        if isinstance(layer_, CopyLayer) and len(layer_.sources) == 1:
+        if isinstance(layer_, CopyLayer) and len(layer_.sources) == 1 and not isinstance(layer_, CastLayer):
           layer_ = layer_.sources[0]
           continue
         return layer_
@@ -1480,7 +1480,6 @@ class TFNetwork(object):
         continue
       blacklist.add(layer)
       layer_queue.extend(_layer_deps(layer))
-
     # Collect back refs, starting from end points.
     deps_used_by_end_points = {layer: {layer} for layer in end_points}  # dep -> set(end points), direct and indirect
     deps_used_by = {layer: set() for layer in end_points}  # dep -> set(used by), direct dependencies only


### PR DESCRIPTION
Since `CastLayer` is of instance `CopyLayer` it will be "skipped" during flattening which potentially causes dtype issues. This should fix the check, maybe its worth looking into the other subinstances of `CopyLayer` for other cases. 
From what I found these are: 
`DropoutLayer`, `ScaledGradientLayer`, `BatchNormLayer` and `TikhonovRegularizationLayer`. If you think only skipping `CopyLayer` would make sense I would change the whole check to:
`type(layer_) is CopyLayer`

Additionally I added some comments for some of the private functions of the flatten logic to make them more understandable, especially when seeing them first. 
Feel free to comment on them and make suggestions how to improve them, these are for now how I understood them and by far not perfect I think.
Also if you have a good suggestion for other functions in there we can add them too.