### PR TITLE
RF: cross_entropy, implemented for torch

### DIFF
--- a/returnn/frontend/__init__.py
+++ b/returnn/frontend/__init__.py
@@ -20,6 +20,7 @@ from .const import *
 from .dims import *
 from .dtype import *
 from .linear import *
+from .loss import *
 from .math_ import *
 from .matmul import *
 from .parameter import *

--- a/returnn/frontend/_backend.py
+++ b/returnn/frontend/_backend.py
@@ -276,6 +276,18 @@ class Backend(Generic[T]):
         raise NotImplementedError
 
     @staticmethod
+    def softmax_cross_entropy_with_logits(logits: Tensor, targets: Tensor, axis: Dim):
+        """
+        Efficient cross entropy.
+
+        :param logits: target estimates given as inputs to softmax (i.e. unnormalized)
+        :param targets: probabilities, i.e. normalized, can also be sparse
+        :param axis: class labels dim over which softmax is computed
+        :return: cross entropy (same Dims as 'logits' but without 'axis')
+        """
+        raise NotImplementedError
+
+    @staticmethod
     def sequence_mask_raw(lengths: T, *, batch_major: bool = True) -> T:
         """
         Like tf.sequence_mask().

--- a/returnn/frontend/loss.py
+++ b/returnn/frontend/loss.py
@@ -1,0 +1,49 @@
+"""
+Loss functions
+"""
+
+from returnn.tensor import Tensor, Dim
+import returnn.frontend as rf
+
+
+def cross_entropy(
+    *,
+    estimated: Tensor,
+    target: Tensor,
+    axis: Dim,
+    estimated_type: str,
+) -> Tensor:
+    """
+    ``target`` is supposed to be in probability space (normalized). It can also be sparse, i.e. contain class indices.
+    ``estimated`` can be probs, log-probs or logits, specified via ``estimated_type``.
+
+    Assuming both are in probability space, the cross entropy is:
+
+        H(target,estimated) = -reduce_sum(target * log(estimated), axis=axis)
+                            = -matmul(target, log(estimated), reduce=axis)
+
+    In case you want label smoothing, you can use e.g.::
+
+        ce = nn.cross_entropy(
+            target=nn.label_smoothing(target, 0.1),
+            estimated=estimated)
+
+    :param estimated: probs, log-probs or logits, specified via ``estimated_type``
+    :param target: probs, normalized, can also be sparse
+    :param axis: class labels dim over which softmax is computed
+    :param estimated_type: "probs", "log-probs" or "logits"
+    :return: cross entropy (same Dims as 'estimated' but without 'axis')
+    """
+
+    if estimated_type == "logits":
+        # This is a common case and most backends provide optimized functions for it.
+        return estimated._raw_backend.softmax_cross_entropy_with_logits(logits=estimated, targets=target, axis=axis)
+    if estimated_type == "probs":
+        log_prob = rf.log(estimated)  # TODO: make numerically stable
+    elif estimated_type == "log-probs":
+        log_prob = estimated
+    else:
+        raise ValueError("estimated_type must be 'probs', 'log-probs' or 'logits'")
+    if target.sparse_dim:
+        return -rf.gather(log_prob, indices=target, axis=axis)
+    return -rf.matmul(target, log_prob, reduce=axis)


### PR DESCRIPTION
@albertz asked for this, so already sharing.

The most important case `estimated_type="logits"` seems to work, see tests. But it's not yet complete, other `estimated_type`s don't work yet (sparse would need implementation of `gather`). Also, the case of additional dims other than batch and class label dim is not tested. Will continue tomorrow...