### PR TITLE
Allow text-dict style vocab on LM Dataset

### DIFF
--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -136,10 +136,10 @@ class LmDataset(CachedDataset2):
     elif orth_symbols_map_file:
       assert not phone_info
       try:
-        d = eval(open(orth_replace_map_file, "r").read())
-        orth_symbols_imap_list = [(int(v), k) for k, v in d.values()]
+        d = eval(open(orth_symbols_map_file, "r").read())
+        orth_symbols_imap_list = [(int(v), k) for k, v in d.items()]
         orth_symbols_imap_list.sort()
-      except Exception:
+      except SyntaxError:
         orth_symbols_imap_list = [
           (int(b), a)
           for (a, b) in [
@@ -147,7 +147,6 @@ class LmDataset(CachedDataset2):
             for line in open(orth_symbols_map_file).read().splitlines()]]
         orth_symbols_imap_list.sort()
       assert orth_symbols_imap_list[0][0] == 0
-      assert orth_symbols_imap_list[-1][0] == len(orth_symbols_imap_list) - 1
       self.orth_symbols_map = {sym: i for (i, sym) in orth_symbols_imap_list}
       self.orth_symbols = [sym for (i, sym) in orth_symbols_imap_list]
       self.labels["data"] = self.orth_symbols

--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -138,7 +138,7 @@ class LmDataset(CachedDataset2):
       assert not phone_info
       with open(orth_symbols_map_file, "r") as f:
         test_string = f.read(1024).replace(" ", "").replace("\n", "")
-        match = re.search("^{[\"'].*[\"']:[0-9]*,", test_string)
+        match = re.search("^{[\"'].+[\"']:[0-9]+,", test_string)
         f.seek(0)
         if match is not None:
           d = literal_eval(f.read())

--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -135,17 +135,21 @@ class LmDataset(CachedDataset2):
       self.seq_gen = None
     elif orth_symbols_map_file:
       assert not phone_info
-      try:
-        d = eval(open(orth_symbols_map_file, "r").read())
-        orth_symbols_imap_list = [(int(v), k) for k, v in d.items()]
-        orth_symbols_imap_list.sort()
-      except SyntaxError:
-        orth_symbols_imap_list = [
-          (int(b), a)
-          for (a, b) in [
-            line.split(None, 1)
-            for line in open(orth_symbols_map_file).read().splitlines()]]
-        orth_symbols_imap_list.sort()
+      with open(orth_symbols_map_file, "r") as f:
+        dict_pattern = re.compile("[\"'].*[\"'][ ]*:[ ]*[0-9]*[ ]*,")
+        match = dict_pattern.search(f.read())
+        f.seek(0)
+        if match is not None:
+          d = eval(f.read())
+          orth_symbols_imap_list = [(int(v), k) for k, v in d.items()]
+          orth_symbols_imap_list.sort()
+        else:
+          orth_symbols_imap_list = [
+            (int(b), a)
+            for (a, b) in [
+              line.split(None, 1)
+              for line in f.read().splitlines()]]
+          orth_symbols_imap_list.sort()
       assert orth_symbols_imap_list[0][0] == 0
       self.orth_symbols_map = {sym: i for (i, sym) in orth_symbols_imap_list}
       self.orth_symbols = [sym for (i, sym) in orth_symbols_imap_list]

--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -14,6 +14,7 @@ from .cached2 import CachedDataset2
 import gzip
 import xml.etree.ElementTree as ElementTree
 from returnn.util.basic import parse_orthography, parse_orthography_into_symbols, load_json, BackendEngine, unicode
+from returnn.util.literal_py_to_pickle import literal_eval
 from returnn.log import log
 import numpy
 import time
@@ -136,11 +137,11 @@ class LmDataset(CachedDataset2):
     elif orth_symbols_map_file:
       assert not phone_info
       with open(orth_symbols_map_file, "r") as f:
-        dict_pattern = re.compile("[\"'].*[\"'][ ]*:[ ]*[0-9]*[ ]*,")
-        match = dict_pattern.search(f.read())
+        test_string = f.read(1024).replace(" ", "").replace("\n", "")
+        match = re.search("^{[\"'].*[\"']:[0-9]*,", test_string)
         f.seek(0)
         if match is not None:
-          d = eval(f.read())
+          d = literal_eval(f.read())
           orth_symbols_imap_list = [(int(v), k) for k, v in d.items()]
           orth_symbols_imap_list.sort()
         else:


### PR DESCRIPTION
The default output vocabulary of the https://github.com/rwth-i6/subword-nmt repo is a python formatted dictionary in text form. The `OggZipDataset` can use it, but the `LMDataset` did not yet, so I added that capability.