### PR TITLE
ChoiceLayer in loop without dep

### DIFF
--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -5778,10 +5778,12 @@ class ChoiceLayer(BaseChoiceLayer):
     super(ChoiceLayer, cls).transform_config_dict(d, network=network, get_layer=get_layer)
 
     if network.is_inside_rec_layer() and search:
-      # We want to have a dependency on the prev search choices to correctly perform beam-search over it,
-      # even if there would be no other dependency to it otherwise.
-      # https://github.com/rwth-i6/returnn/pull/1213
-      d["rec_previous_layer"] = get_layer("prev:%s" % d["_name"])
+      sources = d["sources"]  # type: typing.List[LayerBase]
+      if all(s.output.beam is None for s in sources):
+        # We want to have a dependency on the prev search choices to correctly perform beam-search over it,
+        # even if there would be no other dependency to it otherwise.
+        # https://github.com/rwth-i6/returnn/pull/1213
+        d["rec_previous_layer"] = get_layer("prev:%s" % d["_name"])
 
   @classmethod
   def _create_search_beam(cls, name, beam_size, sources, network):

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -5777,7 +5777,7 @@ class ChoiceLayer(BaseChoiceLayer):
         d["explicit_search_sources"] = []
     super(ChoiceLayer, cls).transform_config_dict(d, network=network, get_layer=get_layer)
 
-    if network.is_inside_rec_layer():
+    if network.is_inside_rec_layer() and search:
       # We want to have a dependency on the prev search choices to correctly perform beam-search over it,
       # even if there would be no other dependency to it otherwise.
       # https://github.com/rwth-i6/returnn/pull/1213


### PR DESCRIPTION
This is the case for beam search on a CTC model. The choice of a label in one frame is independent from the earlier labels.

Attempt to fix/implement:
```
...
Rec layer 'loop' (search True, train False) sub net:
  Input layers moved out of loop: (#: 2)
    rec_unstack
    log_prob
  Output layers moved out of loop: (#: 1)
    output
  Layers in loop: (#: 1)
    choice
  Unused layers: (#: 0)
    None
layer /loop(rec-subnet-input)/'rec_unstack': [B,T|'time'[B],F|F'enc'(10)] float32
layer /loop(rec-subnet-input)/'log_prob': [B,T|'time'[B],F|F'classes'(3)] float32
layer /loop(rec-subnet)/'log_prob': [B,F|F'classes'(3)] float32
layer /loop(rec-subnet)/'choice': [B&Beam{'loop/choice'}(3)] int32 sparse_dim=Dim{F'classes'(3)}
debug search choices:
  base: <ChoiceLayer loop/'choice' out_type=Data{[B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}, ctx=loop('time'[B])}>
  network:
    layer: <RecStepInfoLayer loop/':i' out_type=Data{[], dtype='int32'}>
    layer: <WrappedInternalLayer loop/'log_prob' out_type=Data{[B,F|F'classes'(3)], ctx=loop('time'[B])}>
    layer: <_TemplateLayer(ChoiceLayer)(:prev:choice) loop/'prev:choice' out_type=Data{[B&Beam{'loop/prev:choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}, ctx=loop('time'[B])} (construction stack None)>
  visit: <ChoiceLayer loop/'choice' out_type=Data{[B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}, ctx=loop('time'[B])}>, search choices <SearchChoices owner='choice' beam_size=3 src_layer=None beam_scores=None>
    sources: 'loop/log_prob' search choices None
  visit: <WrappedInternalLayer loop/'log_prob' out_type=Data{[B,F|F'classes'(3)], ctx=loop('time'[B])}>, search choices None
    sources: 'loop/log_prob' search choices None
  visit: <LinearLayer loop/'log_prob' out_type=Data{[B,T|'time'[B],F|F'classes'(3)]}>, search choices None
    sources: 'loop/rec_unstack' search choices None
  visit: <RecUnstackLayer loop/'rec_unstack' out_type=Data{[B,T|'time'[B],F|F'enc'(10)]}>, search choices None
    sources: 'encoder' search choices None
  visit: <LinearLayer 'encoder' out_type=Data{[B,T|'time'[B],F|F'enc'(10)]}>, search choices None
    sources: 'data' search choices None
  visit: <SourceLayer 'data' out_type=Data{[B,T|'time'[B],F|F'feat'(5)]}>, search choices None
    sources: None
Relevant layers:
[]
Full dependency map:
{'data': [],
 'encoder': [],
 'loop/choice': [],
 'loop/log_prob': [],
 'loop/rec_unstack': []}
-> search choices: None
Exception creating layer /loop(rec-subnet)/'choice' of class ChoiceLayer with opts:
{'_name': 'choice',
 '_network': <TFNetwork '/loop(rec-subnet)' parent_layer=<RecLayer 'loop' out_type=Data{[T|'time'[B&Beam{'loop/choice'}(3)],B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}}> train=False search>,
 'beam_size': 3,
 'input_type': 'log_prob',
 'length_normalization': False,
 'name': 'choice',
 'network': <TFNetwork '/loop(rec-subnet)' parent_layer=<RecLayer 'loop' out_type=Data{[T|'time'[B&Beam{'loop/choice'}(3)],B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}}> train=False search>,
 'out_shape': {Dim{B}, ImplicitSparseDim(Dim{F'classes'(3)})},
 'output': Data{'choice_output', [B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}, ctx=loop('time'[B])},
 'rec_previous_layer': None,
 'search': True,
 'sources': [<WrappedInternalLayer loop/'log_prob' out_type=Data{[B,F|F'classes'(3)], ctx=loop('time'[B])}>],
 'target': None}

ERROR: Got exception during in-loop construction of layer 'choice':
AssertionError: Not implemented yet. In rec-layer, we would always have our prev-frame as one previous search choice. Our deps: [<WrappedInternalLayer loop/'log_prob' out_type=Data{[B,F|F'classes'(3)], ctx=loop('time'[B])}>]

Template network (check out types / shapes):
output: <_TemplateLayer(CopyLayer)(:template:copy) loop/'output' out_type=Data{[B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}, ctx=loop('time'[B])} (construction stack None)>
choice: <_TemplateLayer(ChoiceLayer)(:template:choice) loop/'choice' out_type=Data{[B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}, ctx=loop('time'[B])} (construction stack 'output')>
log_prob: <_TemplateLayer(LinearLayer)(:template:linear) loop/'log_prob' out_type=Data{[B,F|F'classes'(3)], ctx=loop('time'[B])} (construction stack 'choice')>
rec_unstack: <_TemplateLayer(RecUnstackLayer)(:template:rec_unstack) loop/'rec_unstack' out_type=Data{[B,F|F'enc'(10)], ctx=loop('time'[B])} (construction stack 'log_prob')>
...
  File "/Users/az/i6/setups/2022-03-19--sis-i6-exp/ext/returnn/returnn/tf/network.py", line 1188, in TFNetwork._create_layer
    line: layer = layer_class(**layer_desc)
    locals:
      layer = <not found>
      layer_class = <local> <class 'returnn.tf.layers.rec.ChoiceLayer'>
      layer_desc = <local> {'target': None, 'beam_size': 3, 'search': True, 'input_type': 'log_prob', 'length_normalization': False, 'out_shape': {Dim{B}, ImplicitSparseDim(Dim{F'classes'(3)})}, '_network': <TFNetwork '/loop(rec-subnet)' parent_layer=<RecLayer 'loop' out_type=Data{[T|'time'[B&Beam{'loop/choice'}(3)],B&Beam..., len = 13
  File "/Users/az/i6/setups/2022-03-19--sis-i6-exp/ext/returnn/returnn/tf/layers/rec.py", line 5318, in ChoiceLayer.__init__
    line: assert self.search_choices.src_layer, self.network.debug_search_choices(base_search_choice=self) or (
            "Not implemented yet. In rec-layer, we would always have our prev-frame as one previous search choice. "
            "Our deps: %r" % self.get_dep_layers())
    locals:
      self = <local> <ChoiceLayer loop/'choice' out_type=Data{[B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}, ctx=loop('time'[B])}>
      self.search_choices = <local> <SearchChoices owner='choice' beam_size=3 src_layer=None beam_scores=None>
      self.search_choices.src_layer = <local> None
      self.network = <local> <TFNetwork '/loop(rec-subnet)' parent_layer=<RecLayer 'loop' out_type=Data{[T|'time'[B&Beam{'loop/choice'}(3)],B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}}> train=False search>
      self.network.debug_search_choices = <local> <bound method TFNetwork.debug_search_choices of <TFNetwork '/loop(rec-subnet)' parent_layer=<RecLayer 'loop' out_type=Data{[T|'time'[B&Beam{'loop/choice'}(3)],B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}}> train=False search>>
      base_search_choice = <not found>
      self.get_dep_layers = <local> <bound method ChoiceLayer.get_dep_layers of <ChoiceLayer loop/'choice' out_type=Data{[B&Beam{'loop/choice'}(3)], dtype='int32', sparse_dim=Dim{F'classes'(3)}, ctx=loop('time'[B])}>>
AssertionError: Not implemented yet. In rec-layer, we would always have our prev-frame as one previous search choice. Our deps: [<WrappedInternalLayer loop/'log_prob' out_type=Data{[B,F|F'classes'(3)], ctx=loop('time'[B])}>]
```
