### PR TITLE
Option to have blank in vocab

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -9105,7 +9105,7 @@ class ForcedAlignmentLayer(_ConcatInputLayer):
     :param str topology: e.g. "ctc" or "rna" (RNA is CTC without label loop)
     :param str input_type: "log_prob" or "prob"
     :param int blank_idx: vocab index of the blank symbol
-    :param bool blank_included: whether blank token is included in the vocabulary
+    :param bool blank_included: whether blank token of the align target is included in the vocabulary
     """
     from returnn.tf.native_op import get_ctc_fsa_fast_bw, fast_viterbi
     super(ForcedAlignmentLayer, self).__init__(**kwargs)

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -9099,7 +9099,7 @@ class ForcedAlignmentLayer(_ConcatInputLayer):
   """
   layer_class = "forced_align"
 
-  def __init__(self, align_target, topology, input_type, blank_idx=-1, blank_included=True, **kwargs):
+  def __init__(self, align_target, topology, input_type, blank_idx=-1, blank_included=False, **kwargs):
     """
     :param LayerBase align_target:
     :param str topology: e.g. "ctc" or "rna" (RNA is CTC without label loop)


### PR DESCRIPTION
This is a fix for #1086 
Since this behavior (even though its really implicit) is most likely far used the only option I saw to fix this is to add a flag. 