### PR TITLE
`chunking` can be a custom function

### DIFF
--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -96,7 +96,7 @@ class Dataset(object):
     :param int window: features will be of dimension window * feature_dim, as we add a context-window around.
       not all datasets support this option.
     :param None|int|dict|NumbersDict|(dict,dict) context_window: will add this context for each chunk
-    :param None|str|int|(int,int)|dict|(dict,dict) chunking: "chunk_size:chunk_step"
+    :param None|str|int|(int,int)|dict|(dict,dict)|function chunking: "chunk_size:chunk_step"
     :param str seq_ordering: "batching"-option in config. e.g. "default", "sorted" or "random".
       See self.get_seq_order_for_epoch() for more details.
     :param int|None random_seed_offset:
@@ -136,7 +136,7 @@ class Dataset(object):
     self._estimated_num_seqs = estimated_num_seqs
     self.min_chunk_size = min_chunk_size
     self.chunking_variance = chunking_variance
-    self.chunk_size, self.chunk_step = self._parse_chunking(chunking)
+    self.chunk_size, self.chunk_step, self.custom_chunking_func = self._parse_chunking(chunking)
     if isinstance(context_window, (tuple, list)):
       assert len(context_window) == 2
       for elem in context_window:
@@ -190,11 +190,13 @@ class Dataset(object):
   @staticmethod
   def _parse_chunking(chunking):
     """
-    :param None|str|int|(int,int)|dict|(dict,dict)|(NumbersDict,NumbersDict) chunking:
+    :param None|str|int|(int,int)|dict|(dict,dict)|(NumbersDict,NumbersDict)|function chunking:
       as it comes from the config / from the user
-    :return: chunk_size, chunk_step
-    :rtype: (NumbersDict,NumbersDict)
+    :return: chunk_size, chunk_step, custom_chunking_func
+    :rtype: (NumbersDict|None,NumbersDict|None,function|None)
     """
+    if callable(chunking):
+      return None, None, chunking
     if isinstance(chunking, str):
       if ":" in chunking:
         chunking = tuple(map(int, chunking.split(":")))
@@ -215,7 +217,7 @@ class Dataset(object):
     if chunk_size != 0:
       assert sorted(chunk_step.keys()) == sorted(chunk_size.keys())
       assert chunk_step.max_value() > 0, "chunking step must be positive (for some key)"
-    return chunk_size, chunk_step
+    return chunk_size, chunk_step, None
 
   @staticmethod
   def _load_seq_list_file(filename, use_cache_manager=False, expect_list=True):
@@ -914,10 +916,17 @@ class Dataset(object):
     :return: generator which yields tuples (seq index, seq start, seq end)
     :rtype: list[(int,NumbersDict,NumbersDict)]
     """
+    if self.custom_chunking_func:
+      sentinel_kw = {"__fwd_compatible_random_arg_%i" % int(random() * 100): None}
+      for seq_idx, t_start, t_end in self.custom_chunking_func(
+            dataset=self, seq_idx_start=0, recurrent_net=recurrent_net, used_data_keys=used_data_keys, **sentinel_kw):
+        yield seq_idx, t_start, t_end
+      return
+
     chunk_size = self.chunk_size
     chunk_step = self.chunk_step
     if not recurrent_net:
-      if chunk_size != 0:
+      if chunk_size:
         print("Non-recurrent network, chunk size %s:%s ignored" % (chunk_size, chunk_step), file=log.v4)
         chunk_size = 0
     chunk_size = NumbersDict(chunk_size)

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -603,13 +603,10 @@ class ClusteringDataset(CachedDataset2):
       max_seqs = float('inf')
     assert max_seqs > 0
     assert seq_drop <= 1.0
-    chunk_size = self.chunk_size
-    chunk_step = self.chunk_step
     from returnn.engine.batch import Batch
     batch = Batch()
     last_seq_idx = None
-    for seq_idx, t_start, t_end in self.iterate_seqs(
-          chunk_size=chunk_size, chunk_step=chunk_step, used_data_keys=used_data_keys):
+    for seq_idx, t_start, t_end in self.iterate_seqs(recurrent_net=recurrent_net, used_data_keys=used_data_keys):
       if self.single_cluster:
         if last_seq_idx is not None and last_seq_idx != seq_idx:
           last_seq_name = self.get_tag(last_seq_idx)

--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -1201,7 +1201,9 @@ class Engine(EngineBase):
         # but in that case, the newly initialized dataset
         # would use the right chunking option from the config overwrite.
         # noinspection PyProtectedMember
-        self.train_data.chunk_size, self.train_data.chunk_step = Dataset._parse_chunking(value)
+        (self.train_data.chunk_size,
+         self.train_data.chunk_step,
+         self.train_data.custom_chunking_func) = Dataset._parse_chunking(value)
       if key in ["train", "dev", "eval"]:
         # `train` actually gets some special treatment, but unify nevertheless now.
         key, value = "eval_datasets", {key: value}

--- a/tests/test_Dataset.py
+++ b/tests/test_Dataset.py
@@ -36,8 +36,10 @@ def test_generate_batches_recurrent():
 
 def test_iterate_seqs_no_chunking_1():
   dataset = DummyDataset(input_dim=2, output_dim=3, num_seqs=2, seq_len=11)
+  dataset.chunk_step = 0
+  dataset.chunk_size = 0
   dataset.init_seq_order(1)
-  seqs = list(dataset.iterate_seqs(chunk_size=0, chunk_step=0, used_data_keys=None))
+  seqs = list(dataset.iterate_seqs())
   assert_equal(len(seqs), 2)
   assert_equal(seqs[0], (0, 0, 11))  # seq-idx, start-frame, end-frame
   assert_equal(seqs[1], (1, 0, 11))
@@ -45,8 +47,10 @@ def test_iterate_seqs_no_chunking_1():
 
 def test_iterate_seqs_chunking_1():
   dataset = DummyDataset(input_dim=2, output_dim=3, num_seqs=2, seq_len=11)
+  dataset.chunk_step = 5
+  dataset.chunk_size = 10
   dataset.init_seq_order(1)
-  seqs = list(dataset.iterate_seqs(chunk_size=10, chunk_step=5, used_data_keys=None))
+  seqs = list(dataset.iterate_seqs())
   for s in seqs:
     print(s)
   assert_equal(len(seqs), 6)
@@ -60,8 +64,10 @@ def test_iterate_seqs_chunking_1():
 
 def test_iterate_seqs_chunking_varying_sequence_length():
   dataset = DummyDatasetMultipleSequenceLength(input_dim=2, output_dim=3, num_seqs=2, seq_len={'data': 24, 'classes': 12})
+  dataset.chunk_size = {'data': 12, 'classes': 6}
+  dataset.chunk_step = {'data': 6, 'classes': 3}
   dataset.init_seq_order(1)
-  seqs = list(dataset.iterate_seqs(chunk_size={'data': 12, 'classes': 6}, chunk_step={'data': 6, 'classes': 3}, used_data_keys=None))
+  seqs = list(dataset.iterate_seqs())
   for s in seqs:
     print(s)
   assert_equal(len(seqs), 8)


### PR DESCRIPTION
See the `_custom_chunking_func` in the test case as an example.

Alternative implementation to PR https://github.com/rwth-i6/returnn/pull/502, PR https://github.com/rwth-i6/returnn/pull/375.

Note that the decoupling as discussed in https://github.com/rwth-i6/returnn/issues/376 is still separate. I think we need further discussion on this, so let's do this in a separate step.

Anyway, we need this functionality here now. (@robin-p-schmitt specifically, for transducer. Not exactly like in #375 or #502 but we want to throw away chunks which just have blank labels.)
