### PR TITLE
ConcatSeqsDataset, option to match alignment

### DIFF
--- a/returnn/datasets/generating.py
+++ b/returnn/datasets/generating.py
@@ -30,7 +30,7 @@ class GeneratingDataset(Dataset):
     :param int|None input_dim:
     :param int|dict[str,int|(int,int)|dict] output_dim: if dict, can specify all data-keys
     :param int|float num_seqs:
-    :param int fixed_random_seed:
+    :param int|None fixed_random_seed:
     """
     super(GeneratingDataset, self).__init__(**kwargs)
     assert self.shuffle_frames_of_nseqs == 0


### PR DESCRIPTION
Example: you have downsampling factor 6, i.e. ceildiv(data_len, 6) == align_len.

Now it could happen that ceildiv(data_len1 + data_len2, 6) < align_len1 + align_len2.

This option would repeat intermediate ending frames such that data_len1 % 6 == 0.

Also part of this PR is some rewrite of `StaticDataset`, somewhat related to https://github.com/rwth-i6/returnn/pull/329.
