### PR TITLE
sprint.cache, more clear code

### DIFF
--- a/returnn/sprint/cache.py
+++ b/returnn/sprint/cache.py
@@ -299,9 +299,9 @@ class FileArchive:
 
     elif typ == "feat":
       type_len = self.read_U32()
-      typ = self.read_str(type_len)
+      type_ = self.read_str(type_len)
       # print(typ)
-      assert typ == "vector-f32"
+      assert type_ == "vector-f32"
       count = self.read_U32()
       data = [None] * count  # type: typing.List[typing.Optional[numpy.ndarray]]
       time_ = [None] * count  # type: typing.List[typing.Optional[numpy.ndarray]]
@@ -313,7 +313,8 @@ class FileArchive:
 
     elif typ in ["align", "align_raw"]:
       type_len = self.read_U32()
-      assert self.read_str(type_len) == "flow-alignment"
+      type_ = self.read_str(type_len)
+      assert type_ == "flow-alignment"
       self.read_u32()  # flag ?
       alignment_header = self.read_str(8)
       if alignment_header in ["ALIGNRLE", "AALPHRLE"]:

--- a/returnn/sprint/cache.py
+++ b/returnn/sprint/cache.py
@@ -313,11 +313,10 @@ class FileArchive:
 
     elif typ in ["align", "align_raw"]:
       type_len = self.read_U32()
-      typ = self.read_str(type_len)
-      assert typ == "flow-alignment"
+      assert self.read_str(type_len) == "flow-alignment"
       self.read_u32()  # flag ?
-      typ = self.read_str(8)
-      if typ in ["ALIGNRLE", "AALPHRLE"]:
+      alignment_header = self.read_str(8)
+      if alignment_header in ["ALIGNRLE", "AALPHRLE"]:
         # In case of AALPHRLE, after the alignment, we include the alphabet of the used labels.
         # We ignore this at the moment.
         size = self.read_U32()
@@ -356,7 +355,7 @@ class FileArchive:
           raise NotImplementedError("No support for weighted "
                                     "alignments yet.")
       else:
-        raise Exception("No valid alignment header found (found: %r). Wrong cache?" % typ)
+        raise Exception("No valid alignment header found (found: %r). Wrong cache?" % alignment_header)
 
   def has_entry(self, filename):
     """


### PR DESCRIPTION
This is a straight-forward fix for the ambiguous use of the variable "typ". It is overwritten multiple times and did not retain the desired information about the alignment type. This caused undesired behavior of the SprintCacheDataset which disregarded the substate.