### PR TITLE
Set forward batch size explicitly for task Search

### DIFF
--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -465,11 +465,14 @@ def execute_main_task():
             config.set("load_epoch", config.int("epoch", 0))
         engine.init_network_from_config(config)
         output_file = config.value("output_file", "dump-fwd-epoch-%i.hdf" % engine.epoch)
+        forward_batch_size = config.int("forward_batch_size", 0)
+        if not forward_batch_size:
+            raise Exception("forward_batch_size not set")
         engine.forward_to_hdf(
             data=eval_data,
             output_file=output_file,
             combine_labels=combine_labels,
-            batch_size=config.int("forward_batch_size", 0),
+            batch_size=forward_batch_size,
         )
     elif task == "search":
         engine.use_search_flag = True

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -1092,7 +1092,7 @@ class Dataset(object):
         :param set(str)|None used_data_keys:
         """
         if not batch_size:
-            raise Exception("batch_size must be set or greater than 0")
+            raise Exception("batch_size must be set and be greater than 0")
         batch_size = NumbersDict(batch_size)
         assert not batch_size.any_compare(NumbersDict(0), (lambda a, b: a <= b))
         max_pad_size = NumbersDict(max_pad_size)

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -1092,7 +1092,7 @@ class Dataset(object):
         :param set(str)|None used_data_keys:
         """
         if not batch_size:
-            batch_size = sys.maxsize
+            raise Exception("batch_size must be set or greater than 0")
         batch_size = NumbersDict(batch_size)
         assert not batch_size.any_compare(NumbersDict(0), (lambda a, b: a <= b))
         max_pad_size = NumbersDict(max_pad_size)

--- a/tests/test_TFEngine.py
+++ b/tests/test_TFEngine.py
@@ -1353,7 +1353,7 @@ def test_engine_end_layer(extra_rec_kwargs=None):
     engine.init_network_from_config(config=config)
     hdf_fn = _get_tmp_file(suffix=".hdf")
     os.remove(hdf_fn)  # forward_to_hdf expects that the file does not exist
-    engine.forward_to_hdf(data=dataset, output_file=hdf_fn)
+    engine.forward_to_hdf(data=dataset, output_file=hdf_fn, batch_size=5000)
 
     engine.finalize()
 
@@ -5260,7 +5260,7 @@ def test_attention_forward_hdf_then_unflatten_2d():
     assert len(att_output_layer.output.size_placeholder) == 2  # encoder and decoder time
     hdf_fn = _get_tmp_file(suffix=".hdf")
     os.remove(hdf_fn)  # forward_to_hdf expects that the file does not exist
-    att_engine.forward_to_hdf(output_file=hdf_fn, data=task_dataset, output_layer=att_output_layer)
+    att_engine.forward_to_hdf(output_file=hdf_fn, data=task_dataset, output_layer=att_output_layer, batch_size=5000)
 
     hdf_dataset = HDFDataset(files=[hdf_fn])
     hdf_dataset.initialize()


### PR DESCRIPTION
Using default value 0 is not a good idea. Also i had a job where i did not set the `forward_batch_size` and the job got stuck with default value 0. 