### PR TITLE
require dim tags to be defined

### DIFF
--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -537,7 +537,9 @@ class LayerBase(object):
       dep_batches = [dep.output.batch for dep in dep_layers if dep.output.batch]
       dyn_dim_tags_with_batch = [
         dim_tag for dim_tag in output.dim_tags
-        if dim_tag.dyn_size_ext and dim_tag.dyn_size_ext.have_batch_axis()]
+        if dim_tag.dyn_size_ext
+        and dim_tag.dyn_size_ext.have_batch_axis()
+        and dim_tag.dyn_size_ext.placeholder is not None]
       dim_tags_with_batch_info = [dim_tag for dim_tag in output.dim_tags if dim_tag.batch]
       if dep_batches:
         output.batch = BatchInfo.get_common_batch_info(dep_batches).copy_set_beam(output.beam)

--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -1864,6 +1864,13 @@ class InternalLayer(LayerBase):
   This is not supposed to be used by the user.
   It is used by some code to construct a wrapper layer or so.
   """
+  def __init__(self, output, **kwargs):
+    """
+    :param Data output:
+    """
+    # Explicit call to fixup_out_data as this might be missing by some direct construction.
+    output = self.fixup_out_data(output=output, **kwargs)
+    super().__init__(output=output, **kwargs)
 
 
 class DataNotAvailableLayer(InternalLayer):

--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -1873,7 +1873,7 @@ class InternalLayer(LayerBase):
     """
     # Explicit call to fixup_out_data as this might be missing by some direct construction.
     output = self.fixup_out_data(output=output, **kwargs)
-    super().__init__(output=output, **kwargs)
+    super(InternalLayer, self).__init__(output=output, **kwargs)
 
 
 class DataNotAvailableLayer(InternalLayer):

--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -529,6 +529,7 @@ class LayerBase(object):
         assert data.available_for_inference
         extern_data.init_batch_info()  # this should create it and also set it
         assert data.batch
+        network.get_root_network().extern_data.set_batch_info(data.batch)
         return data.batch
 
       # Some heuristic for now to fix missing batch info. We should try to fix get_out_data_from_opts though...

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -674,8 +674,8 @@ class SelectSearchSourcesLayer(InternalLayer):
             out_tag.dyn_size_ext = out_tag.dyn_size_ext.copy_extend_with_beam(self.output.beam)
           else:
             out_tag.dyn_size_ext = src_tag.dyn_size_ext.copy()
-        if out_tag.dyn_size_ext.placeholder is None:
-          assert out_tag.dyn_size_ext.have_batch_axis() and out_tag.dyn_size_ext.is_batch_major
+        if out_tag.dyn_size_ext.placeholder is None and out_tag.dyn_size_ext.have_batch_axis():
+          assert out_tag.dyn_size_ext.is_batch_major
           out_tag.dyn_size_ext.placeholder = transform(src_tag.dyn_size_ext.placeholder)
         if out_tag.dyn_size_ext.have_batch_axis():
           assert out_tag.dyn_size_ext.batch == out_tag.batch == self.output.batch

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5068,10 +5068,7 @@ class ReinterpretDataLayer(_ConcatInputLayer):
         new_tag = new_tag.get_for_batch_ctx(old_tag.batch, old_tag.control_flow_ctx)
         if old_tag.is_dim_known() and not new_tag.is_dim_known():
           assert not new_tag.dyn_size_ext
-          if old_tag.dyn_size_ext:
-            # Copy the template so that we know about implicit dims.
-            # The sizes itself will be setup in __init__.
-            new_tag.dyn_size_ext = old_tag.dyn_size_ext.copy_template()
+          new_tag.derive_from(old_tag)
         out = out.copy_template_replace_dim_tag(axis=axis_int, new_dim_tag=new_tag)
     if set_sparse is not None:
       assert isinstance(set_sparse, bool)

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4428,7 +4428,10 @@ class UnflattenNdLayer(_ConcatInputLayer):
       assert not declare_same_sizes_as
     else:
       out_dims = [
-        SpatialDim("%s:unflatten-nd:%i" % (name, i), auto_generated=True)
+        SpatialDim(
+          "%s:unflatten-nd:%i" % (name, i), auto_generated=True,
+          dyn_size_ext=Data(
+            "%s:unflatten-nd:%i" % (name, i), shape=(), dtype=Data.size_dtype))
         for i in range(num_axes)]
       if declare_same_sizes_as:
         for i, other in declare_same_sizes_as.items():

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4976,7 +4976,7 @@ class ReinterpretDataLayer(_ConcatInputLayer):
         new_dyn_size_ext.placeholder = tf.identity(
           new_dyn_size_ext.placeholder, name=get_valid_scope_name_from_str(new_dyn_size_ext.name))
         if new_tag.dyn_size_ext:
-          assert new_dyn_size_ext.dim_tags == new_dyn_size_ext.dim_tags
+          assert new_dyn_size_ext.dim_tags == new_tag.dyn_size_ext.dim_tags
         new_tag.dyn_size_ext = new_dyn_size_ext
         new_tag.set_tag_on_size_tensor(new_dyn_size_ext.placeholder)
     self.output.placeholder = input_data.placeholder

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1197,7 +1197,8 @@ class SliceNdLayer(_ConcatInputLayer):
       if size_data and (not slice_tag.dyn_size_ext or slice_tag.dyn_size_ext.placeholder is None):
         # in this case, size is not known before runtime and becomes dynamic and we need to set dyn_size
         assert slice_tag.is_dynamic()
-        slice_tag = slice_tag.get_for_batch_ctx(batch=size_data.batch, ctx=size_data.control_flow_ctx)
+        if size_data.batch:
+          slice_tag = slice_tag.get_for_batch_ctx(batch=size_data.batch, ctx=size_data.control_flow_ctx)
         slice_tag.dyn_size_ext = size_data
         slice_tag.set_tag_on_size_tensor(size_data.placeholder)
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -1284,6 +1284,8 @@ class SliceNdLayer(_ConcatInputLayer):
     :param Dim|None out_spatial_dim:
     :rtype: Data
     """
+    input_data = get_concat_sources_data_template(sources)
+    axis_int = input_data.get_axis_from_description(axis, allow_int=False)
     if start is None:
       start = 0
     if isinstance(start, int):
@@ -1307,6 +1309,7 @@ class SliceNdLayer(_ConcatInputLayer):
         kind=Dim.Types.Spatial,
         description="sliced-time:%s" % name,
         dimension=size, auto_generated=True)
+      out_spatial_dim_.derive_from(input_data.dim_tags[axis_int])
       if out_spatial_dim:
         out_spatial_dim_.declare_same_as(out_spatial_dim)
       else:

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5072,7 +5072,7 @@ class ReinterpretDataLayer(_ConcatInputLayer):
         new_tag = new_tag.get_for_batch_ctx(old_tag.batch, old_tag.control_flow_ctx)
         if old_tag.is_dim_known() and not new_tag.is_dim_known():
           assert not new_tag.dyn_size_ext
-          new_tag.derive_from(old_tag)
+          new_tag.derive_from(old_tag, set_derived_from_flag=False)
         out = out.copy_template_replace_dim_tag(axis=axis_int, new_dim_tag=new_tag)
     if set_sparse is not None:
       assert isinstance(set_sparse, bool)

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -3659,6 +3659,7 @@ class MergeDimsLayer(_ConcatInputLayer):
     out_dim_ = prod(merge_dim_tags)
     assert isinstance(out_dim_, Dim)
     assert out_dim_.dimension == res_dim
+    out_dim_.complete_dyn_size(template_only=True)
     if out_dim:
       out_dim_.declare_same_as(out_dim)
     new_dim_tags = [d for (i, d) in enumerate(data.dim_tags) if i not in axes]

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -7553,9 +7553,10 @@ class ShiftAxisLayer(_ConcatInputLayer):
       return out
     assert isinstance(amount, int)
     axis = out.get_axis_from_description(axis)
-    tag = out.dim_tags[axis]
-    dim = None if tag.dimension is None else max(0, tag.dimension - abs(amount))
-    tag = Dim(kind=tag.kind, description="%s_shift_axis" % name, dimension=dim, auto_generated=True)
+    old_tag = out.dim_tags[axis]
+    dim = None if old_tag.dimension is None else max(0, old_tag.dimension - abs(amount))
+    tag = Dim(kind=old_tag.kind, description="%s_shift_axis" % name, dimension=dim, auto_generated=True)
+    tag.derive_from(old_tag)
     return out.copy_template_replace_dim_tag(axis=axis, new_dim_tag=tag)
 
 

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -1438,7 +1438,8 @@ class _SubnetworkRecCell(object):
             pass  # ignore in this case
           else:
             raise
-        layer_.kwargs["output"].sanity_check(ignore_placeholder=True)  # placeholder might be overwritten later
+        if lself.got_uninitialized_deps_count == 0:
+          layer_.kwargs["output"].sanity_check(ignore_placeholder=True)  # placeholder might be overwritten later
         layer_.init(layer_class=layer_class, **layer_.kwargs)
         if layer_.need_last:
           self.prev_layers_needed.add(name)

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -8215,13 +8215,8 @@ class MaskedComputationLayer(LayerBase):
         # Create own time dim tag, to make sure we have some own custom.
         if not _Locals.out_spatial_dim_:
           _Locals.out_spatial_dim_ = Dim(
-            kind=Dim.Types.Spatial, description="%s:masked:time" % name,
-            derived_from_tag=_Locals.in_spatial_dim_, auto_generated=True)
-          _Locals.out_spatial_dim_.batch = _Locals.in_spatial_dim_.batch
-          _Locals.out_spatial_dim_.control_flow_ctx = _Locals.in_spatial_dim_.control_flow_ctx
-          if _Locals.in_spatial_dim_.dyn_size_ext:
-            _Locals.out_spatial_dim_.dyn_size_ext = _Locals.in_spatial_dim_.dyn_size_ext.copy_template(
-              name="%s:masked:time" % name)
+            kind=Dim.Types.Spatial, description="%s:masked:time" % name, auto_generated=True)
+          _Locals.out_spatial_dim_.derive_from(_Locals.in_spatial_dim_)
           if _Locals.in_spatial_dim_ == over_rec_time_dim and over_rec_time_dim and not inside_rec_time_dim:
             if extra_net:
               # Optimized out, so any sub layers will effectively operate on the out spatial dim.
@@ -8257,6 +8252,7 @@ class MaskedComputationLayer(LayerBase):
     layer_class.transform_config_dict(layer_desc, network=extra_net, get_layer=sub_get_layer)
     # noinspection PyProtectedMember
     layer_desc = extra_net._create_layer_layer_desc(name=name, layer_desc=layer_desc)
+    _Locals.out_spatial_dim_.derive_from(_Locals.in_spatial_dim_)
     return layer_class, layer_desc, _Locals.in_spatial_dim_, _Locals.out_spatial_dim_
 
   @classmethod

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -8217,6 +8217,11 @@ class MaskedComputationLayer(LayerBase):
           _Locals.out_spatial_dim_ = Dim(
             kind=Dim.Types.Spatial, description="%s:masked:time" % name,
             derived_from_tag=_Locals.in_spatial_dim_, auto_generated=True)
+          _Locals.out_spatial_dim_.batch = _Locals.in_spatial_dim_.batch
+          _Locals.out_spatial_dim_.control_flow_ctx = _Locals.in_spatial_dim_.control_flow_ctx
+          if _Locals.in_spatial_dim_.dyn_size_ext:
+            _Locals.out_spatial_dim_.dyn_size_ext = _Locals.in_spatial_dim_.dyn_size_ext.copy_template(
+              name="%s:masked:time" % name)
           if _Locals.in_spatial_dim_ == over_rec_time_dim and over_rec_time_dim and not inside_rec_time_dim:
             if extra_net:
               # Optimized out, so any sub layers will effectively operate on the out spatial dim.

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -6082,7 +6082,7 @@ class DecideLayer(BaseChoiceLayer):
     output.size_placeholder = {}
     for i, size in src_data.size_placeholder.items():
       tag = Dim.get_tag_from_size_tensor(size)
-      assert tag
+      assert tag, "%s: no dim tag found for size %s from source %r" % (owner or name, size, src)
       tag = tag.get_for_batch_ctx(batch=output.batch, ctx=output.control_flow_ctx)
       if tag.dyn_size is None:
         size = tf.reshape(size, [batch_dim, beam_size])  # (batch, beam)

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -1200,6 +1200,9 @@ class _SubnetworkRecCell(object):
     self.prev_layer_templates = {}  # type: typing.Dict[str,_TemplateLayer]
     self._template_construction_exceptions = None  # type: typing.Optional[typing.List[str]]
     self._construct_template(parent_get_layer=parent_get_layer)
+    if not time_dim_tag.is_dim_known() and self.net.used_data_keys:
+      data = self.parent_net.get_extern_data(min(self.net.used_data_keys), mark_data_key_as_used=False)
+      time_dim_tag.declare_same_as(data.get_time_dim_tag())
     if not time_dim_tag.is_dim_known() and "end" in self.layer_data_templates:
       end_data = self.layer_data_templates["end"].output
       dyn_size_ext = end_data.copy_template("%s:dyn-size" % rec_layer_name)

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3750,17 +3750,12 @@ class _SubnetworkRecCell(object):
           search_choices_cache=search_choices_cache)
         # Use the output Data from the in-loop layer,
         # as this might have set dyn sizes on dim tags.
-        is_out_time_dim = search_choices == self.layer_data_templates["output"].get_search_choices()
         time_dim_tag = Dim.get_tag_from_size_tensor(resolved_seq_len)
         if not time_dim_tag:
-          if is_out_time_dim:
-            time_dim_tag = self.time_dim_tag
-          else:
-            time_dim_tag = Dim(
-              kind=Dim.Types.Spatial,
-              description="dyn-time:%s/%s" % (self.parent_rec_layer.get_full_ctx_name(), search_choices),
-              auto_generated=True)
-        elif is_out_time_dim:
+          time_dim_tag = self.time_dim_tag.get_for_batch_ctx(
+            in_loop_layer.output.batch, self.parent_net.get_control_flow_ctx())
+          time_dim_tag.set_tag_on_size_tensor(resolved_seq_len, batch=in_loop_layer.output.batch)
+        else:
           self.time_dim_tag.declare_same_as(time_dim_tag)
         output = (
           in_loop_layer.output

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -8255,7 +8255,8 @@ class MaskedComputationLayer(LayerBase):
     layer_class.transform_config_dict(layer_desc, network=extra_net, get_layer=sub_get_layer)
     # noinspection PyProtectedMember
     layer_desc = extra_net._create_layer_layer_desc(name=name, layer_desc=layer_desc)
-    _Locals.out_spatial_dim_.derive_from(_Locals.in_spatial_dim_)
+    if _Locals.out_spatial_dim_ and _Locals.in_spatial_dim_:
+      _Locals.out_spatial_dim_.derive_from(_Locals.in_spatial_dim_)
     return layer_class, layer_desc, _Locals.in_spatial_dim_, _Locals.out_spatial_dim_
 
   @classmethod

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -1200,6 +1200,13 @@ class _SubnetworkRecCell(object):
     self.prev_layer_templates = {}  # type: typing.Dict[str,_TemplateLayer]
     self._template_construction_exceptions = None  # type: typing.Optional[typing.List[str]]
     self._construct_template(parent_get_layer=parent_get_layer)
+    if not time_dim_tag.is_dim_known() and "end" in self.layer_data_templates:
+      end_data = self.layer_data_templates["end"].output
+      time_dim_tag.batch = end_data.batch
+      time_dim_tag.control_flow_ctx = parent_net.get_control_flow_ctx()
+      time_dim_tag.dyn_size_ext = end_data.copy_template("%s:dyn-size" % rec_layer_name)
+      time_dim_tag.dyn_size_ext.control_flow_ctx = parent_net.get_control_flow_ctx()
+      time_dim_tag.dyn_size_ext.dtype = Data.size_dtype
     self._last_frames = {}  # type: typing.Dict[str,Data]
     self._initial_outputs = None  # type: typing.Optional[typing.Dict[str,tf.Tensor]]
     self._initial_extra_outputs = None  # type: typing.Optional[typing.Dict[str,typing.Dict[str,typing.Union[tf.Tensor,typing.Tuple[tf.Tensor,...]]]]]  # nopep8

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -4065,7 +4065,8 @@ class _TemplateLayer(LayerBase):
     # this is a problem and not supported currently.
     # In case the seq len is the same always, it just means that we did not fix the specific layer implementation yet.
     # This is work-in-progress.
-    layer.output.sanity_check()
+    layer.output.sanity_check(
+      assume_complete=prev_output is not None or rec_vars_prev_outputs is not None)
     if layer.output.placeholder is not None and self.network.get_config().bool("debug_runtime_sanity_checks", False):
       with layer.cls_setup_scope(**layer.kwargs):
         layer.output.placeholder = layer.output.get_placeholder_with_runtime_sanity_checks()

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3752,7 +3752,9 @@ class _SubnetworkRecCell(object):
         # as this might have set dyn sizes on dim tags.
         time_dim_tag = Dim.get_tag_from_size_tensor(resolved_seq_len)
         if not time_dim_tag:
-          batch = in_loop_layer.output.batch.copy_set_beam(search_choices.get_beam_info())
+          batch = in_loop_layer.output.batch
+          if search_choices:
+            batch = batch.copy_set_beam(search_choices.get_beam_info())
           time_dim_tag = self.time_dim_tag.get_for_batch_ctx(batch=batch, ctx=self.parent_net.get_control_flow_ctx())
           time_dim_tag.set_tag_on_size_tensor(resolved_seq_len, batch=batch)
         else:

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -2424,7 +2424,7 @@ class _SubnetworkRecCell(object):
         fixed_seq_len = input_seq_len
       if fixed_seq_len is not None:
         time_dim_tag = Dim.get_tag_from_size_tensor(fixed_seq_len)
-        assert time_dim_tag == self.time_dim_tag
+        assert time_dim_tag == self.time_dim_tag, "%s: fixed_seq_len %s without dim tag?" % (self, fixed_seq_len)
         if fixed_seq_len.get_shape().ndims > 0:
           assert fixed_seq_len.get_shape().ndims == 1
           with tf.name_scope("check_seq_len_batch_size"):

--- a/returnn/tf/layers/rec.py
+++ b/returnn/tf/layers/rec.py
@@ -3752,9 +3752,9 @@ class _SubnetworkRecCell(object):
         # as this might have set dyn sizes on dim tags.
         time_dim_tag = Dim.get_tag_from_size_tensor(resolved_seq_len)
         if not time_dim_tag:
-          time_dim_tag = self.time_dim_tag.get_for_batch_ctx(
-            in_loop_layer.output.batch, self.parent_net.get_control_flow_ctx())
-          time_dim_tag.set_tag_on_size_tensor(resolved_seq_len, batch=in_loop_layer.output.batch)
+          batch = in_loop_layer.output.batch.copy_set_beam(search_choices.get_beam_info())
+          time_dim_tag = self.time_dim_tag.get_for_batch_ctx(batch=batch, ctx=self.parent_net.get_control_flow_ctx())
+          time_dim_tag.set_tag_on_size_tensor(resolved_seq_len, batch=batch)
         else:
           self.time_dim_tag.declare_same_as(time_dim_tag)
         output = (

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -3159,6 +3159,7 @@ class Subnetwork:
     subnet_layer_dict.pop("sources", None)
     subnet_layer_dict.pop("n_out", None)
     subnet_layer_dict.pop("out_type", None)
+    subnet_layer_dict.pop("out_shape", None)
 
     # The SubnetworkLayer is created only later (if at all).
     # But it doesn't really matter which layer we have as the parent layer for our subnetwork,

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -390,6 +390,15 @@ class Dim(object):
               dyn_size_ext.placeholder._RETURNN_beam_expanded_base_data = beam_expanded_base_data
     if not dyn_size_ext and allow_none and not same_base.derived_from_op:
       return None
+    if not dyn_size_ext and same_base._same_for_batch_ctx and batch.is_global_batch() and not ctx:
+      # There are earlier entries in _same_for_batch_ctx
+      # -- maybe we can infer dyn_size_ext, even with different batch.
+      for (batch_, ctx_), other in same_base._same_for_batch_ctx.items():
+        if batch_.is_global_batch() and not ctx_:
+          if other.dyn_size_ext:
+            dyn_size_ext = other.dyn_size_ext.copy_template()
+            dyn_size_ext.batch = batch
+            break
     ctx = dyn_size_ext.control_flow_ctx if dyn_size_ext else ctx
     if (same_base.batch or batch) == batch and not same_base.control_flow_ctx and not ctx:
       # The same_base instance is either undefined (no batch, no ctx) or it is defined for the same batch and ctx.

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3057,8 +3057,8 @@ class Data(object):
           if not ignore_placeholder:
             if tag.dyn_size_ext.placeholder is None:
               tag.complete_dyn_size()
-            assert tag.dyn_size_ext.placeholder is not None
-        assert not tag.undefined
+            if self.placeholder is not None:
+              assert tag.dyn_size_ext.placeholder is not None
         assert tag.is_dim_known()
 
   def get_runtime_sanity_check_op(self):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1023,7 +1023,7 @@ class Dim(object):
       # If self is defined (self.is_dim_known), be fair to other, and adapt it to the right batch,
       # such that other.is_dim_known is correct, by potentially completing it.
       other = other.get_for_batch_ctx(self.batch, ctx=self.control_flow_ctx)
-    if self.is_dim_known() and not other.is_dim_known():
+    if (self.is_dim_known() and not other.is_dim_known()) or (self.undefined and not other.undefined):
       if self_same_as._creation_idx < other_same_base._creation_idx:
         # We want to keep self instead.
         # https://github.com/rwth-i6/returnn_common/issues/200

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -394,7 +394,10 @@ class Dim(object):
       if dyn_size_ext:
         same_base.dyn_size_ext = dyn_size_ext
         assert not same_base.dyn_size_ext.control_flow_ctx
-      same_base.complete_dyn_size(template_only=True)
+      elif same_base.dyn_size_ext:
+        same_base.dyn_size_ext.batch = batch
+      else:
+        same_base.complete_dyn_size(template_only=True)
       return same_base
     dim_tag = Dim(
       kind=self.kind, description=self.description, dimension=self.dimension,
@@ -4560,6 +4563,8 @@ class Data(object):
     """
     if batch:
       assert batch.beam == self.beam
+    if self._batch == batch:  # fast path
+      return
     self._batch = batch
     self._adapt_batch_consistent_dim_tags()
 

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3053,11 +3053,13 @@ class Data(object):
         if tag.is_batch_dim():
           continue
         if tag.is_dynamic():
-          assert tag.dyn_size_ext
+          assert tag.dyn_size_ext, "%s sanity_check: dynamic dim %s undefined" % (self, tag)
           if not ignore_placeholder:
             if tag.dyn_size_ext.placeholder is None:
               tag.complete_dyn_size()
             assert tag.dyn_size_ext.placeholder is not None
+        assert not tag.undefined
+        assert tag.is_dim_known()
 
   def get_runtime_sanity_check_op(self):
     """

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -113,6 +113,12 @@ class Dim(object):
       assert isinstance(src_data, Data) and isinstance(src_axis, int)
     if not batch and dyn_size_ext:
       batch = dyn_size_ext.batch
+      if not control_flow_ctx:
+        control_flow_ctx = dyn_size_ext.control_flow_ctx
+    if not batch and derived_from_tag:
+      batch = derived_from_tag.batch
+      if not control_flow_ctx:
+        control_flow_ctx = derived_from_tag.control_flow_ctx
     self.batch = batch
     self.control_flow_ctx = control_flow_ctx
     self.src_data = src_data

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -423,13 +423,14 @@ class Dim(object):
         same_base.dyn_size_ext.batch = batch
       else:
         same_base.complete_dyn_size(template_only=True)
-      return same_base
-    dim_tag = Dim(
-      kind=self.kind, description=self.description, dimension=self.dimension,
-      auto_generated=self.auto_generated,
-      batch=batch, control_flow_ctx=ctx,
-      dyn_size_ext=dyn_size_ext)
-    dim_tag.same_as = same_base
+      dim_tag = same_base
+    else:
+      dim_tag = Dim(
+        kind=self.kind, description=self.description, dimension=self.dimension,
+        auto_generated=self.auto_generated,
+        batch=batch, control_flow_ctx=ctx,
+        dyn_size_ext=dyn_size_ext)
+      dim_tag.same_as = same_base
     if dyn_size_ext and dyn_size_ext.placeholder is not None:
       if Dim.get_tag_from_size_tensor(dyn_size_ext.placeholder) is None:
         dim_tag.set_tag_on_size_tensor(dyn_size_ext.placeholder, batch=batch)

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1052,7 +1052,12 @@ class Dim(object):
       other_ = other.get_for_batch_ctx(self.batch, ctx=self.control_flow_ctx)
     else:
       other_ = other
-    if (self.is_dim_known() and not other_.is_dim_known()) or (not self.undefined and other_.undefined):
+    if (
+          (self.is_dim_known() and not other_.is_dim_known()) or
+          # Like is_dim_known but for static dims, we might know both,
+          # but the derived_from_op still would provide more information.
+          (self.derived_from_op and not other_.derived_from_op and other_ not in self.get_derived_bases_set()) or
+          (not self.undefined and other_.undefined)):
       if self_same_as._creation_idx > other_same_base._creation_idx:
         # We want to keep other instead.
         # https://github.com/rwth-i6/returnn_common/issues/200

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -458,7 +458,12 @@ class Dim(object):
     assert self.can_be_used_as_dim()
     same = self.get_for_batch_ctx(batch, ctx)
     assert dyn_size_ext.batch == batch and dyn_size_ext.control_flow_ctx == ctx
-    same.dyn_size_ext = dyn_size_ext
+    if same.dyn_size_ext:
+      assert same.dyn_size_ext.dim_tags == dyn_size_ext.dim_tags
+      if dyn_size_ext.placeholder is not None:
+        same.dyn_size_ext.placeholder = dyn_size_ext.placeholder
+    else:
+      same.dyn_size_ext = dyn_size_ext
     self._maybe_update()
 
   def get_dyn_size_ext_for_batch_ctx(self, batch, ctx, template_only=False):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -3048,16 +3048,16 @@ class Data(object):
         assert self.placeholder.shape[i].value == self.batch_shape[i]
       self.placeholder.set_shape(self.batch_shape)
       assert self.placeholder.dtype.base_dtype.name == self.dtype
-      # Currently only if placeholder is set.
-      # We can later always do the check even without placeholder.
-      if assume_complete:
-        for tag in self.dim_tags:
-          if tag.dimension is None:
-            if tag.is_batch_dim():
-              continue
-            if not tag.dyn_size_ext or tag.dyn_size_ext.placeholder is None:
+    if assume_complete:
+      for tag in self.dim_tags:
+        if tag.is_batch_dim():
+          continue
+        if tag.is_dynamic():
+          assert tag.dyn_size_ext
+          if not ignore_placeholder:
+            if tag.dyn_size_ext.placeholder is None:
               tag.complete_dyn_size()
-            assert tag.dyn_size is not None
+            assert tag.dyn_size_ext.placeholder is not None
 
   def get_runtime_sanity_check_op(self):
     """

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -143,6 +143,8 @@ class Dim(object):
       self.dyn_size = dyn_size
     self._creation_idx = Dim._creation_counter
     Dim._creation_counter += 1
+    if self.derived_from_op:
+      self.complete_dyn_size(template_only=True)
 
   def __repr__(self):
     return "Dim{%s}" % self.short_repr()

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -489,9 +489,6 @@ class Dim(object):
       If the dyn size can potentially be of a different shape, directly access dyn_size_ext.
     :rtype: tf.Tensor|None
     """
-    if self.is_dynamic() and (not self.dyn_size_ext or self.dyn_size_ext.placeholder is None):
-      # Try to complete.
-      self.complete_dyn_size()
     if self.dyn_size_ext:
       return self.dyn_size_ext.placeholder
     return None

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -143,8 +143,8 @@ class Dim(object):
       self.dyn_size = dyn_size
     self._creation_idx = Dim._creation_counter
     Dim._creation_counter += 1
-    if self.derived_from_op:
-      self.complete_dyn_size(template_only=True)
+    if self.derived_from_op and self.is_dynamic():
+      self.complete_dyn_size()
 
   def __repr__(self):
     return "Dim{%s}" % self.short_repr()

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -656,7 +656,8 @@ class Dim(object):
           "\nThis is maybe the result of an incorrect declare_same_as. ",
           "same_as = %s" % self.same_as]))
     if batch and getattr(x, "_RETURNN_dyn_size_beam", None):
-      assert batch.beam == getattr(x, "_RETURNN_dyn_size_beam")
+      assert batch.beam == getattr(x, "_RETURNN_dyn_size_beam"), (
+        "%s: dyn size %s has unexpected batch %s, expected %s" % (self, x, batch, getattr(x, "_RETURNN_dyn_size_beam")))
     if self.batch and batch:
       assert self.batch == batch
     elif batch and not self.batch:

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1131,15 +1131,17 @@ class Dim(object):
       self._same_for_batch_ctx[key] = dim
     other._same_for_batch_ctx.clear()  # we only want to have it once
 
-  def derive_from(self, base):
+  def derive_from(self, base, set_derived_from_flag=True):
     """
     :param Dim base:
+    :param bool set_derived_from_flag:
     """
     self_base = self.get_same_base()
-    if self_base.derived_from_tag:
-      assert self_base.derived_from_tag == base
-    else:
-      self_base.derived_from_tag = base
+    if set_derived_from_flag:
+      if self_base.derived_from_tag:
+        assert self_base.derived_from_tag == base
+      else:
+        self_base.derived_from_tag = base
     if not self.batch:
       self.batch = base.batch
     if not self.control_flow_ctx:

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1201,6 +1201,8 @@ class Dim(object):
             replace_existing = True
           if replace_existing:  # Replace the existing by the new tag.
             tags[tags.index(existing_tag)] = tag
+            for _, dims_ in data_axes_dict.items():
+              dims_[:] = [tag if d == existing_tag else d for d in dims_]
             existing_tag = tag
         else:  # no existing tag
           tags.append(tag)

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -414,7 +414,9 @@ class Dim(object):
     ctx = dyn_size_ext.control_flow_ctx if dyn_size_ext else ctx
     dim_tag = None
     for candidate in [self, same_base]:
-      if (candidate.batch or batch) == batch and not candidate.control_flow_ctx and not ctx:
+      if (
+            (candidate.batch == batch or (not candidate.batch and batch.is_global_batch())) and
+            not candidate.control_flow_ctx and not ctx):
         # The same_base instance is either undefined (no batch, no ctx) or it is defined for the same batch and ctx.
         # In any case, reuse it then.
         candidate.batch = batch

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -5884,6 +5884,7 @@ def _infer_dim_tags_tuple_from_shape(
           # This is such that Dim.is_equal behaves as before, e.g. in Data.get_common_data.
           kind=Dim.Types.Spatial,
           auto_generated=True)
+        tag.dyn_size_ext = Data("%s_dim%i_size" % (name, axis_wo_b), dtype=Data.size_dtype, shape=())
         dim_tags[axis] = tag
       dyn_size = tag.dyn_size
     if tag:
@@ -5896,6 +5897,8 @@ def _infer_dim_tags_tuple_from_shape(
       tag = Dim(
         kind=Dim.Types.Feature, dimension=dim, description="feature:%s" % name,
         undefined=dim is None, auto_generated=True)
+      if dim is None:
+        tag.dyn_size_ext = Data("%s_dim%i_size" % (name, axis_wo_b), dtype=Data.size_dtype, shape=())
     else:
       assert axis in spatial_axes
       description = "time" if axis == time_dim_axis else "spatial%i" % spatial_axes.index(axis)
@@ -5911,6 +5914,8 @@ def _infer_dim_tags_tuple_from_shape(
       tag = Dim(
         kind=Dim.Types.Spatial, description=description, dimension=dim, dyn_size=dyn_size,
         undefined=dim is None and dyn_size is None, auto_generated=True)
+      if dim is None:
+        tag.dyn_size_ext = Data("%s_dim%i_size" % (name, axis_wo_b), dtype=Data.size_dtype, shape=())
     dim_tags[axis] = tag
   assert sorted(dim_tags.keys()) == list(range(len(batch_shape)))
   return tuple(dim_tags[axis] for axis in range(len(batch_shape)))

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1114,6 +1114,23 @@ class Dim(object):
       self._same_for_batch_ctx[key] = dim
     other._same_for_batch_ctx.clear()  # we only want to have it once
 
+  def derive_from(self, base):
+    """
+    :param Dim base:
+    """
+    self_base = self.get_same_base()
+    if self_base.derived_from_tag:
+      assert self_base.derived_from_tag == base
+    else:
+      self_base.derived_from_tag = base
+    if self.is_dynamic():
+      if not self.batch:
+        self.batch = base.batch
+      if not self.control_flow_ctx:
+        self.control_flow_ctx = base.control_flow_ctx
+      if not self.dyn_size_ext:
+        self.dyn_size_ext = base.dyn_size_ext.copy_template(name="%s:size" % self_base.description)
+
   @classmethod
   def get_existing_tag_from_collection(cls, other, tags, is_equal_opts=None):
     """

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1123,13 +1123,16 @@ class Dim(object):
       assert self_base.derived_from_tag == base
     else:
       self_base.derived_from_tag = base
-    if self.is_dynamic():
-      if not self.batch:
-        self.batch = base.batch
-      if not self.control_flow_ctx:
-        self.control_flow_ctx = base.control_flow_ctx
+    if not self.batch:
+      self.batch = base.batch
+    if not self.control_flow_ctx:
+      self.control_flow_ctx = base.control_flow_ctx
+    if self.is_dynamic() or not self.is_dim_known():
       if not self.dyn_size_ext:
-        self.dyn_size_ext = base.dyn_size_ext.copy_template(name="%s:size" % self_base.description)
+        if base.dyn_size_ext:
+          self.dyn_size_ext = base.dyn_size_ext.copy_template(name="%s:size" % self_base.description)
+        elif base.is_batch_dim():
+          self.dyn_size_ext = Data("%s:batch" % self_base.description, shape=(), dtype="int32", batch_dim_axis=None)
 
   @classmethod
   def get_existing_tag_from_collection(cls, other, tags, is_equal_opts=None):

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -390,15 +390,15 @@ class Dim(object):
               dyn_size_ext.placeholder._RETURNN_beam_expanded_base_data = beam_expanded_base_data
     if not dyn_size_ext and allow_none and not same_base.derived_from_op:
       return None
-    if not dyn_size_ext and same_base._same_for_batch_ctx and batch.is_global_batch() and not ctx:
+    if not dyn_size_ext and same_base._same_for_batch_ctx:
       # There are earlier entries in _same_for_batch_ctx
       # -- maybe we can infer dyn_size_ext, even with different batch.
       for (batch_, ctx_), other in same_base._same_for_batch_ctx.items():
-        if batch_.is_global_batch() and not ctx_:
-          if other.dyn_size_ext:
-            dyn_size_ext = other.dyn_size_ext.copy_template()
-            dyn_size_ext.batch = batch
-            break
+        if ctx_ == ctx and other.dyn_size_ext:
+          dyn_size_ext = other.dyn_size_ext.copy_template()
+          dyn_size_ext.beam = batch.beam
+          dyn_size_ext.batch = batch
+          break
     ctx = dyn_size_ext.control_flow_ctx if dyn_size_ext else ctx
     if (same_base.batch or batch) == batch and not same_base.control_flow_ctx and not ctx:
       # The same_base instance is either undefined (no batch, no ctx) or it is defined for the same batch and ctx.

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1038,6 +1038,8 @@ class Dim(object):
     if self_derived_bases.issubset(other_derived_bases):
       # Avoid cycles on derived_from_tag. https://github.com/rwth-i6/returnn/issues/1054
       return other.declare_same_as(self)
+    self.derived_from_op = None
+    self.derived_from_tag = None
     if self_same_as is not self:
       assert not self_same_as.same_as
       if self_same_as is other_same_base:
@@ -1046,6 +1048,10 @@ class Dim(object):
       if (self.dyn_size_ext is None or not self._validate_in_current_graph()) and self_same_as.dyn_size_ext:
         self.dyn_size_ext = self_same_as.get_dyn_size_ext_for_batch_ctx(
           self.batch, self.control_flow_ctx, template_only=True)
+    else:
+      for dim_ in self._same_for_batch_ctx.values():
+        dim_.derived_from_op = None
+        dim_.derived_from_tag = None
     other_same_base._merge_same_for_batch_ctx_dict(self)
     other._maybe_update()
     self.same_as = other_same_base

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -1192,14 +1192,17 @@ class Dim(object):
         assert self_base.derived_from_tag == base
       else:
         self_base.derived_from_tag = base
-    if not self.batch:
+    if not self.batch and base.batch:
       self.batch = base.batch
-    if not self.control_flow_ctx:
       self.control_flow_ctx = base.control_flow_ctx
+      key = base.batch, base.control_flow_ctx
+      assert key not in self_base._same_for_batch_ctx
+      self_base._same_for_batch_ctx[key] = self
     if self.is_dynamic() or not self.is_dim_known():
       if not self.dyn_size_ext:
         if base.dyn_size_ext:
-          self.dyn_size_ext = base.dyn_size_ext.copy_template(name="%s:size" % self_base.description)
+          if base.batch and base.batch == self.batch and base.control_flow_ctx == self.control_flow_ctx:
+            self.dyn_size_ext = base.dyn_size_ext.copy_template(name="%s:size" % self_base.description)
         elif base.is_batch_dim():
           self.dyn_size_ext = Data("%s:batch" % self_base.description, shape=(), dtype="int32", batch_dim_axis=None)
 

--- a/returnn/tf/util/data.py
+++ b/returnn/tf/util/data.py
@@ -329,19 +329,6 @@ class Dim(object):
       return self  # just leave as-is. should not matter.
     same_base = self.get_same_base()
     same_base._validate_in_current_graph()
-    # Might be uninitialized in some cases. Assume batch is global.
-    if not same_base.batch:
-      batch_base = batch.get_global_base()
-      if same_base.dyn_size_ext:
-        assert batch == batch_base
-        same_base.batch = batch
-        assert not same_base.dyn_size_ext.batch or same_base.dyn_size_ext.batch == batch
-        same_base.dyn_size_ext.batch = batch
-      else:
-        same_base.batch = batch_base
-    if same_base.dyn_size_ext:
-      assert same_base.batch == same_base.dyn_size_ext.batch
-      assert same_base.control_flow_ctx == same_base.dyn_size_ext.control_flow_ctx
     for ctx_ in ControlFlowContext.abs_ctx_stack_with_root(ctx):
       tag = same_base._same_for_batch_ctx.get((batch, ctx_), None)
       if tag and tag._can_use_in_ctx(ctx) and tag._validate_in_current_graph():

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -8014,7 +8014,8 @@ def test_ResizeLayer_fill_dropout():
       name="resize", network=net,
       factor=factor, axis="T", kind="fill", fill_value=fill_value, fill_dropout=0.5, sources=[src],
       output=ResizeLayer.get_out_data_from_opts(
-        name="resize", network=net, factor=factor, axis="T", kind="fill", sources=[src]))
+        name="resize", network=net,
+        factor=factor, axis="T", kind="fill", fill_value=fill_value, fill_dropout=0.5, sources=[src]))
     out, seq_lens = session.run([layer.output.placeholder, layer.output.size_placeholder[0]])
     print(out)
     print(seq_lens)

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -1777,6 +1777,21 @@ def test_CompareLayer_allow_broadcast_all_sources():
     })
 
 
+def test_CombineLayer_time_dim_no_session_after_session():
+  from returnn.tf.util.data import batch_dim, FeatureDim, SpatialDim
+  input_dim = FeatureDim("input", 3)
+
+  with make_scope():
+    time_dim = SpatialDim("time")
+    net = TFNetwork(config=Config(), extern_data=ExternData({"data": {"dim_tags": [batch_dim, time_dim, input_dim]}}))
+    net.construct_from_dict({"output": {"class": "copy", "from": "data"}})
+
+  # This has messed up the time dim or batch info at some point.
+  # It is only triggered by executing the code above,
+  # otherwise it ran fine in isolation.
+  test_CombineLayer_broadcast_same_dim_diff_tag()
+
+
 def test_RangeFromLength_over_batch():
   # https://github.com/rwth-i6/pytorch-to-returnn/issues/100
   net_dict = {

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -7533,27 +7533,27 @@ def test_conv_layer_NCHW():
         name="src_nhwc", network=net,
         output=Data(**{
           "name": "src_nhwc_output",
+          "placeholder": tf_compat.v1.placeholder(shape=(None, None, 16, 17), dtype=tf.float32),
+          "size_placeholder": {0: tf_compat.v1.placeholder(shape=(None,), dtype=tf.int32)},
           "dim": 17,
           "shape": (None, 16, 17),
           "batch_dim_axis": 0,
           "time_dim_axis": 1,
           "feature_dim_axis": 3,
           "sparse": False}))
-      src_nhwc.output.placeholder = tf_compat.v1.placeholder(shape=(None, None, 16, 17), dtype=tf.float32)
-      src_nhwc.output.size_placeholder = {0: tf_compat.v1.placeholder(shape=(None,), dtype=tf.int32)}
     with tf_compat.v1.variable_scope("src_nchw"):
       src_nchw = InternalLayer(
         name="src_nchw", network=net,
         output=Data(**{
           "name": "src_nchw_output",
+          "placeholder": tf_compat.v1.placeholder(shape=(None, 17, None, 16), dtype=tf.float32),
+          "size_placeholder": {1: tf_compat.v1.placeholder(shape=(None,), dtype=tf.int32)},
           "dim": 17,
           "shape": (17, None, 16),
           "batch_dim_axis": 0,
           "time_dim_axis": 2,
           "feature_dim_axis": 1,
           "sparse": False}))
-      src_nchw.output.placeholder = tf_compat.v1.placeholder(shape=(None, 17, None, 16), dtype=tf.float32)
-      src_nchw.output.size_placeholder = {1: tf_compat.v1.placeholder(shape=(None,), dtype=tf.int32)}
 
     filters = 64
     filter_size = (5, 5)

--- a/tests/test_TFUtil.py
+++ b/tests/test_TFUtil.py
@@ -227,6 +227,7 @@ def test_Data_copy_with_feature_dim_axis_case_1():
   d = Data(name='test_data', shape=(None, 13, 17), dtype='float32',
            size_placeholder={0: size_placeholder}, batch_dim_axis=0,
            time_dim_axis=1, feature_dim_axis=3)
+  assert list(d.size_placeholder.keys()) == [0]
   d_copy = d.copy_with_feature_dim_axis(1)
   assert d_copy.shape == (17, None, 13)
   assert d_copy.batch_dim_axis == 0

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -23,13 +23,13 @@ def run(*args):
   print("run:", args)
   global _run_count
   if _run_count == 0:
+    _run_count += 1
     # For the first run, as a special case, directly run the script in the current env.
     # This is easier for debugging.
     from returnn.util.basic import generic_import_module
     mod = generic_import_module(os.path.join(base_dir, args[0]))
     # noinspection PyUnresolvedReferences
     mod.main(args)
-    _run_count += 1
     return
   _run_count += 1
   # RETURNN by default outputs on stderr, so just merge both together

--- a/tools/compile_tf_graph.py
+++ b/tools/compile_tf_graph.py
@@ -190,6 +190,7 @@ class SubnetworkRecCellSingleStep(_SubnetworkRecCell):
     dim_tag_ = Dim(
       kind=dim_tag.kind, description=dim_tag.description + "_base_state_var",
       dimension=None, dyn_size_ext=dim_tag_dyn_size_ext,
+      auto_generated=dim_tag.auto_generated,  # keep same is_equal behavior
       batch=dim_tag.batch)
     dim_tag_.set_tag_on_size_tensor(dim_tag_dyn_size_ext.placeholder)
     self._maybe_delay_tiled(state_var, dim_tag_.dyn_size_ext)


### PR DESCRIPTION
"Defined" here means that `dyn_size_ext` is set for dynamic sizes. This can be a template (no `placeholder`). But the shape is important. Usually [B] but not always.

Returnn-common requires this but this should be consistent anyway.

The first commit adds this to the `Data.sanity_check`.

A number of layers don't do this correctly. Namely:

- [x] `ShiftAxisLayer`, e.g. `test_shift_layer`
- [x] `ReinterpretDataLayer` with `set_dim_tags`, e.g. `test_ReinterpretDataLayer_change_batch_to_spatial`
- [x] `SliceNdLayer`, e.g. `test_SliceNdLayer_ReinterpretDataLayer`
- [x] `MergeDimsLayer`
- [x] `UnflattenNdLayer`, via `test_unflatten_2d`
- [x] `MaskedComputationLayer` with given but undefined `out_spatial_dim`, e.g. `test_MaskedComputationLayer_dyn_size_none`, etc
- [x] `RecLayer`, e.g. `test_compile_tf_graph_basic`, `test_reclayer_prev_template_with_out_shape`, etc
- [x] `CumConcatLayer`, e.g. `test_CumConcatLayer_self_attention_equal_to_SelfAttentionLayer`

A few other things broke because of this. This is again a reminder for https://github.com/rwth-i6/returnn/issues/975...
