### PR TITLE
Option for setting blank index in forced_align Layer

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -9099,11 +9099,12 @@ class ForcedAlignmentLayer(_ConcatInputLayer):
   """
   layer_class = "forced_align"
 
-  def __init__(self, align_target, topology, input_type, **kwargs):
+  def __init__(self, align_target, topology, input_type, blank_index=-1, **kwargs):
     """
     :param LayerBase align_target:
     :param str topology: e.g. "ctc" or "rna" (RNA is CTC without label loop)
     :param str input_type: "log_prob" or "prob"
+    :param int blank_index: vocab index of the blank symbol
     """
     from returnn.tf.native_op import get_ctc_fsa_fast_bw, fast_viterbi
     super(ForcedAlignmentLayer, self).__init__(**kwargs)
@@ -9113,6 +9114,9 @@ class ForcedAlignmentLayer(_ConcatInputLayer):
     logits = logits_data.placeholder
     assert logits.get_shape().ndims == 3 and logits.get_shape().dims[-1].value == logits_data.dim
     assert align_target.output.shape == (None,) and align_target.output.dim == logits_data.dim - 1
+    if blank_index < 0:
+      blank_index += logits_data.dim
+    assert 0 <= blank_index < logits_data.dim
     if input_type == "log_prob":
       pass  # ok
     elif input_type == "prob":
@@ -9123,7 +9127,7 @@ class ForcedAlignmentLayer(_ConcatInputLayer):
     edges, weights, start_end_states = get_ctc_fsa_fast_bw(
       targets=align_target.output.get_placeholder_as_batch_major(),
       seq_lens=align_target.output.get_sequence_lengths(),
-      blank_idx=logits_data.dim - 1,
+      blank_idx=blank_index,
       label_loop=topology == "ctc")
     alignment, scores = fast_viterbi(
       am_scores=logits, am_seq_len=logits_data.get_sequence_lengths(),
@@ -9269,7 +9273,7 @@ class CtcLossLayer(LayerBase):
     """
     :param LayerBase logits: (before softmax). shape [B,T,D]
     :param LayerBase targets: sparse. shape [B,T]
-    :param int blank_index:
+    :param int blank_index: vocab index of the blank symbol
     :param bool max_approx: if True, use max instead of sum over alignments (max approx, Viterbi)
     """
     from returnn.tf.native_op import ctc_loss, ctc_loss_viterbi

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -9099,12 +9099,12 @@ class ForcedAlignmentLayer(_ConcatInputLayer):
   """
   layer_class = "forced_align"
 
-  def __init__(self, align_target, topology, input_type, blank_index=-1, **kwargs):
+  def __init__(self, align_target, topology, input_type, blank_idx=-1, **kwargs):
     """
     :param LayerBase align_target:
     :param str topology: e.g. "ctc" or "rna" (RNA is CTC without label loop)
     :param str input_type: "log_prob" or "prob"
-    :param int blank_index: vocab index of the blank symbol
+    :param int blank_idx: vocab index of the blank symbol
     """
     from returnn.tf.native_op import get_ctc_fsa_fast_bw, fast_viterbi
     super(ForcedAlignmentLayer, self).__init__(**kwargs)
@@ -9114,9 +9114,9 @@ class ForcedAlignmentLayer(_ConcatInputLayer):
     logits = logits_data.placeholder
     assert logits.get_shape().ndims == 3 and logits.get_shape().dims[-1].value == logits_data.dim
     assert align_target.output.shape == (None,) and align_target.output.dim == logits_data.dim - 1
-    if blank_index < 0:
-      blank_index += logits_data.dim
-    assert 0 <= blank_index < logits_data.dim
+    if blank_idx < 0:
+      blank_idx += logits_data.dim
+    assert 0 <= blank_idx < logits_data.dim
     if input_type == "log_prob":
       pass  # ok
     elif input_type == "prob":
@@ -9127,7 +9127,7 @@ class ForcedAlignmentLayer(_ConcatInputLayer):
     edges, weights, start_end_states = get_ctc_fsa_fast_bw(
       targets=align_target.output.get_placeholder_as_batch_major(),
       seq_lens=align_target.output.get_sequence_lengths(),
-      blank_idx=blank_index,
+      blank_idx=blank_idx,
       label_loop=topology == "ctc")
     alignment, scores = fast_viterbi(
       am_scores=logits, am_seq_len=logits_data.get_sequence_lengths(),

--- a/returnn/tf/native_op.py
+++ b/returnn/tf/native_op.py
@@ -1323,7 +1323,7 @@ def get_ctc_fsa_fast_bw(targets, seq_lens, blank_idx, label_loop=True):
 
   :param tf.Tensor targets: shape (batch,time), int32
   :param tf.Tensor seq_lens: shape (batch), int32
-  :param int blank_idx:
+  :param int blank_idx: vocab index of the blank symbol
   :param bool label_loop: True -> normal CTC; False -> RNA-like
   :return: edges, weights, start_end_states;
     edges is (4,num_edges), int32, edges of the graph (from,to,emission_idx,sequence_idx).
@@ -1387,7 +1387,7 @@ def ctc_loss(logits, logits_seq_lens, logits_time_major, targets, targets_seq_le
     This is ``p(s|x) - bw``, where ``bw`` is the Baum-Welch soft alignment.
     If logits are already normalized (e.g. we just use ``log p(s|x) = logits``),
     the error signal to logits should be ``-bw``.
-  :param int blank_index:
+  :param int blank_index: vocab index of the blank symbol
   :return: loss, shape (batch,)
   :rtype: tf.Tensor
   """
@@ -1454,7 +1454,7 @@ def ctc_loss_viterbi(logits, logits_seq_lens, logits_time_major, targets, target
   :param bool logits_time_major:
   :param tf.Tensor targets: batch-major, [batch,time]
   :param tf.Tensor targets_seq_lens: (batch,)
-  :param int blank_index:
+  :param int blank_index: vocab index of the blank symbol
   :return: loss, shape (batch,)
   :rtype: tf.Tensor
   """


### PR DESCRIPTION
Similar to e.g. `ctc_loss`  in `native_op.py` this adds the option to set the blank_index for the forced_align layer. Default is still the same as before (last index in the vocab). 
Also adds documentation for the parameter to a few other functions which have the same parameter.