### PR TITLE
get_all_dimension_tags, don't prefer derived bases

### DIFF
--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -1463,8 +1463,6 @@ class _DimMixin:
                     replace_existing = (
                         existing_tag.undefined and not tag.undefined and tag.dimension == existing_tag.dimension
                     )
-                    if tag != existing_tag and tag in existing_tag.get_derived_bases_set():
-                        replace_existing = True
                     if replace_existing:  # Replace the existing by the new tag.
                         tags[tags.index(existing_tag)] = tag
                         for _, dims_ in data_axes_dict.items():

--- a/tests/test_TFUtil.py
+++ b/tests/test_TFUtil.py
@@ -469,8 +469,8 @@ def test_Dim_get_all_dimension_tags_one_derived_time():
     all_dim_tags, _ = DimensionTag.get_all_dimension_tags([b, a], is_equal_opts=is_equal_opts)
     print("all_dim_tags:", all_dim_tags)
     # The is_equal_opts with derived_matches should match time_dim with derived_time_dim.
-    # We explicitly want that the time_dim is returned here.
-    assert derived_time_dim not in all_dim_tags and all_dim_tags == [batch_dim, time_dim, feat_dim]
+    # We explicitly want that the derived_time_dim is returned here.
+    assert time_dim not in all_dim_tags and all_dim_tags == [batch_dim, derived_time_dim, feat_dim]
 
 
 def test_Data_sparse_int32_with_dim_kwargs_init():


### PR DESCRIPTION
In _post_init_output, this would have overwritten some valid dim tags by wrong ones. E.g. when the valid shape was [1+T,B], and there was a target set with shape [T,B],
it would replace 1+T by T.