### PR TITLE
fix obj_diff_list for numpy arrays

### DIFF
--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -1167,6 +1167,12 @@ def obj_diff_list(self, other, **kwargs):
       return ["%sdict diff:" % prefix] + s
     return []
 
+  if isinstance(self, np.ndarray):
+    assert isinstance(other, np.ndarray)
+    if not np.array_equal(self, other):
+      return ["%sself: %r != other: %r" % (prefix, self, other)]
+    return []
+
   if allowed_mapping and self != other and allowed_mapping(self, other):
     if self in equal_map_s2o:
       self = equal_map_s2o[self]


### PR DESCRIPTION
Currently, `obj_diff_list` does not work for numpy arrays. I had an issue with `get_network()` which outputs a network including an array. 

Example test case to reproduce the error:
```
def test_get_network_with_arrays():
  from returnn.config import Config
  from returnn.tf.engine import Engine
  from returnn.datasets import init_dataset
  from returnn.tf.util.data import batch_dim, SpatialDim, FeatureDim

  time_dim = SpatialDim('time')
  in_dim = FeatureDim('in', 3)
  out_dim = FeatureDim('out', 4)

  def _config_get_network(epoch, **_kwargs):
    net_dict = {
      "fw0": {"class": "linear", "n_out": 10, "from": "data"},
      "constant": {"class": "constant", 'value': numpy.array([0, 1, 2])},
      "output": {"class": "reduce", "mode": "mean", "axes": ["B", "T", "F"], "loss": "as_is", "from": "fw0"}
    }
    return net_dict

  config = Config({
    "task": "train", "num_epochs": 2, "start_epoch": 1,
    "get_network": _config_get_network,
    "extern_data": {"data": {"dim_tags": (batch_dim, time_dim, in_dim)}},
  })
  train_dataset = init_dataset(
    {"class": "DummyDataset", "input_dim": in_dim.dimension, "output_dim": 5, "num_seqs": 3})
  engine = Engine(config)
  engine.init_train_from_config(config, train_data=train_dataset)
  engine.train()
```
Error message:
```
  File ".../returnn/util/basic.py", line 1176, in obj_diff_list
    line: if allowed_mapping and self != other and allowed_mapping(self, other):
    locals:
      allowed_mapping = <local> <function Engine._net_dict_diff.<locals>._allowed_mapping at 0x7fb1102e4a60>
      self = <local> array([0, 1, 2])
      other = <local> array([0, 1, 2])
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
