### PR TITLE
Check for tag.batch when creating size placeholder

### DIFF
--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5615,7 +5615,8 @@ def _create_size_placeholder(name, axis_wo_b, tag, batch_dim):
       batch = None
     dyn_size_ext = Data(
       "%s_dim%i_size" % (name, axis_wo_b), dtype=Data.size_dtype,
-      dim_tags=[batch_dim] if batch_dim else [], batch=batch)
+      dim_tags=[batch_dim] if batch_dim else [],
+      batch=batch if batch_dim else None)
     dyn_size = tf_compat.v1.placeholder(
       name=dyn_size_ext.name, dtype=dyn_size_ext.dtype, shape=dyn_size_ext.batch_shape)
     dyn_size_ext.placeholder = dyn_size

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5607,9 +5607,15 @@ def _create_size_placeholder(name, axis_wo_b, tag, batch_dim):
   """
   from .basic import reuse_name_scope
   with reuse_name_scope("extern_data/placeholders/%s" % name, absolute=True):
+    if batch_dim is not None and batch_dim.batch is not None:
+      batch = batch_dim.batch
+    elif tag.batch is not None:
+      batch = tag.batch
+    else:
+      batch = None
     dyn_size_ext = Data(
       "%s_dim%i_size" % (name, axis_wo_b), dtype=Data.size_dtype,
-      dim_tags=[batch_dim] if batch_dim else [], batch=batch_dim.batch if batch_dim else None)
+      dim_tags=[batch_dim] if batch_dim else [], batch=batch)
     dyn_size = tf_compat.v1.placeholder(
       name=dyn_size_ext.name, dtype=dyn_size_ext.dtype, shape=dyn_size_ext.batch_shape)
     dyn_size_ext.placeholder = dyn_size

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5625,8 +5625,8 @@ def _create_size_placeholder(name, axis_wo_b, tag, batch_dim):
         batch=dyn_size_ext.batch, ctx=dyn_size_ext.control_flow_ctx, dyn_size_ext=dyn_size_ext)
     else:
       tag.dyn_size_ext = dyn_size_ext
-    if batch_dim and batch_dim.batch:
-      tag.batch = batch_dim.batch
+    if batch_dim:
+      tag.batch = batch
     tag.set_tag_on_size_tensor(dyn_size)
 
 


### PR DESCRIPTION
Fix for https://github.com/rwth-i6/i6_experiments/issues/73

The check was only for batch info of the batch dim tag, but in cases where the tag has the info instead this was not working. 

I am not sure whether to actually prefer the tag batch info over the batch_dim info, but wanted to not change potential old behavior, thats why the check is for batch_dim first. 