### PR TITLE
extend check for ndarray in CachedDataset

### DIFF
--- a/returnn/datasets/cached.py
+++ b/returnn/datasets/cached.py
@@ -86,7 +86,7 @@ class CachedDataset(Dataset):
     old_index_map = self._index_map[:]
     self._index_map = range(len(seq_index))  # sorted seq idx -> seq_index idx
 
-    if isinstance(seq_index, numpy.ndarray):
+    if isinstance(seq_index, numpy.ndarray) or isinstance(self._seq_index, numpy.ndarray):
       seq_index_unchanged = numpy.array_equal(self._seq_index, seq_index)
     else:
       seq_index_unchanged = (self._seq_index == seq_index)


### PR DESCRIPTION
I have a MetaDataset which combines multiple HDFDatasets. During construction, the case occurred that `self._seq_index` was a `numpy.ndarray` but `seq_index` was of type `list`.