### PR TITLE
init_seq_order: consistently treat empty seq_list/seq_order to mean 0 sequences

### DIFF
--- a/returnn/datasets/cached.py
+++ b/returnn/datasets/cached.py
@@ -444,9 +444,7 @@ class CachedDataset(Dataset):
 
   @property
   def num_seqs(self):
-    if self._index_map:
-      return len(self._index_map)
-    return self._num_seqs
+    return len(self._index_map)
 
   def is_cached(self, start, end, blocking = False):
     """

--- a/returnn/datasets/generating.py
+++ b/returnn/datasets/generating.py
@@ -55,7 +55,8 @@ class GeneratingDataset(Dataset):
     This is called when we start a new epoch, or at initialization.
     """
     super(GeneratingDataset, self).init_seq_order(epoch=epoch)
-    assert not seq_list and not seq_order, "predefined order doesn't make sense for %s" % self.__class__.__name__
+    assert seq_list is None and seq_order is None, (
+      "predefined order doesn't make sense for %s" % self.__class__.__name__)
     self.random.seed(self.fixed_random_seed or self._get_random_seed_for_epoch(epoch=epoch))
     self._num_timesteps = 0
     self.reached_final_seq = False

--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -1390,7 +1390,7 @@ class TranslationDataset(CachedDataset2):
 
     if seq_list is None and self.seq_list:
       seq_list = self.seq_list
-    if seq_order:
+    if seq_order is not None:
       self._seq_order = seq_order
     elif seq_list is not None:
       self._seq_order = [int(s[len(self._tag_prefix):]) for s in seq_list]

--- a/returnn/datasets/map.py
+++ b/returnn/datasets/map.py
@@ -106,7 +106,7 @@ class MapDatasetWrapper(CachedDataset2):
     """
     super(MapDatasetWrapper, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
 
-    if seq_list or seq_order:
+    if seq_list is not None or seq_order is not None:
       raise NotImplementedError
 
     try:

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -342,9 +342,9 @@ class MetaDataset(CachedDataset2):
       return False
 
     seq_order_dataset = None
-    if seq_order:
+    if seq_order is not None:
       seq_index = seq_order
-    elif seq_list:
+    elif seq_list is not None:
       seq_index = [self.tag_idx[tag] for tag in seq_list]
     elif self.seq_order_control_dataset:
       seq_order_dataset = self.datasets[self.seq_order_control_dataset]
@@ -669,9 +669,9 @@ class ConcatDataset(CachedDataset2):
     if not need_reinit:
       return False
 
-    if seq_order:
+    if seq_order is not None:
       raise NotImplementedError("Predefined order via sequence indices for ConcatDataset")
-    if seq_list:  # reference order
+    if seq_list is not None:  # reference order
       seq_lists = []
       for dataset in self.datasets:
         # This depends on the num_seqs of our childs.
@@ -1316,7 +1316,7 @@ class ConcatSeqsDataset(CachedDataset2):
     :rtype: bool
     """
     super(ConcatSeqsDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
-    assert not seq_list and not seq_order  # not implemented
+    assert seq_list is None and seq_order is None  # not implemented
     if not seq_list:
       def get_seq_len(i):
         """
@@ -1485,7 +1485,7 @@ class ChunkShuffleDataset(CachedDataset2):
     if not need_reinit:
       return False
 
-    if seq_list or seq_order:
+    if seq_list is not None or seq_order is not None:
       raise NotImplementedError("predefined order seq_list")
     if self.seq_ordering != "default":
       raise NotImplementedError("seq_ordering %s" % self.seq_ordering)

--- a/returnn/datasets/numpy_dump.py
+++ b/returnn/datasets/numpy_dump.py
@@ -73,7 +73,7 @@ class NumpyDumpDataset(Dataset):
     :rtype: bool
     """
     super(NumpyDumpDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
-    if seq_list or seq_order:
+    if seq_list is not None or seq_order is not None:
       raise NotImplementedError
     if self.seq_ordering == "sorted":  # not supported atm
       self.seq_ordering = "default"

--- a/returnn/datasets/raw_wav.py
+++ b/returnn/datasets/raw_wav.py
@@ -222,7 +222,7 @@ class RawWavDataset(CachedDataset2):
         self._seq_index_list = range(self.num_seqs)
         return True
 
-    if seq_list or seq_order:
+    if seq_list is not None or seq_order is not None:
       raise NotImplementedError('init_seq_order of RawWavDataset does not support a predefined seq_list yet.')
     else:
       seq_index = self.get_seq_order_for_epoch(epoch, self.num_seqs, lambda s: self.get_seq_length(s).get('data', None))

--- a/returnn/datasets/sprint.py
+++ b/returnn/datasets/sprint.py
@@ -184,7 +184,7 @@ class SprintDatasetBase(Dataset):
     """
     Called by RETURNN train thread when we enter a new epoch.
     """
-    if seq_order:
+    if seq_order is not None:
       raise NotImplementedError("Predefined sequence order via indices in SprintDataset.")
     super(SprintDatasetBase, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     if self.orth_vocab:
@@ -974,9 +974,9 @@ class ExternSprintDataset(SprintDatasetBase):
     :param list[int]|None seq_order:
     :rtype: bool
     """
-    if seq_order:
+    if seq_order is not None:
       raise NotImplementedError("Predefined sequence order via indices in ExternSprintDataset.")
-    if seq_list:
+    if seq_list is not None:
       assert self.partition_epoch == 1, "specifying partition_epoch and using seq_list not supported"
     if epoch is None:
       epoch = 1
@@ -1134,7 +1134,7 @@ class SprintCacheDataset(CachedDataset2):
     :param list[int]|None seq_order:
     :rtype: bool
     """
-    assert not seq_list and not seq_order
+    assert seq_list is None and seq_order is None
     need_reinit = self.epoch is None or self.epoch != epoch
     super(SprintCacheDataset, self).init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
     self._num_seqs = len(self.seq_list_ordered)

--- a/returnn/datasets/stereo.py
+++ b/returnn/datasets/stereo.py
@@ -88,7 +88,7 @@ class StereoDataset(CachedDataset2):
     self._current_partition = (epoch - 1) % self._partition_epoch
     partition_size = self._get_partition_size(self._current_partition)
 
-    if seq_list or seq_order:
+    if seq_list is not None or seq_order is not None:
       raise NotImplementedError('init_seq_order of StereoDataset does not support a predefined seq_list yet.')
     else:
       seq_index = self.get_seq_order_for_epoch(epoch, partition_size, lambda s: self.get_seq_length(s).get('data', None))

--- a/tests/test_TFEngine.py
+++ b/tests/test_TFEngine.py
@@ -757,7 +757,7 @@ def test_engine_forward_to_hdf():
 
   assert_equal(ds.num_inputs, n_classes_dim) # forwarded input is network output
   assert_equal(ds.get_num_timesteps(), seq_len*num_seqs)
-  assert_equal(ds.num_seqs, num_seqs)
+  assert_equal(ds.get_total_num_seqs(), num_seqs)
 
   os.remove(output_file)
 


### PR DESCRIPTION
A sampling size of 0 did not work in `CombinedDataset` with `TranslationDataset` as subdatasets because an empty `seq_order` list as parameter of `init_seq_order()` was interpreted as "no sequence order given" in `TranslationDataset`. The dataset then creates a sequence order itself with more sequences which makes the "all_sequences_used" check in `CombinedDataset._expand_dataset_sec_idxs()` fail.

I tried to fix it in all places now. Maybe a bit pedantic, but necessary at least for this special use case.