### PR TITLE
fix: Correct assertion on HDF data dtype

### DIFF
--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -519,7 +519,7 @@ class FeatureSequenceStreamParser(StreamParser):
                 self.dtype = str(seq_data.dtype)
 
             assert seq_data.shape[1] == self.num_features
-            assert seq_data.dtype == self.dtype
+            assert str(seq_data.dtype) == self.dtype
 
         self.feature_type = 2
 


### PR DESCRIPTION
We convert the dtype to `str` but then in the assertion try comparing for equality with the original, uncoverted type. This assertion triggered for me even though it does not seem right.