### PR TITLE
RecLayer, use existing time_dim_tag

### DIFF
--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -2376,8 +2376,11 @@ class _SubnetworkRecCell(object):
         fixed_seq_len = rec_layer.output.size_placeholder[0]
       elif rec_layer.size_target:  # if this is set, always use it
         # noinspection PyProtectedMember
-        fixed_seq_len = rec_layer._get_target_value(
-          target=rec_layer.size_target, mark_data_key_as_used=True).get_sequence_lengths()
+        tag = rec_layer._get_target_value(
+          target=rec_layer.size_target, mark_data_key_as_used=True).get_time_dim_tag()
+        tag = tag.get_for_batch_ctx(batch, rec_layer.output.control_flow_ctx)
+        if tag.dyn_size_ext and tag.dyn_size_ext.placeholder is not None:
+          fixed_seq_len = tag.dyn_size
       elif rec_layer.time_dim_tag:
         tag = rec_layer.time_dim_tag.get_for_batch_ctx(batch, rec_layer.output.control_flow_ctx)
         if tag.dyn_size_ext and tag.dyn_size_ext.placeholder is not None:

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -2378,7 +2378,7 @@ class _SubnetworkRecCell(object):
         # noinspection PyProtectedMember
         fixed_seq_len = rec_layer._get_target_value(
           target=rec_layer.size_target, mark_data_key_as_used=True).get_sequence_lengths()
-      elif rec_layer.time_dim_tag and not output_template_search_choices:
+      elif rec_layer.time_dim_tag:
         batch = rec_layer.get_batch_info()
         tag = rec_layer.time_dim_tag.get_for_batch_ctx(batch, rec_layer.output.control_flow_ctx)
         if tag.dyn_size_ext and tag.dyn_size_ext.placeholder is not None:

--- a/tests/test_TFEngine.py
+++ b/tests/test_TFEngine.py
@@ -2885,6 +2885,18 @@ def test_rec_subnet_eval_init_out_apply0():
   engine.search(cv_data)
 
 
+def test_tf_nn_sparse_softmax_cross_entropy_with_logits_nan():
+  inf = float("inf")
+  logits = [[-inf, -inf, -inf, -0.05736833, -0.05736833, -0.05736833]]
+  targets = [3]
+  with make_scope() as session:
+    ce = tf.nn.sparse_softmax_cross_entropy_with_logits(logits=logits, labels=targets)
+    ce_v, = session.run(ce)
+  # This fails in some strange cases? E.g. on my MacBook M1, TF 2.7.0.
+  # This causes some other tests to fail, e.g. test_search_multi_choice_hdf_dump below.
+  assert numpy.isfinite(ce_v)
+
+
 def test_search_multi_choice_hdf_dump():
   """
   Checking multiple things here:


### PR DESCRIPTION
Before, I got:
```
  File "/Users/az/i6/setups/2022-03-19--sis-i6-exp/ext/returnn/returnn/tf/layers/rec.py", line 2391, in _SubnetworkRecCell.get_output
    line: assert input_seq_len is not None, "length is not defined. provide an 'end' layer"
```
Even though I provided an existing defined `time_dim_tag`.
However, I also had some beam search inside, thus `output_template_search_choices` was set, thus the `time_dim_tag` was not used (for whatever reason). This fixes it.