### PR TITLE
fixes for depthwise 1d conv

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5213,7 +5213,7 @@ class ConvLayer(_ConcatInputLayer):
       if len(filter_size) == 1:
         filters = tf.reshape(filters, [filter_size[0], 1, n_in, n_out // n_in])  # [1,K,n_in,n_out//n_in]
         x = tf.expand_dims(x, axis=-1 if out_batch_feature_major else -2)  # [B,T,1,n_in]
-        strides = strides + [1]
+        strides = strides * 2
         dilation_rate = dilation_rate + [1]
       else:
         filters = tf.reshape(filters, list(filter_size) + [n_in, n_out // n_in])  # K+[n_in,n_out//n_in]
@@ -5221,7 +5221,7 @@ class ConvLayer(_ConcatInputLayer):
         x, data_format="NCHW" if out_batch_feature_major else "NHWC",
         filter=filters,
         padding=padding,
-        strides=([1] + strides + [1]) if out_batch_feature_major else ([1, 1] + strides),
+        strides=([1, 1] + strides) if out_batch_feature_major else ([1] + strides + [1]),
         dilations=dilation_rate)
       if len(filter_size) == 1:
         y = tf.squeeze(y, axis=-1 if out_batch_feature_major else -2)


### PR DESCRIPTION
The `ConvLayer` implements depthwise convolution via `tf.nn.depthwise_conv2d`. This is used in a testcase in https://github.com/rwth-i6/pytorch-to-returnn/pull/128.

There are currently two issues:
1) It seems to me that the strides are confused for `"NCHW"` and `"NHWC"`.
2) When we actually have a 1D case, an additional dim is added and still `tf.nn.depthwise_conv2d` is used. An additional stride of 1 is added for this dim. However, I get
```
InvalidArgumentError: Current implementation only supports equal length strides in the row and column dimensions.
```
in this case. Since the added dim is anyway 1, we can also have the same stride as for the spatial dim which is then supported.