### PR TITLE
Decoupled constraints better, grad accum and others deterministic

### DIFF
--- a/docs/configuration_reference/behavior_version.rst
+++ b/docs/configuration_reference/behavior_version.rst
@@ -22,6 +22,18 @@ and not listing legacy/deprecated parameters.
 Version History
 ---------------
 
+Behavior version 15 (2022-11-08)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``TFNetwork.global_train_step`` should deterministically
+always return the initial value of the current step.
+Before, it could non-deterministically return the current step or the next step.
+This has an influence on any code which makes use of it.
+The biggest effect is on gradient accumulation
+where the old non-deterministic behavior likely was wrong.
+
+See issue `#1205 <https://github.com/rwth-i6/returnn/issues/1205>`__.
+
 Behavior version 14 (2022-10-19)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -2294,7 +2294,7 @@ class TFNetwork(object):
         continue
       if BehaviorVersion.get() <= 14:
         return net.global_train_step_var
-      with tf_util.reuse_name_scope("", absolute=True), tf.device("/cpu:0"):
+      with tf_util.default_control_flow_ctx(), tf_util.reuse_name_scope("", absolute=True), tf.device("/cpu:0"):
         net._global_train_step = net.global_train_step_var.read_value()
       return net._global_train_step
 

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -2270,7 +2270,7 @@ class TFNetwork(object):
         continue
       # Reuse mostly because some of the test cases currently work that way.
       with tf_util.reuse_name_scope("", absolute=True, reuse=getattr(tf_compat.v1, "AUTO_REUSE", None)):
-        with tf.device("/cpu:0"):
+        with tf_util.default_control_flow_ctx(), tf.device("/cpu:0"):
           net._global_train_step_var = tf_compat.v1.get_variable(
             name="global_step", shape=(), dtype=tf.int64, initializer=tf_compat.v1.zeros_initializer(tf.int64),
             collections=[tf_compat.v1.GraphKeys.GLOBAL_STEP], trainable=False)

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -2269,9 +2269,10 @@ class TFNetwork(object):
         continue
       # Reuse mostly because some of the test cases currently work that way.
       with tf_util.reuse_name_scope("", absolute=True, reuse=getattr(tf_compat.v1, "AUTO_REUSE", None)):
-        net._global_train_step = tf_compat.v1.get_variable(
-          name="global_step", shape=(), dtype=tf.int64, initializer=tf_compat.v1.zeros_initializer(tf.int64),
-          collections=[tf_compat.v1.GraphKeys.GLOBAL_STEP], trainable=False)
+        with tf.device("/cpu:0"):
+          net._global_train_step = tf_compat.v1.get_variable(
+            name="global_step", shape=(), dtype=tf.int64, initializer=tf_compat.v1.zeros_initializer(tf.int64),
+            collections=[tf_compat.v1.GraphKeys.GLOBAL_STEP], trainable=False)
       return net._global_train_step
 
   def set_global_train_step(self, step, session):

--- a/returnn/tf/updater.py
+++ b/returnn/tf/updater.py
@@ -925,7 +925,7 @@ class Updater(object):
                     tf_compat.v1.mod(self.global_train_step, accum_grad_multiple_num_steps),
                     accum_grad_multiple_num_steps - 1),
                   true_fn=_get_apply_constraints_op,
-                  false_fn=lambda: tf.no_op(),
+                  false_fn=tf.no_op,
                   name="apply_decoupled_constraints/accum_grad_multiple_step")
               else:
                 apply_constraint = _get_apply_constraints_op()

--- a/returnn/tf/updater.py
+++ b/returnn/tf/updater.py
@@ -897,7 +897,7 @@ class Updater(object):
       new_grad, apply_grad_opts = self._post_process_grad(grad=grad, var=var, global_info=global_info)
       grads_per_apply_grad_opts.setdefault(make_hashable(apply_grad_opts), []).append((new_grad, var))
 
-    if self.decoupled_constraints is not None:
+    if self.decoupled_constraints is not None and not isinstance(self.decoupled_constraints, (int, float)):
       # Note: We want to perform the decoupled constraint updates after all the gradients (and post processing)
       # is calculated (i.e. forward + backprop used the original variable, not any weight decayed version).
       # We want to perform the decoupled constraint updates before we do the gradient update.

--- a/returnn/tf/updater.py
+++ b/returnn/tf/updater.py
@@ -221,7 +221,7 @@ class Updater(object):
         "please specify **kwargs in dynamic_learning_rate for future compatibility")
       lr = learning_rate_function(
         network=self.network,
-        global_train_step=self.network.global_train_step,
+        global_train_step=self.global_train_step,
         learning_rate=lr)
     elif self.config.typed_dict.get("dynamic_learning_rate"):
       # To implement any kind of cyclic learning rate during the epoch. E.g.: https://arxiv.org/abs/1608.03983
@@ -229,8 +229,8 @@ class Updater(object):
         from returnn.util.basic import CollectionReadCheckCovered
         opts = CollectionReadCheckCovered(self.config.typed_dict["dynamic_learning_rate"])
         # Currently all intervals of same step size.
-        interval_steps = tf.constant(opts["interval"], name="interval", dtype=self.network.global_train_step.dtype)
-        step_in_interval = tf_compat.v1.mod(self.network.global_train_step, interval_steps, name="step_in_interval")
+        interval_steps = tf.constant(opts["interval"], name="interval", dtype=self.global_train_step.dtype)
+        step_in_interval = tf_compat.v1.mod(self.global_train_step, interval_steps, name="step_in_interval")
         factor = tf.pow(
           tf.constant(opts["decay"], name="decay", dtype=tf.float32),
           tf.cast(step_in_interval, dtype=tf.float32, name="step_in_interval_float"), name="factor")

--- a/returnn/tf/updater.py
+++ b/returnn/tf/updater.py
@@ -363,8 +363,8 @@ class Updater(object):
       self.optim_op = tf.group(self.optim_op, add_check_numerics_ops([self.optim_op]))
 
     # Do this at the very end.
-    with tf.control_dependencies([self.optim_op]):
-      incr_step_op = tf_compat.v1.assign_add(self.network.global_train_step, 1, name="global_train_step_increment")
+    with tf.control_dependencies([self.optim_op, self.network.global_train_step]):
+      incr_step_op = tf_compat.v1.assign_add(self.network.global_train_step_var, 1, name="global_train_step_increment")
     self.optim_op = tf.group(self.optim_op, incr_step_op, name="optim_and_step_incr")
 
     if self.config.bool("debug_save_updater_vars", False):

--- a/returnn/tf/updater.py
+++ b/returnn/tf/updater.py
@@ -916,15 +916,15 @@ class Updater(object):
             with tf.control_dependencies([grad]):
               # Don't just add the diff to the var because we want to have it decoupled,
               # which would not be the case with apply_gradients below.
-              def _get_apply_constraints_op(multiplier=1.):
-                return var.assign_sub(var * (l2 * 2. * multiplier), use_locking=self.use_locking, read_value=False)
+              def _get_apply_constraints_op():
+                return var.assign_sub(var * (l2 * 2.), use_locking=self.use_locking, read_value=False)
               accum_grad_multiple_num_steps = apply_grad_opts.get("accum_grad_multiple_num_steps", 0)
               if accum_grad_multiple_num_steps > 1:
                 apply_constraint = tf.cond(
                   tf.equal(
                     tf_compat.v1.mod(self.global_train_step, accum_grad_multiple_num_steps),
                     accum_grad_multiple_num_steps - 1),
-                  true_fn=lambda: _get_apply_constraints_op(multiplier=float(accum_grad_multiple_num_steps)),
+                  true_fn=_get_apply_constraints_op,
                   false_fn=lambda: tf.no_op(),
                   name="apply_decoupled_constraints/accum_grad_multiple_step")
               else:

--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -6480,9 +6480,11 @@ def get_variable_from_tensor(var):
 def add_control_input(op, control_input):
   """
   :param tf.Operation op:
-  :param tf.Operation control_input:
+  :param tf.Operation|tf.Tensor control_input:
   """
   assert isinstance(op, tf.Operation)
+  if isinstance(control_input, tf.Tensor):
+    control_input = control_input.op
   assert isinstance(control_input, tf.Operation)
   if hasattr(op, "_add_control_input"):  # some later TF version
     # noinspection PyProtectedMember

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -215,7 +215,7 @@ class BehaviorVersion:
   The version will be set after the config is defined at __main__.init_config() or Engine.__init__()
   """
 
-  _latest_behavior_version = 14
+  _latest_behavior_version = 15
   _behavior_version = None  # type: typing.Optional[int]
 
   @classmethod

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5047,7 +5047,7 @@ def test_ScatterNdLayer_RangeLayer():
     assert out_layer.output.feature_dim_axis_or_unspecified is NotSpecified and out_layer.output.feature_dim_axis == 2
     assert out_layer.output.time_dim_axis == 1
 
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     info, out = session.run(
       (fetches, out_layer.output.placeholder),
       feed_dict={
@@ -5279,7 +5279,7 @@ def test_ScatterNdLayer_RangeLayer_RangeInAxisLayer():
     assert out_layer.output.feature_dim_axis_or_unspecified is NotSpecified and out_layer.output.feature_dim_axis == 2
     assert out_layer.output.time_dim_axis == 0
 
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     info, out = session.run(
       (fetches, out_layer.output.placeholder),
       feed_dict={
@@ -8595,7 +8595,7 @@ def test_SyntheticGradientLayer():
     n_time = 11
     rnd = numpy.random.RandomState(42)
     with tf_compat.v1.Session() as session:
-      session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+      session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
       for step in range(5):
         info, _ = session.run(
           (fetches, update_op),
@@ -8660,7 +8660,7 @@ def test_TikhonovRegularizationLayer():
     n_time = 11
     rnd = numpy.random.RandomState(42)
     with tf_compat.v1.Session() as session:
-      session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+      session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
       for step in range(5):
         info, _ = session.run(
           (fetches, update_op),
@@ -8789,7 +8789,7 @@ def test_extra1():
     assert len(params) == 2  # W + b
 
     feed_dict = make_feed_dict(network.extern_data)
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     out1 = session.run(network.layers["output1"].output.placeholder, feed_dict=feed_dict)
     out2 = session.run(network.layers["output2"].output.placeholder, feed_dict=feed_dict)
     out3 = session.run(network.layers["output3"].output.placeholder, feed_dict=feed_dict)
@@ -8840,7 +8840,7 @@ def test_extra_subnet():
     assert len(params) == 4
 
     feed_dict = make_feed_dict(network.extern_data)
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     in_ = feed_dict[network.extern_data.data["data"].placeholder]
     sub1_out1 = session.run(network.layers["sub1_output1"].output.placeholder, feed_dict=feed_dict)
     sub1_out2 = session.run(network.layers["sub1_output2"].output.placeholder, feed_dict=feed_dict)
@@ -9034,7 +9034,7 @@ def test_extra_search():
     fetches = network.get_fetches_dict()
     data_input = network.extern_data.data["data"]
 
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     info, out = session.run(
       (fetches, layer_output.output.placeholder),
       feed_dict={

--- a/tests/test_TFNetworkRecLayer.py
+++ b/tests/test_TFNetworkRecLayer.py
@@ -8596,7 +8596,7 @@ def test_extra_scatter_nd_search_train():
     assert isinstance(train3_out_layer_cell, _SubnetworkRecCell)
     assert not train3_out_layer_cell.layers_in_loop, "all should be moved out"
 
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     outputs = [train1_search_out.placeholder, train1_out.placeholder,
                train2_search_out.placeholder, train2_out.placeholder, train3_out.placeholder]
     info, out = session.run(
@@ -8750,7 +8750,7 @@ def test_trafo_search_lm():
     print(input_seqs)
     print("lens:", input_seq_lens)
 
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     fetches = (fetches, output_out.placeholder, output_out.get_sequence_lengths())
     feed_dict = {
       network.extern_data.get_batch_info().dim: len(input_seq_lens),
@@ -8840,7 +8840,7 @@ def test_self_att_rec_state():
     print(input_seqs)
     print("lens:", input_seq_lens)
 
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     fetches = (output_out.placeholder, output_out.get_sequence_lengths())
     feed_dict = {
       network.extern_data.get_batch_info().dim: len(input_seq_lens),
@@ -8921,7 +8921,7 @@ def test_generalized_non_rec_self_attention():
     assert new_dim in net.get_layer("v_").output.dim_tags
     assert set(net.get_layer("energy").output.dim_tags).issuperset({new_dim, time_dim})
     assert time_dim in net.get_layer("att").output.dim_tags
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [net.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [net.global_train_step_var]))
     from test_TFNetworkLayer import make_feed_dict
     feed_dict = make_feed_dict(net.extern_data)
     out_old_data = net.get_layer("att_old").output
@@ -9013,7 +9013,7 @@ def test_cumulated_attention_weights_search():
       print(input_seqs)
       print("lens:", input_seq_lens)
 
-      session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+      session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
       fetches = (fetches, output_out.placeholder, output_out.get_sequence_lengths())
       feed_dict = {
         network.extern_data.get_batch_info().dim: len(input_seq_lens),
@@ -9065,7 +9065,7 @@ def test_PositionalEncodingLayer_offset_no_rec():
     assert data_input.batch_shape == (None, None)
 
     train_out = network.get_layer("output").output
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     rand_data = rnd.randint(0, n_out, size=(n_batch, n_time,), dtype="int32")
     outputs = [train_out.placeholder]
     info, out = session.run(
@@ -9137,7 +9137,7 @@ def test_PositionalEncodingLayer_offset_in_rec():
     assert data_input.batch_shape == (None, None)
 
     train_out = network.get_layer("output").output
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     rand_data = rnd.randint(0, n_out, size=(n_batch, n_time,), dtype="int32")
     outputs = [train_out.placeholder]
     info, out = session.run(
@@ -9186,7 +9186,7 @@ def test_RelativePositionalEncodingLayer():
     data_input = network.extern_data.data["data"]
     assert data_input.batch_shape == (None, None, n_out)
     train_out = network.get_layer("output").output
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     rand_data = rnd.rand(n_batch, n_time, n_out)
     outputs = [train_out.placeholder]
     info, out = session.run(
@@ -9400,7 +9400,7 @@ def test_CumConcatLayer_search():
     print(input_seqs)
     print("lens:", input_seq_lens)
 
-    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step]))
+    session.run(tf_compat.v1.variables_initializer(tf_compat.v1.global_variables() + [network.global_train_step_var]))
     fetches = (fetches, output_out.placeholder, output_out.get_sequence_lengths())
     feed_dict = {
       network.extern_data.get_batch_info().dim: len(input_seq_lens),

--- a/tests/test_TFUpdater.py
+++ b/tests/test_TFUpdater.py
@@ -274,6 +274,43 @@ def test_Updater_decouple_constraints():
     session.run(update_op, feed_dict=feed_dict)
 
 
+def test_Updater_decouple_constraints_simple_graph():
+  with make_scope() as session:
+    from returnn.tf.network import TFNetwork, ExternData
+    from returnn.config import Config
+
+    config = Config({
+      "decouple_constraints": True,
+      "decouple_constraints_factor": 1.,
+    })
+    extern_data = ExternData({"data": dict(shape=(), dtype="float32")})
+    network = TFNetwork(config=config, extern_data=extern_data, train_flag=True)
+    network.construct_from_dict({
+      "var": {"class": "variable", "shape": (), "init": 1., "L2": 0.01},
+      "loss": {
+        "class": "eval", "from": ["data", "var"],
+        "eval": "source(0, auto_convert=False) * source(1, auto_convert=False)",
+        "loss": "as_is"},
+    })
+    network.initialize_params(session=session)
+    var = network.get_layer("var").output.placeholder
+    assert_equal(session.run(var), 1.)
+
+    updater = Updater(config=config, network=network, initial_learning_rate=1.)
+    updater.set_learning_rate(1.0, session=session)
+    updater.set_trainable_vars(network.get_trainable_params())
+    updater.init_optimizer_vars(session=session)
+    update_op = updater.get_optim_op()
+    assert updater.decoupled_constraints is not None
+
+    tf_util.print_graph_output(update_op)
+
+    session.run(
+      update_op, feed_dict={
+        extern_data.data["data"].placeholder: [0.0, 0.0, 0.0], extern_data.get_batch_info().dim: 3})
+    assert_almost_equal(session.run(var), 1. - 2. * 0.01)
+
+
 def test_Updater_multiple_optimizers():
   with make_scope() as session:
     from returnn.tf.network import TFNetwork, ExternData

--- a/tests/test_TFUpdater.py
+++ b/tests/test_TFUpdater.py
@@ -257,7 +257,7 @@ def test_Updater_decouple_constraints():
     updater.set_trainable_vars(network.get_trainable_params())
     updater.init_optimizer_vars(session=session)
     update_op = updater.get_optim_op()
-    assert updater.decoupled_constraints is not None
+    assert updater.decouple_constraints
 
     from returnn.tf.data_pipeline import FeedDictDataProvider
     batches = dataset.generate_batches(
@@ -301,7 +301,7 @@ def test_Updater_decouple_constraints_simple_graph():
     updater.set_trainable_vars(network.get_trainable_params())
     updater.init_optimizer_vars(session=session)
     update_op = updater.get_optim_op()
-    assert updater.decoupled_constraints is not None
+    assert updater.decouple_constraints
 
     tf_util.print_graph_output(update_op)
 
@@ -339,7 +339,7 @@ def test_Updater_decouple_constraints_simple_graph_grad_accum():
     updater.set_trainable_vars(network.get_trainable_params())
     updater.init_optimizer_vars(session=session)
     update_op = updater.get_optim_op()
-    assert updater.decoupled_constraints is not None
+    assert updater.decouple_constraints
 
     session.run(
       update_op, feed_dict={


### PR DESCRIPTION
The decoupled constraints are calculated in a more direct way, not using the SGD optimizer. This should make it (much) more efficient (at compilation time), while being equivalent otherwise. But I actually had memory problems and this solved it.

I also fixed/changed the logic of decoupled constraints when used with gradient accumulation: With gradient accumulation N, the constraints are only applied every Nth step. This is because this is actually equivalent if you would increase the batch size by N instead of using gradient accumulation.

Along the way, I discovered and fixed non-deterministic behavior on global train step incr and read order, which potentially has an effect on gradient accumulation (#1205). Thus it introduces the new behavior version 15 for this. Note that this is necessary for the gradient accumulation logic of the decoupled constraints as well. At least on my computer (MacBook M1), the test `test_Updater_decouple_constraints_simple_graph_grad_accum` does not pass with behavior version 14.
