### PR TITLE
preload_from_files for PT engine

### DIFF
--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -325,9 +325,11 @@ class Engine(EngineBase):
                     # Currently, this only supports single level dicts, but it could be extended if needed.
                     preload_model_state = preload_model_state[opts["checkpoint_key"]]
                 if opts.get("prefix", ""):
-                    # Only params with this prefix should be loaded. They are expected to be in the checkpoint without
-                    # this prefix. By adding the prefix to all params, we make sure that only params matching this
-                    # condition are loaded. This is in line with the behavior of the tf engine.
+                    # Only params with this prefix should be loaded.
+                    # They are expected to be in the checkpoint without this prefix.
+                    # By adding the prefix to all params,
+                    # we make sure that only params matching this condition are loaded.
+                    # This is in line with the behavior of the TF engine.
                     preload_model_state = {opts["prefix"] + key: value for key, value in preload_model_state.items()}
                 ignore_params = opts.get("ignore_params", [])
                 ignore_params_prefixes = opts.get("ignore_params_prefixes", [])

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -301,6 +301,10 @@ class Engine(EngineBase):
             is_first_train_epoch = epoch == 1 and (
                 is_training or self.config.value("task", "train") == "initialize_model"
             )
+            # we use the reversed sorted order here to achieve consistent behavior with the tf engine. There, the keys
+            # are used in sorted order but if a variable is loaded, it will not be considered anymore afterwards. So
+            # the first occurrence is used. Here, we overwrite variables even if they have been loaded before. In order
+            # to get consistent behavior, we use the reversed order.
             for preload_key, opts in reversed(sorted(preload_from_files.items())):
                 assert isinstance(opts, dict) and "filename" in opts
                 if opts.get("init_for_train", False):

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -301,10 +301,12 @@ class Engine(EngineBase):
             is_first_train_epoch = epoch == 1 and (
                 is_training or self.config.value("task", "train") == "initialize_model"
             )
-            # we use the reversed sorted order here to achieve consistent behavior with the tf engine. There, the keys
-            # are used in sorted order but if a variable is loaded, it will not be considered anymore afterwards. So
-            # the first occurrence is used. Here, we overwrite variables even if they have been loaded before. In order
-            # to get consistent behavior, we use the reversed order.
+            # We use the reversed sorted order here to achieve consistent behavior with the TF engine.
+            # There, the keys are used in sorted order but if a variable is loaded,
+            # it will not be considered anymore afterwards.
+            # So the first occurrence is used.
+            # Here, we overwrite variables even if they have been loaded before.
+            # In order to get consistent behavior, we use the reversed order.
             for preload_key, opts in reversed(sorted(preload_from_files.items())):
                 assert isinstance(opts, dict) and "filename" in opts
                 if opts.get("init_for_train", False):

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -301,10 +301,9 @@ class Engine(EngineBase):
                 print(f"Pre-load weights for key '{key}' from {opts['filename']}")
                 preload_model_state = torch.load(opts["filename"])
                 if opts.get("checkpoint_key", None) is not None:
-                  preload_model_state = preload_model_state[opts["checkpoint_key"]]
+                    preload_model_state = preload_model_state[opts["checkpoint_key"]]
                 if opts.get("prefix", ""):
-                    preload_model_state = {
-                        opts["prefix"] + key: value for key, value in preload_model_state.items()}
+                    preload_model_state = {opts["prefix"] + key: value for key, value in preload_model_state.items()}
                 strict = not opts.get("ignore_missing", False)
                 missing_keys, unexpected_keys = self._model.load_state_dict(preload_model_state, strict=strict)
                 print(f"Missing keys: {missing_keys}")

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -298,7 +298,9 @@ class Engine(EngineBase):
         elif preload_from_files:
             # see `preload_from_files` in tf engine and `returnn.tf.network.CustomCheckpointLoader`
             is_training = self.config.value("task", "train") == "train"
-            is_first_train_epoch = epoch == 1 and (is_training or self.config.value("task", "train") == "initialize_model")
+            is_first_train_epoch = epoch == 1 and (
+                is_training or self.config.value("task", "train") == "initialize_model"
+            )
             for key, opts in preload_from_files.items():
                 assert isinstance(opts, dict) and "filename" in opts
                 if opts.get("init_for_train", False):
@@ -316,7 +318,9 @@ class Engine(EngineBase):
                 ignore_params = opts.get("ignore_params", [])
                 ignore_params_prefixes = opts.get("ignore_params_prefixes", [])
                 for key in list(preload_model_state.keys()):
-                    if key in ignore_params or any([key.startswith(ignore_key) for ignore_key in ignore_params_prefixes]):
+                    if key in ignore_params or any(
+                        [key.startswith(ignore_key) for ignore_key in ignore_params_prefixes]
+                    ):
                         print(f"Ignoring variable {key}", file=log.v3)
                         preload_model_state.pop(key)
                 for new_name, name_in_checkpoint in opts.get("var_name_mapping", {}).items():

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -318,6 +318,11 @@ class Engine(EngineBase):
                 print(f"Pre-load weights for key '{preload_key}' from {opts['filename']}", file=log.v3)
                 preload_model_state = torch.load(opts["filename"])
                 if opts.get("checkpoint_key", None) is not None:
+                    # This can be used if an external checkpoint saves a checkpoint a different structure that just the
+                    # model state dict. E.g., if a checkpoint is created using
+                    # `torch.save({"model": model.state_dict(), "optimizer": optimizer.state)_dict(), ...})`
+                    # we can set checkpoint_key = "model" to load the model.
+                    # Currently, this only supports single level dicts, but it could be extended if needed.
                     preload_model_state = preload_model_state[opts["checkpoint_key"]]
                 if opts.get("prefix", ""):
                     preload_model_state = {opts["prefix"] + key: value for key, value in preload_model_state.items()}


### PR DESCRIPTION
As discussed in https://github.com/rwth-i6/returnn/issues/1120, `preload_from_files` or something equivalent should be added for the PT engine as well. This is certainly not complete, but could be helpful as a starting point. It works as a proof-of-concept to load a wav2vec 2.0 checkpoint.

What do you think in general?