### PR TITLE
Engine search, do not fall back to default_target

### DIFF
--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -2313,11 +2313,7 @@ class Engine(EngineBase):
         print("Given output %r has beam %s." % (output_layer, out_beam), file=log.v1)
         output_layer_beam_scores.append(output_layer.get_search_choices().beam_scores)
       out_beam_sizes.append(out_beam.beam_size if out_beam else None)
-      target_key = output_layer.target
-      if output_layer.output.sparse and not target_key:
-        # Use the default target key for sparse outputs
-        target_key = self.network.extern_data.default_target
-      target_keys.append(target_key)
+      target_keys.append(output_layer.target)
 
     out_cache = None
     seq_idx_to_tag = {}


### PR DESCRIPTION
We used `default_target` just for historically reasons here (earlier it was even hardcoded to `"classes"`).

I'm not really sure that anyone really depends on this, as you can just set the `target` on a layer explicitly.

It seems some tests are failing, which depends on this, i.e. they did not have `target` set on the layer (e.g. `decision` layer) and assumed that the `default_target` is set to the right target. There might be setups which have the same assumption, so they would break. I'm not really sure about the solution.

Note that the current behavior, this fallback to `default_target` breaks my search, as I have some output layer which does not correspond to a target. So with this change, it just behaves as I expect, it just does not try to serialize with any vocab.
