### PR TITLE
PyTorch DistributedDataParallel Multi-GPU training

### DIFF
--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -397,6 +397,11 @@ def finalize(error_occurred=False):
                 import horovod.tensorflow as hvd  # noqa
 
                 hvd.shutdown()
+        elif BackendEngine.is_torch_selected():
+            if config.typed_value("torch_distributed") is not None:
+                from torch.distributed import destroy_process_group
+
+                destroy_process_group()
 
 
 def need_data():

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -335,6 +335,7 @@ def init_backend_engine():
             returnn.tf.distributed.init_distributed_tf(config)
     elif BackendEngine.is_torch_selected():
         if config.is_true("use_DDP"):
+            # initializes the distributed backend which will take care of sychronizing nodes/GPUs
             from torch.distributed import init_process_group
             init_process_group("nccl")
         print("PyTorch:", util.describe_torch_version(), file=log.v3)

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -337,6 +337,7 @@ def init_backend_engine():
         if config.is_true("use_DDP"):
             # initializes the distributed backend which will take care of sychronizing nodes/GPUs
             from torch.distributed import init_process_group
+
             init_process_group("nccl")
         print("PyTorch:", util.describe_torch_version(), file=log.v3)
     else:

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -334,6 +334,9 @@ def init_backend_engine():
 
             returnn.tf.distributed.init_distributed_tf(config)
     elif BackendEngine.is_torch_selected():
+        if config.is_true("use_DDP"):
+            from torch.distributed import init_process_group
+            init_process_group("nccl")
         print("PyTorch:", util.describe_torch_version(), file=log.v3)
     else:
         raise NotImplementedError

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -336,6 +336,7 @@ def init_backend_engine():
         if config.typed_value("torch_distributed") is not None:
             import socket
             import returnn.torch.distributed
+
             torch_distributed = returnn.torch.distributed.get_ctx(config=config)
             print(
                 "Torch: Hostname %s, pid %i, using GPU %s."
@@ -508,12 +509,12 @@ def execute_main_task():
         engine.init_network_from_config(config)
         engine.web_server(port=config.int("web_server_port", 12380))
     elif task.startswith("config:"):
-        action = config.typed_dict[task[len("config:"):]]
+        action = config.typed_dict[task[len("config:") :]]
         print("Task: %r" % action, file=log.v1)
         assert callable(action)
         action()
     elif task.startswith("optional-config:"):
-        action = config.typed_dict.get(task[len("optional-config:"):], None)
+        action = config.typed_dict.get(task[len("optional-config:") :], None)
         if action is None:
             print("No task found for %r, so just quitting." % task, file=log.v1)
         else:

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -18,6 +18,7 @@ __license__ = "RWTHOCR"
 __maintainer__ = "Patrick Doetsch"
 __email__ = "doetsch@i6.informatik.rwth-aachen.de"
 
+
 import os
 import sys
 import time

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -245,9 +245,10 @@ class Dataset(object):
 
             if returnn.tf.horovod.get_ctx().is_dataset_distribution_random_seed_offset():
                 return returnn.tf.horovod.get_ctx().rank() * 16127
-        
+
         if config.is_true("use_DDP"):
             import torch.distributed as dist
+
             return dist.get_rank() * 16127
         return 0
 

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -246,10 +246,10 @@ class Dataset(object):
             if returnn.tf.horovod.get_ctx().is_dataset_distribution_random_seed_offset():
                 return returnn.tf.horovod.get_ctx().rank() * 16127
 
-        if config.is_true("use_DDP"):
-            import torch.distributed as dist
+        if config.typed_value("torch_distributed") is not None:
+            import returnn.torch.distributed
 
-            return dist.get_rank() * 16127
+            return returnn.torch.distributed.get_ctx().rank() * 16127
         return 0
 
     @staticmethod

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -245,6 +245,10 @@ class Dataset(object):
 
             if returnn.tf.horovod.get_ctx().is_dataset_distribution_random_seed_offset():
                 return returnn.tf.horovod.get_ctx().rank() * 16127
+        
+        if config.is_true("use_DDP"):
+            import torch.distributed as dist
+            return dist.get_rank() * 16127
         return 0
 
     @staticmethod

--- a/returnn/log.py
+++ b/returnn/log.py
@@ -192,6 +192,15 @@ class Log:
                 fn_ext = ".horovod-%i-%i%s" % (hvd.rank(), hvd.size(), fn_ext)
                 new_logs.append(fn_prefix + fn_ext)
             logs = new_logs
+        
+        if config.is_true("use_DDP"):
+            new_logs = []
+            for fn in logs:
+                fn_prefix, fn_ext = os.path.splitext(fn)
+                fn_ext = ".nccl-%i-%i%s" % (int(os.environ['LOCAL_RANK']), int(os.environ['WORLD_SIZE']), fn_ext)
+                new_logs.append(fn_prefix + fn_ext)
+            logs = new_logs
+
         self.initialize(logs=logs, verbosity=log_verbosity, formatter=log_format)
 
     def print_warning(self, text, prefix_text="WARNING:", extra_text=None):

--- a/returnn/log.py
+++ b/returnn/log.py
@@ -193,11 +193,14 @@ class Log:
                 new_logs.append(fn_prefix + fn_ext)
             logs = new_logs
 
-        if config.is_true("use_DDP"):
+        if config.typed_value("torch_distributed") is not None:
+            import returnn.torch.distributed
+
+            torch_distributed = returnn.torch.distributed.get_ctx(config=config)
             new_logs = []
             for fn in logs:
                 fn_prefix, fn_ext = os.path.splitext(fn)
-                fn_ext = ".nccl-%i-%i%s" % (int(os.environ["LOCAL_RANK"]), int(os.environ["WORLD_SIZE"]), fn_ext)
+                fn_ext = ".torch-distrib-%i-%i%s" % (torch_distributed.rank(), torch_distributed.size(), fn_ext)
                 new_logs.append(fn_prefix + fn_ext)
             logs = new_logs
 

--- a/returnn/log.py
+++ b/returnn/log.py
@@ -192,12 +192,12 @@ class Log:
                 fn_ext = ".horovod-%i-%i%s" % (hvd.rank(), hvd.size(), fn_ext)
                 new_logs.append(fn_prefix + fn_ext)
             logs = new_logs
-        
+
         if config.is_true("use_DDP"):
             new_logs = []
             for fn in logs:
                 fn_prefix, fn_ext = os.path.splitext(fn)
-                fn_ext = ".nccl-%i-%i%s" % (int(os.environ['LOCAL_RANK']), int(os.environ['WORLD_SIZE']), fn_ext)
+                fn_ext = ".nccl-%i-%i%s" % (int(os.environ["LOCAL_RANK"]), int(os.environ["WORLD_SIZE"]), fn_ext)
                 new_logs.append(fn_prefix + fn_ext)
             logs = new_logs
 

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -59,7 +59,7 @@ class DistributedContext:
 
 
 _is_set_up = False
-_ctx = None  # type: typing.Optional[HorovodContext]
+_ctx = None  # type: Optional[DistributedContext]
 
 
 def get_ctx(config=None):

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -1,0 +1,135 @@
+import os
+import socket
+
+from contextlib import contextmanager
+import torch
+from torch.distributed.algorithms.join import Join
+
+from returnn.config import Config
+import returnn.frontend as rf
+
+
+class DistributedContext:
+    """
+    This class setups some helper functions for torch distributed training
+    """
+
+    def __init__(self, config):
+        """
+        :param Config config:
+        """
+        import torch.distributed as dist
+
+        dist.init_process_group("nccl")
+
+        self._config = config
+        self._local_rank = os.environ["LOCAL_RANK"]
+        self._local_size = os.environ["LOCAL_WORLD_SIZE"]
+        self._rank = dist.get_rank()
+        self._size = dist.get_world_size()
+
+        print(
+            "Torch distributed initialized. Hostname %s, pid %i, rank %i / size %i, local rank %s / local size %s."
+            % (socket.gethostname(), os.getpid(), self._rank, self._size, self._local_rank, self._local_size)
+        )
+
+    def local_rank(self):
+        """
+        :rtype: int
+        """
+        return self._local_rank
+
+    def rank(self):
+        """
+        :rtype: int
+        """
+        return self._rank
+
+    def size(self):
+        """
+        :rtype: int
+        """
+        return self._size
+
+
+_is_set_up = False
+_ctx = None  # type: typing.Optional[HorovodContext]
+
+
+def get_ctx(config=None):
+    """
+    :param Config|None config:
+    :returns: the global context if Torch distributed is enabled, or None otherwise.
+      If we did not setup the context yet, it will automatically create it.
+    :rtype: DistributedContext|None
+    """
+    global _is_set_up, _ctx
+    if _is_set_up:
+        return _ctx
+    if not config:
+        from returnn.config import get_global_config
+
+        config = get_global_config(raise_exception=False)
+        if not config:
+            return None
+    _is_set_up = True
+    if config.typed_value("torch_distributed") is None:
+        return None
+    _ctx = DistributedContext(config=config)
+    return _ctx
+
+
+@contextmanager
+def _ddp_ctx(pt_model):
+    # the original (unwrapped) module is passed to the train step, therefore here we set up the right context
+    # as what DistributedDataParallel.forward does internally
+    if torch.is_grad_enabled() and pt_model.require_backward_grad_sync:
+        assert pt_model.logger is not None
+        pt_model.logger.set_runtime_stats_and_log()
+        pt_model.num_iterations += 1
+        pt_model.reducer.prepare_for_forward()
+
+    with torch.autograd.profiler.record_function("DistributedDataParallel.forward"):
+        if torch.is_grad_enabled() and pt_model.require_backward_grad_sync:
+            assert pt_model.logger is not None
+            pt_model.logger.set_runtime_stats_and_log()
+            pt_model.num_iterations += 1
+            pt_model.reducer.prepare_for_forward()
+
+        work = Join.notify_join_context(pt_model)
+        if work:
+            pt_model.reducer._set_forward_pass_work_handle(
+                work, pt_model._divide_by_initial_world_size  # type: ignore[arg-type]
+            )
+
+        if torch.is_grad_enabled() and pt_model.reducer._rebuild_buckets():
+            pt_model._has_rebuilt_buckets = True
+
+        if pt_model._check_sync_bufs_pre_fwd():
+            pt_model._sync_buffers()
+
+        if pt_model._join_config.enable:
+            # Notify joined ranks whether they should sync in backwards pass or not.
+            pt_model._check_global_requires_backward_grad_sync(is_joined_rank=False)
+        with pt_model._inside_ddp_forward():
+            yield
+
+        if pt_model._check_sync_bufs_post_fwd():
+            pt_model._sync_buffers()
+
+        if torch.is_grad_enabled() and pt_model.require_backward_grad_sync:
+            pt_model.require_forward_param_sync = True
+            # We'll return the output object verbatim since it is a freeform
+            # object. We need to find any tensors in this object, though,
+            # because we need to figure out which parameters were used during
+            # this forward pass, to ensure we short circuit reduction for any
+            # unused parameters. Only if `find_unused_parameters` is set.
+            if pt_model.find_unused_parameters and not pt_model.static_graph:
+                # Do not need to populate this for static graph.
+                train_ctx = rf.get_run_ctx()
+                loss = list(train_ctx.losses.values())[0].loss.raw_tensor
+                pt_model.reducer.prepare_for_backward(list(torch.nn.parallel.distributed._find_tensors(loss)))
+            else:
+                pt_model.reducer.prepare_for_backward([])
+        else:
+            pt_model.require_forward_param_sync = False

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -79,8 +79,24 @@ def get_ctx(config=None):
     return _ctx
 
 
+def get_device_ids():
+    # It depends on the specific setup what to return here,
+    # how CUDA_VISIBLE_DEVICES is set up, etc.
+    # This is currently a reasonable assumption
+    # but we might extend the logic later,
+    # or make it configurable.
+    return [get_local_rank()]
+
+
+def get_local_rank():
+    # torch.distributed does not seem to provide a function for this.
+    # Via mpirun (OpenMPI), this env variable would be set.
+    # It should fail with an error otherwise.
+    return int(os.environ["LOCAL_RANK"])
+
+
 @contextmanager
-def _ddp_ctx(pt_model):
+def ddp_train_forward_ctx(pt_model):
     # the original (unwrapped) module is passed to the train step, therefore here we set up the right context
     # as what DistributedDataParallel.forward does internally
     if torch.is_grad_enabled() and pt_model.require_backward_grad_sync:

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -128,7 +128,7 @@ def ddp_train_forward_ctx(pt_model):
         if work:
             # noinspection PyProtectedMember
             pt_model.reducer._set_forward_pass_work_handle(
-                work, pt_model._divide_by_initial_world_size  # type: ignore[arg-type]
+                work, pt_model._divide_by_initial_world_size
             )
 
         # noinspection PyProtectedMember
@@ -166,6 +166,7 @@ def ddp_train_forward_ctx(pt_model):
                 # Do not need to populate this for static graph.
                 train_ctx = rf.get_run_ctx()
                 loss = list(train_ctx.losses.values())[0].loss.raw_tensor
+                # noinspection PyProtectedMember
                 pt_model.reducer.prepare_for_backward(list(torch.nn.parallel.distributed._find_tensors(loss)))
             else:
                 pt_model.reducer.prepare_for_backward([])

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -1,3 +1,9 @@
+"""
+torch.distributed utils
+"""
+
+from __future__ import annotations
+from typing import Optional
 import os
 import socket
 

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -8,6 +8,7 @@ from typing import Optional, Union, Callable, Dict
 import os
 import torch
 import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.utils.data.datapipes as dp
 from torchdata.dataloader2 import DataLoader2
 from random import random
@@ -107,6 +108,9 @@ class Engine(EngineBase):
         self._load_model(epoch=self._start_epoch)
         self._save_model_epoch_interval = config.int("save_interval", 1)
 
+        if self._use_DDP:
+            # wrap the model use DDP
+            self._pt_model = DDP(self._pt_model, device_ids=[self._device])
         self._updater = Updater(self.config, self._pt_model, self.learning_rate)
         self._updater.create_optimizer()
         if self._start_epoch > 1:

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -215,7 +215,12 @@ class Engine(EngineBase):
 
         while True:
             data = next(data_iter, None)
+            # WARNING: torch.distributed works only for the registered device,
+            # as it uses only one mechanism for communication, like NCCL.
+            # This is suboptimal here as we have the roundtrip CPU -> GPU -> NCCL -> GPU -> CPU.
+            # TODO: Use more direct CPU -> Ethernet -> CPU communication.
             _has_data = torch.tensor([data is not None], dtype=torch.int8).to(self._device)
+
             if self._use_torch_distributed:
                 # use all reduce to check if all workers have data, if at least one worker does not have data,
                 # all workers finish this epoch

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -231,7 +231,6 @@ class Engine(EngineBase):
 
             step_begin_time = time.time()
             self._run_step(data, train_flag=True)
-            elapsed_computation_time += time.time() - step_begin_time
 
             train_ctx = rf.get_run_ctx()
 
@@ -272,6 +271,8 @@ class Engine(EngineBase):
                     self._grad_scaler.update()
                 else:
                     self._updater.get_optimizer().step()
+
+            elapsed_computation_time += time.time() - step_begin_time
 
             accumulated_losses_dict += losses_dict
             accumulated_inv_norm_factors_dict += inv_norm_factors_dict

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -173,8 +173,12 @@ class Engine(EngineBase):
             self._run_step(data, train_flag=True)
 
             train_ctx = rf.get_run_ctx()
+            
             # scale the loss to account for gradient accumulation
-            train_ctx.losses = {name:loss/self._gradient_accumulation_steps for name, loss in train_ctx.losses.items()}
+            if self._use_DDP and self._gradient_accumulation_steps > 1:
+                for loss_name in train_ctx.losses.keys():
+                    train_ctx.losses[loss_name].loss /= self._gradient_accumulation_steps
+
             total_loss = train_ctx.total_loss()
             losses_dict = NumbersDict(
                 {

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -78,8 +78,6 @@ class Engine(EngineBase):
         assert config is self.config
         super().init_train_from_config(config=config)
         if self._use_DDP:
-            # initializes the distributed backend which will take care of sychronizing nodes/GPUs
-            init_process_group("nccl")
             ddp_local_rank = int(os.environ['LOCAL_RANK'])
             print(f"Start running basic DDP example on local rank {ddp_local_rank}.", file=log.v2)
             self._device = f'cuda:{ddp_local_rank}'

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -71,6 +71,7 @@ class Engine(EngineBase):
         self._torch_distributed_class = None  # type: Optional[Callable]
         self._torch_distributed_options = None  # type: Optional[dict]
         self._ddp_pt_model = None  # type: Optional[torch.nn.Module]
+        self._accum_grad_multiple_step = config.int("accum_grad_multiple_step", 1)
 
         torch_distributed = config.typed_value("torch_distributed")
         if torch_distributed is not None:
@@ -166,8 +167,6 @@ class Engine(EngineBase):
 
         self._train_step_func = self.config.typed_value("train_step")
         assert self._train_step_func, "train_step not defined"
-
-        self._accum_grad_multiple_step = config.int("accum_grad_multiple_step", 1)
 
     def train(self):
         """

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -76,13 +76,13 @@ class Engine(EngineBase):
         """
         assert config is self.config
         super().init_train_from_config(config=config)
-        self._use_DDP = int(os.environ.get('RANK', -1)) != -1
-        if self._use_DDP:
+        if config.is_true("use_DDP"):
             # initializes the distributed backend which will take care of sychronizing nodes/GPUs
             init_process_group("nccl")
             ddp_local_rank = int(os.environ['LOCAL_RANK'])
             print(f"Start running basic DDP example on local rank {ddp_local_rank}.", file=log.v2)
             self._device = f'cuda:{ddp_local_rank}'
+            self._use_DDP = True
 
         self.train_dataset = train_data
         self.eval_datasets.clear()


### PR DESCRIPTION
For PyTorch (#1120).

1. Multi GPU training with `DistributedDataParallel`
2. Gradient accumulation
3. Add elapsed training time for each sub-epoch

Fix #1332.

Question: how do we set the multi-GPU flag in the returnn config?  I saw for the automated mix precision, the opts dict should be defined in the returnn config. Should I also use a dict opts for the DistributedDataParallel in the returnn config? So that we can define parameters like `bucket_cap_mb`, `find_unused_parameters` in the opts dict?
