### PR TITLE
PT weight_decay fix for shared params

### DIFF
--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -9,6 +9,7 @@ import torch
 import typing
 
 from returnn.log import log
+from returnn.util.basic import RefIdEq
 
 _OptimizerClassesDictInitialized = False
 _OptimizerClassesDict = {}
@@ -242,12 +243,13 @@ class Updater(object):
         no_wd_params = set()
         blacklist_wd_modules = (torch.nn.LayerNorm, torch.nn.Embedding)
         # Tracker of visited parameters to only add each parameter once, in case two modules share common parameters.
-        visited_params = set()
+        # We need the wrapper class RefIdEq because Parameters are compared by value and not by reference.
+        visited_params: typing.Set[RefIdEq[torch.nn.Parameter]] = set()
         for mn, m in self.network.named_modules():
             for pn, p in m.named_parameters():
-                if p in visited_params:
+                if RefIdEq(p) in visited_params:
                     continue
-                visited_params.add(p)
+                visited_params.add(RefIdEq(p))
                 fpn = "%s.%s" % (mn, pn) if mn else pn  # Full param name
                 if pn.endswith("bias"):
                     no_wd_params.add(fpn)

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -241,8 +241,13 @@ class Updater(object):
         wd_params = set()
         no_wd_params = set()
         blacklist_wd_modules = (torch.nn.LayerNorm, torch.nn.Embedding)
+        # Tracker of visited parameters to only add each parameter once, in case two modules share common parameters.
+        visited_params = set()
         for mn, m in self.network.named_modules():
             for pn, p in m.named_parameters():
+                if p in visited_params:
+                    continue
+                visited_params.add(p)
                 fpn = "%s.%s" % (mn, pn) if mn else pn  # Full param name
                 if pn.endswith("bias"):
                     no_wd_params.add(fpn)

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import torch
 import typing
+from typing import Set
 
 from returnn.log import log
 from returnn.util.basic import RefIdEq

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -245,7 +245,7 @@ class Updater(object):
         blacklist_wd_modules = (torch.nn.LayerNorm, torch.nn.Embedding)
         # Tracker of visited parameters to only add each parameter once, in case two modules share common parameters.
         # We need the wrapper class RefIdEq because Parameters are compared by value and not by reference.
-        visited_params: typing.Set[RefIdEq[torch.nn.Parameter]] = set()
+        visited_params: Set[RefIdEq[torch.nn.Parameter]] = set()
         for mn, m in self.network.named_modules():
             for pn, p in m.named_parameters():
                 if RefIdEq(p) in visited_params:


### PR DESCRIPTION
Should only add one parameter to the weight decay set if two or more modules share common parameters.

Fix #1319.
