### PR TITLE
CondLayer, fix support for multiple dyn axes

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -8187,11 +8187,6 @@ class CondLayer(LayerBase):
     """
     out = layer.output
     out_template = self.output.copy_template()
-    assert len(out.size_placeholder) == len(out_template.size_placeholder) <= 1  # not implemented yet...
-    if len(out.size_placeholder) == len(out_template.size_placeholder) == 1:
-      # Make sure that it is the same dynamic size, so that copy_compatible_to accepts it.
-      out_template.size_placeholder[list(out_template.size_placeholder.keys())[0]] = (
-        list(out.size_placeholder.values())[0])
     out = out.copy_compatible_to(out_template)
     return out.placeholder, [out.size_placeholder[i] for i in sorted(out_template.size_placeholder.keys())]
 


### PR DESCRIPTION
Fix #1207.

It's a bit strange. So far I just removed code. The removed code triggered test_CondLayer_mult_dyn_axes to fail, and now it works.

The code anyway was a bit strange.

I wonder where it really was needed?

Maybe we actually don't really support the case when a dim tag is created inside the CondLayer?

If it turns out we need it, we should have a test case for it to make sure we get it right.
