### PR TITLE
center for energy

### DIFF
--- a/returnn/datasets/util/feature_extraction.py
+++ b/returnn/datasets/util/feature_extraction.py
@@ -335,7 +335,7 @@ def _get_audio_features_mfcc(audio, sample_rate, window_len=0.025, step_len=0.01
     rms_func = librosa.feature.rmse  # noqa
   energy = rms_func(
     y=audio,
-    hop_length=int(step_len * sample_rate), frame_length=int(window_len * sample_rate))
+    hop_length=int(step_len * sample_rate), frame_length=int(window_len * sample_rate), center=center)
   features[0] = energy  # replace first MFCC with energy, per convention
   assert features.shape[0] == num_feature_filters  # (dim, time)
   features = features.transpose().astype("float32")  # (time, dim)


### PR DESCRIPTION
Adds center to mfcc energy function. Tbh. I am not sure how with center=False, for the code before this change, this would work and not crash due to different shapes (librosa default is True, so I think there would be a mismatch)

This option is both in [rsme](http://man.hubwiz.com/docset/LibROSA.docset/Contents/Resources/Documents/generated/librosa.feature.rmse.html) and [rms](https://librosa.org/doc/main/generated/librosa.feature.rms.html) so also the if check should not be a problem.