### PR TITLE
CondLayer fix LayerNotFound

### DIFF
--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -927,8 +927,7 @@ class TFNetwork(object):
         # Call via base to make sure any custom getter sees this...
         return base_get_layer(explicit_extra_layer_name)
       if dep_layers_in_extra:
-        return extra_net.construct_layer(
-          net_dict=net_dict, name=src_name, get_layer=get_layer, add_layer=base_add_layer)
+        return base_get_layer(explicit_extra_layer_name)
       return base_get_layer(src_name)
 
     created_layers = []

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1021,7 +1021,8 @@ class TFNetwork(object):
       if explicit_extra_layer_name in net_dict:
         layer_desc = net_dict[explicit_extra_layer_name]
       else:
-        raise Exception("XXX do we really want this????")
+        return self.extra_parent_net.construct_layer(
+          net_dict, name=name, get_layer=get_layer, add_layer=add_layer, check_existing=check_existing)
       # Pass on here to construct the layer here in this extra net, as this was explicitly called.
     if not layer_desc:
       if name not in net_dict:

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1022,7 +1022,8 @@ class TFNetwork(object):
         layer_desc = net_dict[explicit_extra_layer_name]
       else:
         return self.extra_parent_net.construct_layer(
-          net_dict, name=name, get_layer=get_layer, add_layer=add_layer, check_existing=check_existing)
+          self.extra_parent_net.layers_desc, name=full_name,
+          get_layer=get_layer, add_layer=add_layer, check_existing=check_existing)
       # Pass on here to construct the layer here in this extra net, as this was explicitly called.
     if not layer_desc:
       if name not in net_dict:

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1021,6 +1021,8 @@ class TFNetwork(object):
       explicit_extra_layer_name = "%s:%s" % (self.extra_name_prefix, name)
       if explicit_extra_layer_name in net_dict:
         layer_desc = net_dict[explicit_extra_layer_name]
+      else:
+        raise Exception("XXX do we really want this????")
       # Pass on here to construct the layer here in this extra net, as this was explicitly called.
     if not layer_desc:
       if name not in net_dict:

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5395,14 +5395,12 @@ def test_CondLayer_outside_layer_access():
             'output': {
               'class': 'copy',
               'from': 'qkv',
-              'out_shape': {}
             }
           }
         },
         'output': {
           'class': 'copy',
           'from': 'self_att',
-          'out_shape': {}
         }
       }
     },
@@ -5412,17 +5410,12 @@ def test_CondLayer_outside_layer_access():
       'subnetwork': {
         'weight': {
           'class': 'variable',
-          'shape': [
-            input_dim,
-            labels_1_dim
-          ],
+          'shape': [input_dim, labels_1_dim],
           'param_name': 'param',
         },
         'bias': {
           'class': 'variable',
-          'shape': [
-            labels_1_dim
-          ],
+          'shape': [labels_1_dim],
           'param_name': 'param',
           'init': 0.0
         },

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5351,13 +5351,9 @@ def test_CondLayer_outside_layer_access():
   qkv_dim_ = (2 * keys_dim) + input_dim
   num_heads_dim = SpatialDim('num_heads', 1)
   keys_h_dim = keys_dim.div_left(num_heads_dim)
-  time__1_dim = time_dim + (-1)
-  time__1_time_dim = time_dim + (-1) + time_dim
-  input_dim_ = input_dim.div_left(2)
   value_h_dim = input_dim.div_left(num_heads_dim)
   qkv_dim = 2 * keys_h_dim + value_h_dim
   time_kv_dim = SpatialDim('time:kv')
-  time_dim_ = 1 + time_dim + (-1) + time_dim
   time_kv_0_dim = SpatialDim('time:kv')
 
   net_dict = {
@@ -5380,17 +5376,12 @@ def test_CondLayer_outside_layer_access():
               'subnetwork': {
                 'weight': {
                   'class': 'variable',
-                  'shape': [
-                    input_dim,
-                    qkv_dim_
-                  ],
+                  'shape': [input_dim, qkv_dim_],
                   'param_name': 'param',
                 },
                 'bias': {
                   'class': 'variable',
-                  'shape': [
-                    qkv_dim_
-                  ],
+                  'shape': [qkv_dim_],
                   'param_name': 'param',
                   'init': 0.0
                 },
@@ -5401,191 +5392,9 @@ def test_CondLayer_outside_layer_access():
                 }
               }
             },
-            'linear_pos': {
-              'class': 'subnetwork',
-              'from': [],
-              'subnetwork': {
-                'weight': {
-                  'class': 'variable',
-                  'shape': [
-                    input_dim,
-                    keys_dim
-                  ],
-                  'param_name': 'param',
-                },
-                'output': {
-                  'class': 'copy',
-                  'from': 'weight',
-                  'out_shape': {input_dim, keys_dim}
-                }
-              }
-            },
-            'pos_bias_u': {
-              'class': 'variable',
-              'shape': [
-                num_heads_dim,
-                keys_h_dim
-              ],
-              'param_name': 'param',
-            },
-            'pos_bias_v': {
-              'class': 'variable',
-              'shape': [
-                num_heads_dim,
-                keys_h_dim
-              ],
-              'param_name': 'param',
-            },
-            'range_over_dim': {
-              'class': 'range_in_axis',
-              'from': ['base:base:data:data'],
-              'axis': time_dim,
-              'dtype': 'float32',
-              'out_shape': {ImplicitDynSizeDim(batch_dim), time_dim}
-            },
-            'relative_positional_encoding': {
-              'class': 'subnetwork',
-              'from': [],
-              'subnetwork': {
-                'length': {
-                  'class': 'length',
-                  'from': ['base:base:base:data:data'],
-                  'axis': time_dim,
-                  'out_shape': {batch_dim}
-                },
-                'dim_value': {
-                  'class': 'subnetwork',
-                  'from': [],
-                  'subnetwork': {
-                    'reduce': {
-                      'class': 'reduce',
-                      'from': 'base:length',
-                      'mode': 'max',
-                      'axis': (batch_dim,),
-                      'out_shape': {}
-                    },
-                    'reduce_0': {
-                      'class': 'reduce',
-                      'from': 'base:base:base:base:length',
-                      'mode': 'max',
-                      'axis': (batch_dim,),
-                      'out_shape': {}
-                    },
-                    'output': {
-                      'class': 'copy',
-                      'from': 'reduce_0',
-                      'out_shape': {}
-                    }
-                  }
-                },
-                'neg': {
-                  'class': 'activation',
-                  'from': 'dim_value/reduce',
-                  'activation': 'negative',
-                  'out_shape': {}
-                },
-                'range_over_dim': {
-                  'class': 'range_in_axis',
-                  'from': ['base:base:base:data:data'],
-                  'axis': time__1_dim,
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_dim}
-                },
-                'add': {
-                  'class': 'combine',
-                  'from': ['neg', 'range_over_dim'],
-                  'kind': 'add',
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_dim}
-                },
-                'add_0': {
-                  'class': 'eval',
-                  'from': 'add',
-                  'eval': 'source(0) + 1',
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_dim}
-                },
-                'cast': {
-                  'class': 'cast',
-                  'from': 'add_0',
-                  'dtype': 'float32',
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_dim}
-                },
-                'concat': {
-                  'class': 'concat',
-                  'from': (
-                    (
-                      'cast',
-                      time__1_dim
-                    ),
-                    (
-                      'base:range_over_dim',
-                      time_dim
-                    )
-                  ),
-                  'out_dim': time__1_time_dim,
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_time_dim}
-                },
-                'range_over_dim_0': {
-                  'class': 'range_in_axis',
-                  'from': [],
-                  'axis': input_dim_,
-                  'dtype': 'float32',
-                  'out_shape': {input_dim_}
-                },
-                'mul': {
-                  'class': 'eval',
-                  'from': 'range_over_dim_0',
-                  'eval': 'source(0) * -1.8420680743952367',
-                  'out_shape': {input_dim_}
-                },
-                'exp': {
-                  'class': 'activation',
-                  'from': 'mul',
-                  'activation': 'exp',
-                  'out_shape': {input_dim_}
-                },
-                'combine_bc': {
-                  'class': 'combine',
-                  'from': ['concat', 'exp'],
-                  'kind': '*',
-                  'allow_broadcast_all_sources': True,
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_time_dim, input_dim_}
-                },
-                'add_1': {
-                  'class': 'eval',
-                  'from': 'combine_bc',
-                  'eval': 'source(0) + 1.5707963267948966',
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_time_dim, input_dim_}
-                },
-                'concat_0': {
-                  'class': 'concat',
-                  'from': (
-                    (
-                      'combine_bc',
-                      input_dim_
-                    ),
-                    (
-                      'add_1',
-                      input_dim_
-                    )
-                  ),
-                  'out_dim': input_dim,
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), input_dim, time__1_time_dim}
-                },
-                'sin': {
-                  'class': 'activation',
-                  'from': 'concat_0',
-                  'activation': 'sin',
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), input_dim, time__1_time_dim}
-                },
-                'output': {
-                  'class': 'copy',
-                  'from': 'dim_value',
-                  'out_shape': {}
-                }
-              }
-            },
             'output': {
               'class': 'copy',
-              'from': 'relative_positional_encoding',
+              'from': 'qkv',
               'out_shape': {}
             }
           }
@@ -5644,37 +5453,6 @@ def test_CondLayer_outside_layer_access():
                 'class': 'subnetwork',
                 'from': [],
                 'subnetwork': {
-                  'linear_pos': {
-                    'class': 'subnetwork',
-                    'from': [],
-                    'subnetwork': {
-                      'dot': {
-                        'class': 'dot',
-                        'from': [
-                          'base:base:base:base:encoder/self_att/relative_positional_encoding/sin',
-                          'base:base:base:base:encoder/self_att/linear_pos'
-                        ],
-                        'reduce': input_dim,
-                        'out_shape': {ImplicitDynSizeDim(batch_dim), keys_dim, time__1_time_dim}
-                      },
-                      'output': {
-                        'class': 'copy',
-                        'from': 'dot',
-                        'out_shape': {ImplicitDynSizeDim(batch_dim), keys_dim, time__1_time_dim}
-                      }
-                    }
-                  },
-                  'split_dims': {
-                    'class': 'split_dims',
-                    'from': 'linear_pos',
-                    'axis': keys_dim,
-                    'dims': (
-                      num_heads_dim,
-                      keys_h_dim
-                    ),
-                    'out_shape': {ImplicitDynSizeDim(batch_dim), num_heads_dim, keys_h_dim,
-                                  time__1_time_dim}
-                  },
                   'qkv': {
                     'class': 'subnetwork',
                     'from': [],
@@ -5702,52 +5480,35 @@ def test_CondLayer_outside_layer_access():
                     'class': 'split_dims',
                     'from': 'qkv',
                     'axis': qkv_dim_,
-                    'dims': (
-                      num_heads_dim,
-                      qkv_dim
-                    ),
-                    'out_shape': {batch_dim, time_dim, num_heads_dim,
-                                  qkv_dim}
+                    'dims': (num_heads_dim, qkv_dim),
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, qkv_dim}
                   },
                   'split': {
                     'class': 'split',
                     'from': 'qkv_split_dims',
                     'axis': qkv_dim,
-                    'out_dims': (
-                      keys_h_dim,
-                      keys_h_dim,
-                      value_h_dim
-                    ),
-                    'out_shape': {batch_dim, time_dim, num_heads_dim,
-                                  qkv_dim}
+                    'out_dims': (keys_h_dim, keys_h_dim, value_h_dim),
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, qkv_dim}
                   },
                   'reinterpret_new_dim': {
                     'class': 'reinterpret_data',
-                    'set_dim_tags': {
-                      time_dim: time_kv_dim
-                    },
+                    'set_dim_tags': {time_dim: time_kv_dim},
                     'from': 'split/1',
                     'out_shape': {batch_dim, num_heads_dim, keys_h_dim, time_kv_dim}
                   },
                   'reinterpret_new_dim_0': {
                     'class': 'reinterpret_data',
-                    'set_dim_tags': {
-                      time_dim: time_kv_dim
-                    },
+                    'set_dim_tags': {time_dim: time_kv_dim},
                     'from': 'split/2',
                     'out_shape': {batch_dim, num_heads_dim, value_h_dim, time_kv_dim}
                   },
                   'add': {
-                    'class': 'combine',
-                    'from': ['split/0', 'base:base:base:encoder/self_att/pos_bias_u'],
-                    'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, keys_h_dim}
+                    'class': 'copy',
+                    'from': 'split/0',
                   },
                   'add_0': {
-                    'class': 'combine',
-                    'from': ['split/0', 'base:base:base:encoder/self_att/pos_bias_v'],
-                    'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, keys_h_dim}
+                    'class': 'copy',
+                    'from': 'split/0',
                   },
                   'dot': {
                     'class': 'dot',
@@ -5755,80 +5516,9 @@ def test_CondLayer_outside_layer_access():
                     'reduce': keys_h_dim,
                     'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_dim}
                   },
-                  'dot_0': {
-                    'class': 'dot',
-                    'from': ['add_0', 'split_dims'],
-                    'reduce': keys_h_dim,
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
-                  },
-                  'RelPosSelfAttention._rel_shift': {
-                    'class': 'subnetwork',
-                    'from': [],
-                    'subnetwork': {
-                      'pad': {
-                        'class': 'pad',
-                        'from': 'base:dot_0',
-                        'axes': time__1_time_dim,
-                        'padding': (1, 0),
-                        'value': 0.0,
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_dim_}
-                      },
-                      'reshape': {
-                        'class': 'reshape',
-                        'from': 'pad',
-                        'in_dims': (
-                          time_dim,
-                          time_dim_
-                        ),
-                        'out_dims': (
-                          time_dim_,
-                          time_dim
-                        ),
-                        'extra_deps': ['pad', 'base:base:base:base:data:data'],
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_dim_}
-                      },
-                      'slice': {
-                        'class': 'slice',
-                        'from': 'reshape',
-                        'axis': time_dim_,
-                        'slice_start': 1,
-                        'out_dim': time__1_time_dim,
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
-                      },
-                      'reshape_0': {
-                        'class': 'reshape',
-                        'from': 'slice',
-                        'in_dims': (
-                          time__1_time_dim,
-                          time_dim
-                        ),
-                        'out_dims': (
-                          time_dim,
-                          time__1_time_dim
-                        ),
-                        'extra_deps': ['base:base:base:base:data:data'],
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
-                      },
-                      'slice_nd': {
-                        'class': 'slice_nd',
-                        'from': 'reshape_0',
-                        'size': time_kv_dim,
-                        'axis': time__1_time_dim,
-                        'out_spatial_dim': time_kv_dim,
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_dim}
-                      },
-                      'output': {
-                        'class': 'copy',
-                        'from': 'slice_nd',
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_dim}
-                      }
-                    }
-                  },
                   'add_1': {
-                    'class': 'combine',
-                    'from': ['dot', 'RelPosSelfAttention._rel_shift'],
-                    'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_dim}
+                    'class': 'copy',
+                    'from': 'dot',
                   },
                   'mul': {
                     'class': 'eval',
@@ -5858,10 +5548,7 @@ def test_CondLayer_outside_layer_access():
                   'output_0': {
                     'class': 'merge_dims',
                     'from': 'att',
-                    'axes': (
-                      num_heads_dim,
-                      value_h_dim
-                    ),
+                    'axes': (num_heads_dim, value_h_dim),
                     'out_dim': input_dim,
                     'out_shape': {batch_dim, time_dim, input_dim}
                   },
@@ -5898,37 +5585,6 @@ def test_CondLayer_outside_layer_access():
                 'class': 'subnetwork',
                 'from': [],
                 'subnetwork': {
-                  'linear_pos': {
-                    'class': 'subnetwork',
-                    'from': [],
-                    'subnetwork': {
-                      'dot': {
-                        'class': 'dot',
-                        'from': [
-                          'base:base:base:base:encoder/self_att/relative_positional_encoding/sin',
-                          'base:base:base:base:encoder/self_att/linear_pos'
-                        ],
-                        'reduce': input_dim,
-                        'out_shape': {ImplicitDynSizeDim(batch_dim), keys_dim, time__1_time_dim}
-                      },
-                      'output': {
-                        'class': 'copy',
-                        'from': 'dot',
-                        'out_shape': {ImplicitDynSizeDim(batch_dim), keys_dim, time__1_time_dim}
-                      }
-                    }
-                  },
-                  'split_dims': {
-                    'class': 'split_dims',
-                    'from': 'linear_pos',
-                    'axis': keys_dim,
-                    'dims': (
-                      num_heads_dim,
-                      keys_h_dim
-                    ),
-                    'out_shape': {ImplicitDynSizeDim(batch_dim), num_heads_dim, keys_h_dim,
-                                  time__1_time_dim}
-                  },
                   'qkv': {
                     'class': 'subnetwork',
                     'from': [],
@@ -5956,52 +5612,35 @@ def test_CondLayer_outside_layer_access():
                     'class': 'split_dims',
                     'from': 'qkv',
                     'axis': qkv_dim_,
-                    'dims': (
-                      num_heads_dim,
-                      qkv_dim
-                    ),
-                    'out_shape': {batch_dim, time_dim, num_heads_dim,
-                                  qkv_dim}
+                    'dims': (num_heads_dim, qkv_dim),
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, qkv_dim}
                   },
                   'split': {
                     'class': 'split',
                     'from': 'qkv_split_dims',
                     'axis': qkv_dim,
-                    'out_dims': (
-                      keys_h_dim,
-                      keys_h_dim,
-                      value_h_dim
-                    ),
-                    'out_shape': {batch_dim, time_dim, num_heads_dim,
-                                  qkv_dim}
+                    'out_dims': (keys_h_dim, keys_h_dim, value_h_dim),
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, qkv_dim}
                   },
                   'reinterpret_new_dim': {
                     'class': 'reinterpret_data',
-                    'set_dim_tags': {
-                      time_dim: time_kv_0_dim
-                    },
+                    'set_dim_tags': {time_dim: time_kv_0_dim},
                     'from': 'split/1',
                     'out_shape': {batch_dim, num_heads_dim, keys_h_dim, time_kv_0_dim}
                   },
                   'reinterpret_new_dim_0': {
                     'class': 'reinterpret_data',
-                    'set_dim_tags': {
-                      time_dim: time_kv_0_dim
-                    },
+                    'set_dim_tags': {time_dim: time_kv_0_dim},
                     'from': 'split/2',
                     'out_shape': {batch_dim, num_heads_dim, value_h_dim, time_kv_0_dim}
                   },
                   'add': {
-                    'class': 'combine',
-                    'from': ['split/0', 'base:base:base:encoder/self_att/pos_bias_u'],
-                    'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, keys_h_dim}
+                    'class': 'copy',
+                    'from': 'split/0',
                   },
                   'add_0': {
-                    'class': 'combine',
-                    'from': ['split/0', 'base:base:base:encoder/self_att/pos_bias_v'],
-                    'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, keys_h_dim}
+                    'class': 'copy',
+                    'from': 'split/0',
                   },
                   'dot': {
                     'class': 'dot',
@@ -6009,81 +5648,9 @@ def test_CondLayer_outside_layer_access():
                     'reduce': keys_h_dim,
                     'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_0_dim}
                   },
-                  'dot_0': {
-                    'class': 'dot',
-                    'from': ['add_0', 'split_dims'],
-                    'reduce': keys_h_dim,
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
-                  },
-                  'RelPosSelfAttention._rel_shift': {
-                    'class': 'subnetwork',
-                    'from': [],
-                    'subnetwork': {
-                      'pad': {
-                        'class': 'pad',
-                        'from': 'base:dot_0',
-                        'axes': time__1_time_dim,
-                        'padding': (1, 0),
-                        'value': 0.0,
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_dim_}
-                      },
-                      'reshape': {
-                        'class': 'reshape',
-                        'from': 'pad',
-                        'in_dims': (
-                          time_dim,
-                          time_dim_
-                        ),
-                        'out_dims': (
-                          time_dim_,
-                          time_dim
-                        ),
-                        'extra_deps': ['base:base:base:encoder/self_att/RelPosSelfAttention._rel_shift/pad',
-                                       'base:base:base:base:data:data'],
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_dim_}
-                      },
-                      'slice': {
-                        'class': 'slice',
-                        'from': 'reshape',
-                        'axis': time_dim_,
-                        'slice_start': 1,
-                        'out_dim': time__1_time_dim,
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
-                      },
-                      'reshape_0': {
-                        'class': 'reshape',
-                        'from': 'slice',
-                        'in_dims': (
-                          time__1_time_dim,
-                          time_dim
-                        ),
-                        'out_dims': (
-                          time_dim,
-                          time__1_time_dim
-                        ),
-                        'extra_deps': ['base:base:base:base:data:data'],
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
-                      },
-                      'slice_nd': {
-                        'class': 'slice_nd',
-                        'from': 'reshape_0',
-                        'size': time_kv_0_dim,
-                        'axis': time__1_time_dim,
-                        'out_spatial_dim': time_kv_0_dim,
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_0_dim}
-                      },
-                      'output': {
-                        'class': 'copy',
-                        'from': 'slice_nd',
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_0_dim}
-                      }
-                    }
-                  },
                   'add_1': {
-                    'class': 'combine',
-                    'from': ['dot', 'RelPosSelfAttention._rel_shift'],
-                    'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_0_dim}
+                    'class': 'copy',
+                    'from': 'dot',
                   },
                   'mul': {
                     'class': 'eval',
@@ -6113,10 +5680,7 @@ def test_CondLayer_outside_layer_access():
                   'output_0': {
                     'class': 'merge_dims',
                     'from': 'att',
-                    'axes': (
-                      num_heads_dim,
-                      value_h_dim
-                    ),
+                    'axes': (num_heads_dim, value_h_dim),
                     'out_dim': input_dim,
                     'out_shape': {batch_dim, time_dim, input_dim}
                   },
@@ -6232,9 +5796,7 @@ def test_CondLayer_outside_layer_access():
     'constant': {
       'class': 'constant',
       'value': 5,
-      'shape': [
-        batch_dim
-      ],
+      'shape': [batch_dim],
       'sparse_dim': labels_1_dim,
       'shape_deps': ['data:data']
     }

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -6214,7 +6214,6 @@ def test_CondLayer_outside_layer_access():
         }
       },
       'axis': time_dim,
-      'max_seq_len_via': 'mul',
       'out_shape': {batch_dim, time_dim, ImplicitSparseDim(labels_1_dim)},
       'name_scope': ''
     },

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5348,17 +5348,16 @@ def test_CondLayer_outside_layer_access():
   labels_dim = FeatureDim('labels', 5)
   labels_1_dim = labels_dim + 1
   keys_dim = FeatureDim('keys', 2)
-  _2_keys_input_dim = (2 * keys_dim) + input_dim
+  qkv_dim_ = (2 * keys_dim) + input_dim
   num_heads_dim = SpatialDim('num_heads', 1)
-  truediv_left_keys__num_heads__dim = keys_dim.div_left(num_heads_dim)
+  keys_h_dim = keys_dim.div_left(num_heads_dim)
   time__1_dim = time_dim + (-1)
   time__1_time_dim = time_dim + (-1) + time_dim
-  truediv_left_input__2__dim = input_dim.div_left(2)
-  truediv_left_input__num_heads__dim = input_dim.div_left(num_heads_dim)
-  _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim = (
-    2 * truediv_left_keys__num_heads__dim + truediv_left_input__num_heads__dim)
+  input_dim_ = input_dim.div_left(2)
+  value_h_dim = input_dim.div_left(num_heads_dim)
+  qkv_dim = 2 * keys_h_dim + value_h_dim
   time_kv_dim = SpatialDim('time:kv')
-  _1_time__1_time_dim = 1 + time_dim + (-1) + time_dim
+  time_dim_ = 1 + time_dim + (-1) + time_dim
   time_kv_0_dim = SpatialDim('time:kv')
 
   net_dict = {
@@ -5383,28 +5382,14 @@ def test_CondLayer_outside_layer_access():
                   'class': 'variable',
                   'shape': [
                     input_dim,
-                    _2_keys_input_dim
+                    qkv_dim_
                   ],
                   'param_name': 'param',
-                  'init_by_layer': 'Parameter.initial'
-                },
-                'Parameter.initial': {
-                  'class': 'random',
-                  'shape': (
-                    input_dim,
-                    _2_keys_input_dim
-                  ),
-                  'distribution': 'uniform',
-                  'minval': -0.5,
-                  'maxval': 0.5,
-                  'dtype': 'float32',
-                  'static': True,
-                  'shape_deps': []
                 },
                 'bias': {
                   'class': 'variable',
                   'shape': [
-                    _2_keys_input_dim
+                    qkv_dim_
                   ],
                   'param_name': 'param',
                   'init': 0.0
@@ -5412,7 +5397,7 @@ def test_CondLayer_outside_layer_access():
                 'output': {
                   'class': 'copy',
                   'from': 'bias',
-                  'out_shape': {_2_keys_input_dim}
+                  'out_shape': {qkv_dim_}
                 }
               }
             },
@@ -5427,20 +5412,6 @@ def test_CondLayer_outside_layer_access():
                     keys_dim
                   ],
                   'param_name': 'param',
-                  'init_by_layer': 'Parameter.initial'
-                },
-                'Parameter.initial': {
-                  'class': 'random',
-                  'shape': (
-                    input_dim,
-                    keys_dim
-                  ),
-                  'distribution': 'uniform',
-                  'minval': -0.7071067811865476,
-                  'maxval': 0.7071067811865476,
-                  'dtype': 'float32',
-                  'static': True,
-                  'shape_deps': []
                 },
                 'output': {
                   'class': 'copy',
@@ -5453,45 +5424,17 @@ def test_CondLayer_outside_layer_access():
               'class': 'variable',
               'shape': [
                 num_heads_dim,
-                truediv_left_keys__num_heads__dim
+                keys_h_dim
               ],
               'param_name': 'param',
-              'init_by_layer': 'Parameter.initial'
             },
             'pos_bias_v': {
               'class': 'variable',
               'shape': [
                 num_heads_dim,
-                truediv_left_keys__num_heads__dim
+                keys_h_dim
               ],
               'param_name': 'param',
-              'init_by_layer': 'Parameter.initial_0'
-            },
-            'Parameter.initial': {
-              'class': 'random',
-              'shape': (
-                num_heads_dim,
-                truediv_left_keys__num_heads__dim
-              ),
-              'distribution': 'uniform',
-              'minval': -1.4142135623730951,
-              'maxval': 1.4142135623730951,
-              'dtype': 'float32',
-              'static': True,
-              'shape_deps': []
-            },
-            'Parameter.initial_0': {
-              'class': 'random',
-              'shape': (
-                num_heads_dim,
-                truediv_left_keys__num_heads__dim
-              ),
-              'distribution': 'uniform',
-              'minval': -1.4142135623730951,
-              'maxval': 1.4142135623730951,
-              'dtype': 'float32',
-              'static': True,
-              'shape_deps': []
             },
             'range_over_dim': {
               'class': 'range_in_axis',
@@ -5583,45 +5526,45 @@ def test_CondLayer_outside_layer_access():
                 'range_over_dim_0': {
                   'class': 'range_in_axis',
                   'from': [],
-                  'axis': truediv_left_input__2__dim,
+                  'axis': input_dim_,
                   'dtype': 'float32',
-                  'out_shape': {truediv_left_input__2__dim}
+                  'out_shape': {input_dim_}
                 },
                 'mul': {
                   'class': 'eval',
                   'from': 'range_over_dim_0',
                   'eval': 'source(0) * -1.8420680743952367',
-                  'out_shape': {truediv_left_input__2__dim}
+                  'out_shape': {input_dim_}
                 },
                 'exp': {
                   'class': 'activation',
                   'from': 'mul',
                   'activation': 'exp',
-                  'out_shape': {truediv_left_input__2__dim}
+                  'out_shape': {input_dim_}
                 },
                 'combine_bc': {
                   'class': 'combine',
                   'from': ['concat', 'exp'],
                   'kind': '*',
                   'allow_broadcast_all_sources': True,
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_time_dim, truediv_left_input__2__dim}
+                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_time_dim, input_dim_}
                 },
                 'add_1': {
                   'class': 'eval',
                   'from': 'combine_bc',
                   'eval': 'source(0) + 1.5707963267948966',
-                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_time_dim, truediv_left_input__2__dim}
+                  'out_shape': {ImplicitDynSizeDim(batch_dim), time__1_time_dim, input_dim_}
                 },
                 'concat_0': {
                   'class': 'concat',
                   'from': (
                     (
                       'combine_bc',
-                      truediv_left_input__2__dim
+                      input_dim_
                     ),
                     (
                       'add_1',
-                      truediv_left_input__2__dim
+                      input_dim_
                     )
                   ),
                   'out_dim': input_dim,
@@ -5665,20 +5608,6 @@ def test_CondLayer_outside_layer_access():
             labels_1_dim
           ],
           'param_name': 'param',
-          'init_by_layer': 'Parameter.initial'
-        },
-        'Parameter.initial': {
-          'class': 'random',
-          'shape': (
-            input_dim,
-            labels_1_dim
-          ),
-          'distribution': 'uniform',
-          'minval': -0.6123724356957945,
-          'maxval': 0.6123724356957945,
-          'dtype': 'float32',
-          'static': True,
-          'shape_deps': []
         },
         'bias': {
           'class': 'variable',
@@ -5741,9 +5670,9 @@ def test_CondLayer_outside_layer_access():
                     'axis': keys_dim,
                     'dims': (
                       num_heads_dim,
-                      truediv_left_keys__num_heads__dim
+                      keys_h_dim
                     ),
-                    'out_shape': {ImplicitDynSizeDim(batch_dim), num_heads_dim, truediv_left_keys__num_heads__dim,
+                    'out_shape': {ImplicitDynSizeDim(batch_dim), num_heads_dim, keys_h_dim,
                                   time__1_time_dim}
                   },
                   'qkv': {
@@ -5754,43 +5683,43 @@ def test_CondLayer_outside_layer_access():
                         'class': 'dot',
                         'from': ['base:base:base:base:data:data', 'base:base:base:base:encoder/self_att/qkv/weight'],
                         'reduce': input_dim,
-                        'out_shape': {batch_dim, time_dim, _2_keys_input_dim}
+                        'out_shape': {batch_dim, time_dim, qkv_dim_}
                       },
                       'add': {
                         'class': 'combine',
                         'from': ['dot', 'base:base:base:base:encoder/self_att/qkv'],
                         'kind': 'add',
-                        'out_shape': {batch_dim, time_dim, _2_keys_input_dim}
+                        'out_shape': {batch_dim, time_dim, qkv_dim_}
                       },
                       'output': {
                         'class': 'copy',
                         'from': 'add',
-                        'out_shape': {batch_dim, time_dim, _2_keys_input_dim}
+                        'out_shape': {batch_dim, time_dim, qkv_dim_}
                       }
                     }
                   },
                   'qkv_split_dims': {
                     'class': 'split_dims',
                     'from': 'qkv',
-                    'axis': _2_keys_input_dim,
+                    'axis': qkv_dim_,
                     'dims': (
                       num_heads_dim,
-                      _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim
+                      qkv_dim
                     ),
                     'out_shape': {batch_dim, time_dim, num_heads_dim,
-                                  _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim}
+                                  qkv_dim}
                   },
                   'split': {
                     'class': 'split',
                     'from': 'qkv_split_dims',
-                    'axis': _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim,
+                    'axis': qkv_dim,
                     'out_dims': (
-                      truediv_left_keys__num_heads__dim,
-                      truediv_left_keys__num_heads__dim,
-                      truediv_left_input__num_heads__dim
+                      keys_h_dim,
+                      keys_h_dim,
+                      value_h_dim
                     ),
                     'out_shape': {batch_dim, time_dim, num_heads_dim,
-                                  _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim}
+                                  qkv_dim}
                   },
                   'reinterpret_new_dim': {
                     'class': 'reinterpret_data',
@@ -5798,7 +5727,7 @@ def test_CondLayer_outside_layer_access():
                       time_dim: time_kv_dim
                     },
                     'from': 'split/1',
-                    'out_shape': {batch_dim, num_heads_dim, truediv_left_keys__num_heads__dim, time_kv_dim}
+                    'out_shape': {batch_dim, num_heads_dim, keys_h_dim, time_kv_dim}
                   },
                   'reinterpret_new_dim_0': {
                     'class': 'reinterpret_data',
@@ -5806,30 +5735,30 @@ def test_CondLayer_outside_layer_access():
                       time_dim: time_kv_dim
                     },
                     'from': 'split/2',
-                    'out_shape': {batch_dim, num_heads_dim, truediv_left_input__num_heads__dim, time_kv_dim}
+                    'out_shape': {batch_dim, num_heads_dim, value_h_dim, time_kv_dim}
                   },
                   'add': {
                     'class': 'combine',
                     'from': ['split/0', 'base:base:base:encoder/self_att/pos_bias_u'],
                     'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, truediv_left_keys__num_heads__dim}
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, keys_h_dim}
                   },
                   'add_0': {
                     'class': 'combine',
                     'from': ['split/0', 'base:base:base:encoder/self_att/pos_bias_v'],
                     'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, truediv_left_keys__num_heads__dim}
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, keys_h_dim}
                   },
                   'dot': {
                     'class': 'dot',
                     'from': ['add', 'reinterpret_new_dim'],
-                    'reduce': truediv_left_keys__num_heads__dim,
+                    'reduce': keys_h_dim,
                     'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_dim}
                   },
                   'dot_0': {
                     'class': 'dot',
                     'from': ['add_0', 'split_dims'],
-                    'reduce': truediv_left_keys__num_heads__dim,
+                    'reduce': keys_h_dim,
                     'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
                   },
                   'RelPosSelfAttention._rel_shift': {
@@ -5842,26 +5771,26 @@ def test_CondLayer_outside_layer_access():
                         'axes': time__1_time_dim,
                         'padding': (1, 0),
                         'value': 0.0,
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, _1_time__1_time_dim}
+                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_dim_}
                       },
                       'reshape': {
                         'class': 'reshape',
                         'from': 'pad',
                         'in_dims': (
                           time_dim,
-                          _1_time__1_time_dim
+                          time_dim_
                         ),
                         'out_dims': (
-                          _1_time__1_time_dim,
+                          time_dim_,
                           time_dim
                         ),
                         'extra_deps': ['pad', 'base:base:base:base:data:data'],
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, _1_time__1_time_dim}
+                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_dim_}
                       },
                       'slice': {
                         'class': 'slice',
                         'from': 'reshape',
-                        'axis': _1_time__1_time_dim,
+                        'axis': time_dim_,
                         'slice_start': 1,
                         'out_dim': time__1_time_dim,
                         'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
@@ -5924,14 +5853,14 @@ def test_CondLayer_outside_layer_access():
                     'class': 'dot',
                     'from': ['dropout', 'reinterpret_new_dim_0'],
                     'reduce': time_kv_dim,
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, truediv_left_input__num_heads__dim}
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, value_h_dim}
                   },
                   'output_0': {
                     'class': 'merge_dims',
                     'from': 'att',
                     'axes': (
                       num_heads_dim,
-                      truediv_left_input__num_heads__dim
+                      value_h_dim
                     ),
                     'out_dim': input_dim,
                     'out_shape': {batch_dim, time_dim, input_dim}
@@ -5995,9 +5924,9 @@ def test_CondLayer_outside_layer_access():
                     'axis': keys_dim,
                     'dims': (
                       num_heads_dim,
-                      truediv_left_keys__num_heads__dim
+                      keys_h_dim
                     ),
-                    'out_shape': {ImplicitDynSizeDim(batch_dim), num_heads_dim, truediv_left_keys__num_heads__dim,
+                    'out_shape': {ImplicitDynSizeDim(batch_dim), num_heads_dim, keys_h_dim,
                                   time__1_time_dim}
                   },
                   'qkv': {
@@ -6008,43 +5937,43 @@ def test_CondLayer_outside_layer_access():
                         'class': 'dot',
                         'from': ['base:base:base:base:data:data', 'base:base:base:base:encoder/self_att/qkv/weight'],
                         'reduce': input_dim,
-                        'out_shape': {batch_dim, time_dim, _2_keys_input_dim}
+                        'out_shape': {batch_dim, time_dim, qkv_dim_}
                       },
                       'add': {
                         'class': 'combine',
                         'from': ['dot', 'base:base:base:base:encoder/self_att/qkv'],
                         'kind': 'add',
-                        'out_shape': {batch_dim, time_dim, _2_keys_input_dim}
+                        'out_shape': {batch_dim, time_dim, qkv_dim_}
                       },
                       'output': {
                         'class': 'copy',
                         'from': 'add',
-                        'out_shape': {batch_dim, time_dim, _2_keys_input_dim}
+                        'out_shape': {batch_dim, time_dim, qkv_dim_}
                       }
                     }
                   },
                   'qkv_split_dims': {
                     'class': 'split_dims',
                     'from': 'qkv',
-                    'axis': _2_keys_input_dim,
+                    'axis': qkv_dim_,
                     'dims': (
                       num_heads_dim,
-                      _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim
+                      qkv_dim
                     ),
                     'out_shape': {batch_dim, time_dim, num_heads_dim,
-                                  _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim}
+                                  qkv_dim}
                   },
                   'split': {
                     'class': 'split',
                     'from': 'qkv_split_dims',
-                    'axis': _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim,
+                    'axis': qkv_dim,
                     'out_dims': (
-                      truediv_left_keys__num_heads__dim,
-                      truediv_left_keys__num_heads__dim,
-                      truediv_left_input__num_heads__dim
+                      keys_h_dim,
+                      keys_h_dim,
+                      value_h_dim
                     ),
                     'out_shape': {batch_dim, time_dim, num_heads_dim,
-                                  _2__truediv_left_keys__num_heads_____truediv_left_input__num_heads___dim}
+                                  qkv_dim}
                   },
                   'reinterpret_new_dim': {
                     'class': 'reinterpret_data',
@@ -6052,7 +5981,7 @@ def test_CondLayer_outside_layer_access():
                       time_dim: time_kv_0_dim
                     },
                     'from': 'split/1',
-                    'out_shape': {batch_dim, num_heads_dim, truediv_left_keys__num_heads__dim, time_kv_0_dim}
+                    'out_shape': {batch_dim, num_heads_dim, keys_h_dim, time_kv_0_dim}
                   },
                   'reinterpret_new_dim_0': {
                     'class': 'reinterpret_data',
@@ -6060,30 +5989,30 @@ def test_CondLayer_outside_layer_access():
                       time_dim: time_kv_0_dim
                     },
                     'from': 'split/2',
-                    'out_shape': {batch_dim, num_heads_dim, truediv_left_input__num_heads__dim, time_kv_0_dim}
+                    'out_shape': {batch_dim, num_heads_dim, value_h_dim, time_kv_0_dim}
                   },
                   'add': {
                     'class': 'combine',
                     'from': ['split/0', 'base:base:base:encoder/self_att/pos_bias_u'],
                     'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, truediv_left_keys__num_heads__dim}
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, keys_h_dim}
                   },
                   'add_0': {
                     'class': 'combine',
                     'from': ['split/0', 'base:base:base:encoder/self_att/pos_bias_v'],
                     'kind': 'add',
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, truediv_left_keys__num_heads__dim}
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, keys_h_dim}
                   },
                   'dot': {
                     'class': 'dot',
                     'from': ['add', 'reinterpret_new_dim'],
-                    'reduce': truediv_left_keys__num_heads__dim,
+                    'reduce': keys_h_dim,
                     'out_shape': {batch_dim, time_dim, num_heads_dim, time_kv_0_dim}
                   },
                   'dot_0': {
                     'class': 'dot',
                     'from': ['add_0', 'split_dims'],
-                    'reduce': truediv_left_keys__num_heads__dim,
+                    'reduce': keys_h_dim,
                     'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
                   },
                   'RelPosSelfAttention._rel_shift': {
@@ -6096,27 +6025,27 @@ def test_CondLayer_outside_layer_access():
                         'axes': time__1_time_dim,
                         'padding': (1, 0),
                         'value': 0.0,
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, _1_time__1_time_dim}
+                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_dim_}
                       },
                       'reshape': {
                         'class': 'reshape',
                         'from': 'pad',
                         'in_dims': (
                           time_dim,
-                          _1_time__1_time_dim
+                          time_dim_
                         ),
                         'out_dims': (
-                          _1_time__1_time_dim,
+                          time_dim_,
                           time_dim
                         ),
                         'extra_deps': ['base:base:base:encoder/self_att/RelPosSelfAttention._rel_shift/pad',
                                        'base:base:base:base:data:data'],
-                        'out_shape': {batch_dim, time_dim, num_heads_dim, _1_time__1_time_dim}
+                        'out_shape': {batch_dim, time_dim, num_heads_dim, time_dim_}
                       },
                       'slice': {
                         'class': 'slice',
                         'from': 'reshape',
-                        'axis': _1_time__1_time_dim,
+                        'axis': time_dim_,
                         'slice_start': 1,
                         'out_dim': time__1_time_dim,
                         'out_shape': {batch_dim, time_dim, num_heads_dim, time__1_time_dim}
@@ -6179,14 +6108,14 @@ def test_CondLayer_outside_layer_access():
                     'class': 'dot',
                     'from': ['dropout', 'reinterpret_new_dim_0'],
                     'reduce': time_kv_0_dim,
-                    'out_shape': {batch_dim, time_dim, num_heads_dim, truediv_left_input__num_heads__dim}
+                    'out_shape': {batch_dim, time_dim, num_heads_dim, value_h_dim}
                   },
                   'output_0': {
                     'class': 'merge_dims',
                     'from': 'att',
                     'axes': (
                       num_heads_dim,
-                      truediv_left_input__num_heads__dim
+                      value_h_dim
                     ),
                     'out_dim': input_dim,
                     'out_shape': {batch_dim, time_dim, input_dim}


### PR DESCRIPTION
Causes by some returnn_common experiment. Reproduced in `test_CondLayer_outside_layer_access`.

I got a very strange `LayerNotFound` exception, which seems triggered by some combination of `RecLayer` and `CondLayer`. The layer construction recursively goes from the output layer to the rec subnet template construction to the cond layer and then to the base network to access some parameters which are in a subnet of the base network. This fails:

```
...
  File "/Users/az/i6/setups/2022-03-19--sis-i6-exp/ext/returnn/returnn/tf/layers/base.py", line 621, in <listcomp>
    line: get_layer(src_name)
    locals:
      get_layer = <local> <GetLayer '/cond(false_layer)/cond/encoder/self_att/qkv' parent_get_layer=<GetLayer '/cond(false_layer)/cond/encoder/self_att' parent_get_layer=<GetLayer '/cond(false_layer)/cond/encoder' parent_get_layer=<GetLayer '/cond(false_layer)/cond'>>>>
      src_name = <local> 'base:base:base:base:encoder/self_att/qkv/weight', len = 47
  File "/Users/az/i6/setups/2022-03-19--sis-i6-exp/ext/returnn/returnn/tf/network.py", line 3521, in GetLayer.__call__
    line: return get_layer.network.construct_layer(
            net_dict=get_layer._net_dict, name=name,
            get_layer=get_layer, add_layer=get_layer._add_layer_func)
    locals:
      get_layer = <local> <GetLayer '/cond(false_layer)'>
      get_layer.network = <local> <TFNetwork '/cond(false_layer)' train=False>
      get_layer.network.construct_layer = <local> <bound method TFNetwork.construct_layer of <TFNetwork '/cond(false_layer)' train=False>>
      net_dict = <not found>
      get_layer._net_dict = <local> {}
      name = <local> 'encoder/self_att/qkv/weight', len = 27
      add_layer = <not found>
      get_layer._add_layer_func = <local> None
  File "/Users/az/i6/setups/2022-03-19--sis-i6-exp/ext/returnn/returnn/tf/network.py", line 1040, in TFNetwork.construct_layer
    line: raise LayerNotFound(
            "layer %r not found in %r" % (name, self), layer_name=full_name, network=self, net_dict=net_dict)
    locals:
      LayerNotFound = <global> <class 'returnn.tf.network.LayerNotFound'>
      name = <local> 'encoder', len = 7
      self = <local> <TFNetwork '/cond(false_layer)' train=False>
      layer_name = <not found>
      full_name = <local> 'encoder/self_att/qkv/weight', len = 27
      network = <not found>
      net_dict = <local> {}
returnn.tf.network.LayerNotFound: layer 'encoder' not found in <TFNetwork '/cond(false_layer)' train=False>
```
Note that `get_layer = <local> <GetLayer '/cond(false_layer)'>` and then it calls `get_layer.network.construct_layer`, i.e. for the network `<TFNetwork '/cond(false_layer)' train=False>`. This net has `extra_parent_net` set to the root base network.

In `construct_layer`, we have this logic for extra nets and extra parent nets:
```python
...
    if self._extra_layer_name_prefix_pattern.match(name):  # not the case here, name = "encoder"
      ...
    elif self.extra_parent_net:  # the case here
      extra_prefix = self.extra_name_prefix
      explicit_extra_layer_name = "%s:%s" % (self.extra_name_prefix, name)
      if explicit_extra_layer_name in net_dict:  # not the case here
        layer_desc = net_dict[explicit_extra_layer_name]
      else:
        # Added this now, because I'm unsure:
        raise Exception("XXX do we really want this????")
      # Pass on here to construct the layer here in this extra net, as this was explicitly called.
```
I wonder a bit about the supposed extra net logic in this case. Is it correct that `GetLayer` calls it for the extra net `<TFNetwork '/cond(false_layer)' train=False>`? If so, this comment here seems wrong:

> Pass on here to construct the layer here in this extra net, as this was explicitly called.

So I added the exception as you see in the code, to see what actually fails then. I exactly run into the exception then.