### PR TITLE
add type check to Tensor compare

### DIFF
--- a/returnn/frontend/math_.py
+++ b/returnn/frontend/math_.py
@@ -87,6 +87,15 @@ def compare(
     """
     from . import _utils as utils
 
+    if (not isinstance(a, (Tensor,) + tuple(_RawTensorTypes.__args__))) or (
+        not isinstance(b, (Tensor,) + tuple(_RawTensorTypes.__args__))
+    ):
+        if kind in ["equal", "=="]:
+            # for Tensor checks against other types than specified equality can never be given
+            return False
+        else:
+            raise TypeError("Unsupported compare type of %s and %s" % (str(a), str(b)))
+
     backend = utils.get_backend_from_tensors(a, b)
     out, a, b = utils.bin_op_out_template(
         backend,


### PR DESCRIPTION
There are cases where Tensor objects might be compared to other objects by value, using the backend compare operation for "==" would be wrong for such cases. E.g.:

```python
  File "/work/asr4/rossenbach/sisyphus_work_folders/tts_asr_2023_work/i6_core/tools/git/CloneGitRepositoryJob.Ki8uGd1mnLj6/output/repository/returnn/tf/network.py", line 1726, in <genexpr>
    line: if any(dim in layer_kwargs_flat_values for dim in dims):  # e.g. to operate on the axis
    locals:
      any = <builtin> <built-in function any>
      dim = <local> Dim{'audio_features_time'[B]}
      layer_kwargs_flat_values = <local> ['reduce', <TFNetwork '/mean_squared_difference' parent_layer=<InternalLayer 'mean_squared_difference' out_type=Data{[B]}> train=<tf.Tensor 'globals/train_flag:0' shape=() dtype=bool>>, Dim{F'reconstruction_dim'(80)}, 'mean', 'reduce', <TFNetwork '/mean_squared_difference' parent_layer=<InternalL..., len = 8, _[0]: {len = 6}
      dims = <not found>
  File "/work/asr4/rossenbach/sisyphus_work_folders/tts_asr_2023_work/i6_core/tools/git/CloneGitRepositoryJob.Ki8uGd1mnLj6/output/repository/returnn/tensor/_tensor_op_overloads.py", line 20, in _TensorOpOverloadsMixin.__eq__
    line: return _rf().compare(self, "==", other)
    locals:
      _rf = <global> <function _rf at 0x7f83b8879750>
      compare = <not found>
      self = <local> Data{'reduce_output', [T|'audio_features_time'[B],B]}
      other = <local> Dim{'audio_features_time'[B]}
```