### PR TITLE
Fix `-no_ogg` option in bliss-to-ogg-zip.py tool

### DIFF
--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -180,7 +180,7 @@ class OggZipDataset(CachedDataset2):
         first_entry = data[0]
         assert isinstance(first_entry, dict)
         assert isinstance(first_entry["text"], str)
-        assert isinstance(first_entry["duration"], float)
+        assert isinstance(first_entry["duration"], (float, int))
         # when 'audio' is None and sequence names are given, this dataset can be used in text-only mode
         if "file" in first_entry:
             assert isinstance(first_entry["file"], str)

--- a/tools/bliss-to-ogg-zip.py
+++ b/tools/bliss-to-ogg-zip.py
@@ -345,8 +345,11 @@ def main():
         rec_filename = seq.recording_filename
         assert os.path.isfile(rec_filename) or args.no_ogg
         assert (seq.start_time < seq.end_time and seq.delta_time > 0) or args.no_ogg
-        duration = seq.delta_time
-        assert duration > 0 or args.no_ogg
+        if args.no_ogg:
+            duration = len(seq.orth.split(" "))
+        else:
+            duration = seq.delta_time
+        assert duration > 0
         total_duration += duration
         assert rec_filename.startswith(rec_filename_common_prefix) and rec_filename.endswith(
             rec_filename_common_postfix

--- a/tools/bliss-to-ogg-zip.py
+++ b/tools/bliss-to-ogg-zip.py
@@ -343,10 +343,10 @@ def main():
 
     for seq in seqs:
         rec_filename = seq.recording_filename
-        assert os.path.isfile(rec_filename)
-        assert seq.start_time < seq.end_time and seq.delta_time > 0
+        assert os.path.isfile(rec_filename) or args.no_ogg
+        assert (seq.start_time < seq.end_time and seq.delta_time > 0) or args.no_ogg
         duration = seq.delta_time
-        assert duration > 0
+        assert duration > 0 or args.no_ogg
         total_duration += duration
         assert rec_filename.startswith(rec_filename_common_prefix) and rec_filename.endswith(
             rec_filename_common_postfix


### PR DESCRIPTION
The current code had undefined behavior with respect to the written duration or even crashed for some bliss datasets with missing audio.

Now the duration is always given by the text length if the `-no_ogg` option is set. This does change the behavior, but I am not sure how we want to deal with it in tools. If this behavior change is not accepted, I can keep my local version for experiments that require this. I do not want to add an extra flag because this would make the way the tool works even more complicated and non-understandable.