### PR TITLE
PyTorch: save/load models

### DIFF
--- a/demos/demo-torch.config
+++ b/demos/demo-torch.config
@@ -39,7 +39,7 @@ class Model(torch.nn.Module):
     def forward(self, x):
         return self.linear_relu_stack(x)
 
-def get_model(*, epoch: int, **_kwargs):
+def get_model(**_kwargs):
     return Model()
 
 def train_step(*, model: Model, data, train_ctx, **_kwargs):

--- a/returnn/engine/base.py
+++ b/returnn/engine/base.py
@@ -56,6 +56,10 @@ class EngineBase(object):
           if os.path.exists(fn + ".index"):
             file_list[epoch] = fn
             break
+        elif util.BackendEngine.is_torch_selected():
+          if os.path.exists(fn + ".pt"):
+            file_list[epoch] = fn
+            break
     return file_list
 
   @classmethod

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -314,6 +314,8 @@ def get_model_filename_postfix():
   if BackendEngine.is_tensorflow_selected():
     # There will be multiple files but a *.meta file will always be present.
     return ".meta"
+  if BackendEngine.is_torch_selected():
+    return ".pt"
   return ""
 
 
@@ -329,6 +331,8 @@ def get_checkpoint_filepattern(filepath):
     return filepath[:-len(".meta")]
   elif filepath.endswith(".index"):
     return filepath[:-len(".index")]
+  elif filepath.endswith(".pt"):
+    return filepath[:-len(".pt")]
   return filepath
 
 


### PR DESCRIPTION
".pt" file extension seems standard.
I think calling `model.load_state_dict()` in each epoch is the right way to do it if we really want `get_model_func` to be specific to the epoch. Although this probably has to be extended if the set of model parameters really changes between epochs.

The demo now carries over the model state between model epochs, saves model files, and can be interrupted and continued.