### PR TITLE
Fix Error Messages

### DIFF
--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -323,7 +323,7 @@ class _TensorMixin(_TensorMixinBase):
                     continue  # we allow anything in the placeholder
                 if raw_shape[i] != self.batch_shape[i]:
                     raise Exception(
-                        f"Mismatching shape: Raw tensor {self._raw_tensor.shape} vs Tensor {self};\n"
+                        f"Mismatching shape: Raw tensor {raw_shape} vs Tensor {self};\n"
                         + backend.format_graph_output(self._raw_tensor, max_depth=3)
                     )
             backend.set_known_shape_raw(self._raw_tensor, self.batch_shape)

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -323,7 +323,7 @@ class _TensorMixin(_TensorMixinBase):
                     continue  # we allow anything in the placeholder
                 if raw_shape[i] != self.batch_shape[i]:
                     raise Exception(
-                        f"Mismatching shape: Raw tensor {self._raw_tensor} vs Tensor {self};\n"
+                        f"Mismatching shape: Raw tensor {self._raw_tensor.shape} vs Tensor {self};\n"
                         + backend.format_graph_output(self._raw_tensor, max_depth=3)
                     )
             backend.set_known_shape_raw(self._raw_tensor, self.batch_shape)

--- a/returnn/tf/engine.py
+++ b/returnn/tf/engine.py
@@ -774,7 +774,7 @@ class Runner(object):
             self._print_finish_process()
 
             if not hvd_stop and not self.data_provider.have_reached_end():
-                raise Exception("Did not successfully reached the end of the dataset.")
+                raise Exception("Did not successfully reach the end of the dataset.")
 
             if self._should_train:
                 final_global_train_step = self.engine.network.get_global_train_step(session=sess)


### PR DESCRIPTION
When I got the exception for mismatching shapes of raw tensor vs. tensor, the printed output was very large and I guess just the shape is needed, right? The other change is just a typo.