### PR TITLE
ReinterpretDataLayer, fix dyn_size_ext placeholder context

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -5465,9 +5465,10 @@ class ReinterpretDataLayer(_ConcatInputLayer):
                     assert old_tag.dyn_size_ext
                     new_dyn_size_ext = old_tag.dyn_size_ext.copy(name="%s_size" % (new_tag.description or "<unnamed>"))
                 # Need to create new size tensor as long as we have get_tag_from_size_tensor.
-                new_dyn_size_ext.placeholder = tf.identity(
-                    new_dyn_size_ext.placeholder, name=get_valid_scope_name_from_str(new_dyn_size_ext.name)
-                )
+                with tf_util.same_control_flow_ctx(new_dyn_size_ext.placeholder):
+                    new_dyn_size_ext.placeholder = tf.identity(
+                        new_dyn_size_ext.placeholder, name=get_valid_scope_name_from_str(new_dyn_size_ext.name)
+                    )
                 if new_tag.dyn_size_ext:
                     assert new_dyn_size_ext.dim_tags == new_tag.dyn_size_ext.dim_tags
                 new_tag.dyn_size_ext = new_dyn_size_ext

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5661,7 +5661,6 @@ def test_CondLayer_dyn_dim_replace():
 
     _2_time_dim = 2 * time_dim
     time_2_dim = time_dim * 2
-    random_state_dim = FeatureDim("random-state", 3)
 
     net_dict = {
         "length": {"class": "length", "from": ["data:data"], "axis": time_dim, "out_shape": {batch_dim}},

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5725,8 +5725,8 @@ def test_CondLayer_dyn_dim_replace():
         # tensorflow.python.framework.errors_impl.InvalidArgumentError: Retval[0] does not have value
         # Adding the same_control_flow_ctx at the place where it is created fixes this.
         print("out_seq_len:", out_seq_len)
-        tf_util.print_graph_output(out_seq_len)
-        print(out_seq_len.op._traceback)
+        # tf_util.print_graph_output(out_seq_len) -- not really relevant
+        # print(out_seq_len.op._traceback) -- not always available?
         fetch = out.placeholder
         session.run(fetch, feed_dict=make_feed_dict(network.extern_data, n_time=1))
         session.run(fetch, feed_dict=make_feed_dict(network.extern_data, n_time=2))

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5659,6 +5659,8 @@ def test_CondLayer_dyn_dim_replace():
         )
     )
 
+    # For the test, it is crucial to have two different dim tags here
+    # which can be replaced by each other though.
     _2_time_dim = 2 * time_dim
     time_2_dim = time_dim * 2
 

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -5717,7 +5717,17 @@ def test_CondLayer_dyn_dim_replace():
         network = TFNetwork(config=config)
         network.construct_from_dict(net_dict)
         network.initialize_params(session)
-        fetch = network.get_default_output_layer().output.placeholder
+        out = network.get_default_output_layer().output
+        print("out:", out)
+        out_seq_len = out.get_sequence_lengths()
+        # Before the fix, the seq len tensor had the wrong control flow context inside the condition.
+        # This caused the error:
+        # tensorflow.python.framework.errors_impl.InvalidArgumentError: Retval[0] does not have value
+        # Adding the same_control_flow_ctx at the place where it is created fixes this.
+        print("out_seq_len:", out_seq_len)
+        tf_util.print_graph_output(out_seq_len)
+        print(out_seq_len.op._traceback)
+        fetch = out.placeholder
         session.run(fetch, feed_dict=make_feed_dict(network.extern_data, n_time=1))
         session.run(fetch, feed_dict=make_feed_dict(network.extern_data, n_time=2))
 


### PR DESCRIPTION
When some dim was initially created inside a CondLayer, it had the wrong control flow context.
This lead to the error:
```
tensorflow.python.framework.errors_impl.InvalidArgumentError: Retval[0] does not have value
```
This fixes it.