### PR TITLE
Dim ceildiv nicer description

### DIFF
--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -2221,6 +2221,8 @@ class _OpMultTerm:
                 raise ValueError("invalid kind %r" % (kind,))
         if kind == "floordiv" and right:
             description = "%s//%s" % (_get_description(numerator), _get_description(denominator))
+        elif kind == "ceildiv" and right:
+            description = "⌈%s/%s⌉" % (_get_description(numerator), _get_description(denominator))
         else:
             description = "%s_%s(%s, %s)" % (
                 kind,

--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -457,6 +457,9 @@ def get_valid_scope_name_from_str(s):
     # because this name is used e.g. for layers, and you might introduce incompatibility by changes here.
     import re
 
+    # remove all unicode chars
+    s = "".join([c for c in s if ord(c) < 128])
+
     s = re.sub("[:(){}&+\\-*'\" ,]", "__", s)
     if s[:1] in "_-\\/":  # invalid first chars
         s = (".%i." % ord(s[0])) + s[1:]


### PR DESCRIPTION
Changes the old `ceildiv_right(a, b)` to `⌈a/b⌉`.

Example: `conv dim: Dim{'⌈(-1+time+-2)/3⌉'[B]} time dim: Dim{'time'[B]}`