### PR TITLE
MaskedComputationLayer, fix state

### DIFF
--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -1810,8 +1810,9 @@ class LayerBase(object):
     return {}
 
   @classmethod
-  def get_rec_initial_extra_outputs_shape_invariants(cls, **kwargs):
+  def get_rec_initial_extra_outputs_shape_invariants(cls, rec_layer, **kwargs):
     """
+    :param returnn.tf.layers.rec.RecLayer|LayerBase|None rec_layer: for the scope
     :return: optional shapes for the tensors by get_rec_initial_extra_outputs
     :rtype: dict[str,tf.TensorShape]
     """

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -8767,8 +8767,9 @@ class SubnetworkLayer(LayerBase):
     return extra_outputs
 
   @classmethod
-  def get_rec_initial_extra_outputs_shape_invariants(cls, encapsulate=False, **kwargs):
+  def get_rec_initial_extra_outputs_shape_invariants(cls, rec_layer, encapsulate=False, **kwargs):
     """
+    :param returnn.tf.layers.rec.RecLayer rec_layer:
     :param bool encapsulate:
     :return: optional shapes for the tensors by get_rec_initial_extra_outputs
     :rtype: dict[str,tf.TensorShape]
@@ -8788,7 +8789,7 @@ class SubnetworkLayer(LayerBase):
       layer_desc = sub_layer.kwargs
       assert issubclass(cl, LayerBase)
       with cl.cls_setup_scope(**layer_desc):
-        d = cl.get_rec_initial_extra_outputs_shape_invariants(**layer_desc)
+        d = cl.get_rec_initial_extra_outputs_shape_invariants(rec_layer=rec_layer, **layer_desc)
         for key, value in d.items():
           shape_invariants["%s/%s" % (layer_name, key)] = value
     return shape_invariants

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -8576,8 +8576,8 @@ class SubnetworkLayer(LayerBase):
     """
     Update self.rec_vars_outputs.
     """
-    for layer in self.subnetwork.layers.values():
-      self.rec_vars_outputs.update({"%s/%s" % (layer.name, k): v for (k, v) in layer.rec_vars_outputs.items()})
+    for name, layer in self.subnetwork.layers.items():
+      self.rec_vars_outputs.update({"%s/%s" % (name, k): v for (k, v) in layer.rec_vars_outputs.items()})
 
   def update_load_on_init(self):
     """


### PR DESCRIPTION
The problem arises due to the template construction logic of the RecLayer. (Related: #1129)

The templating is done multiple times, and thus the logic is flawed, to store the `_queried_sub_layers` via `get_sub_layer_out_data_from_opts`, and then later rely on the items in there as the information what sub layers were queried, because the kwargs might have been reset in the meantime.

This is not really so much an argument against the RecLayer construction logic, but it was unreliable in the first place to rely on `_queried_sub_layers` for this, and having this implicit assumption that `get_sub_layer_out_data_from_opts` must have been called before, and the same `kwargs` are used. It's bad to have such implicit assumptions.

Now the only real assumption is that we are inside a `RecLayer`, which is obviously true in this function `get_rec_initial_extra_outputs`.

At the same time, this also simplifies the code.
