### PR TITLE
Reuse global batch dim

### DIFF
--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -436,6 +436,8 @@ class _DimMixin:
             # We ignore the ctx for the batch dim currently.
             if self.batch == batch:
                 return self
+            if batch.is_global_batch():
+                return _d.batch_dim  # reuse global batch dim if possible
             return _d.Dim(kind=DimTypes.Batch, description="batch:%s" % batch.short_repr(), batch=batch, dimension=None)
         if not self.is_dynamic():
             # If static dim, no effect.

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -1540,13 +1540,13 @@ class _DimMixin:
                 assert self_base_extra.derived_from_tag == base
             else:
                 self_base_extra.derived_from_tag = base
-        if not self.batch and base.batch:
-            self.batch = base.batch
-            self.control_flow_ctx = base.control_flow_ctx
-            key = base.batch, base.control_flow_ctx
-            assert key not in self_base_extra.same_for_batch_ctx
-            self_base_extra.same_for_batch_ctx[key] = self
         if self.is_dynamic() or not self.is_dim_known():
+            if not self.batch and base.batch:
+                self.batch = base.batch
+                self.control_flow_ctx = base.control_flow_ctx
+                key = base.batch, base.control_flow_ctx
+                assert key not in self_base_extra.same_for_batch_ctx
+                self_base_extra.same_for_batch_ctx[key] = self
             if not self.dyn_size_ext:
                 if base.dyn_size_ext:
                     if base.batch and base.batch == self.batch and base.control_flow_ctx == self.control_flow_ctx:

--- a/returnn/tf/frontend_layers/config_entry_points.py
+++ b/returnn/tf/frontend_layers/config_entry_points.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Dict, Tuple
 from tensorflow.python.util import nest
 from returnn.util.basic import BehaviorVersion
-from returnn.tensor import TensorDict, Tensor, Dim
+from returnn.tensor import TensorDict, Tensor, Dim, batch_dim
 from returnn.config import get_global_config
 import returnn.frontend as rf
 from .. import frontend_layers as rfl
@@ -109,5 +109,10 @@ def get_net_dict(
                 elem.dyn_size_ext.raw_tensor = None
         return elem
 
-    net_dict = nest.map_structure(_cleanup_net_dict_value, net_dict)
+    # Do some cleanup.
+    nest.map_structure(_cleanup_net_dict_value, net_dict)
+    _cleanup_net_dict_value(batch_dim)
+    for data in extern_data.data.values():
+        for dim in data.dims:
+            _cleanup_net_dict_value(dim)
     return net_dict, model

--- a/returnn/tf/layers/variable.py
+++ b/returnn/tf/layers/variable.py
@@ -154,9 +154,9 @@ class VariableLayer(LayerBase):
                 0, Dim(kind=Dim.Types.Time, description="%s:dummy-time" % name, dimension=1, auto_generated=True)
             )
         if add_batch_axis:
-            dim_tags.insert(
-                0, Dim(kind=Dim.Types.Batch, description="batch", batch=network.get_global_batch_info(), dimension=None)
-            )
+            from returnn.tensor.dim import batch_dim
+
+            dim_tags.insert(0, batch_dim)
         return Tensor(
             name="%s_output" % name,
             dim_tags=dim_tags,

--- a/tests/rf_utils.py
+++ b/tests/rf_utils.py
@@ -8,6 +8,7 @@ import contextlib
 import re
 import numpy
 import numpy.testing
+import tensorflow as tf
 
 from returnn.config import Config, global_config_ctx
 from returnn.util.pprint import pprint
@@ -88,7 +89,7 @@ def run_model(
 
 def run_model_torch(extern_data: TensorDict, get_model: rf.GetModelFunc, forward_step: rf.StepFunc) -> TensorDict:
     """run"""
-    extern_data_raw = extern_data.as_raw_tensor_dict()
+    extern_data_raw = extern_data.as_raw_tensor_dict(expected_type=numpy.ndarray)
     rf.select_backend_torch()
     rf.set_random_seed(42)
 
@@ -110,7 +111,7 @@ def run_model_torch(extern_data: TensorDict, get_model: rf.GetModelFunc, forward
 
 def run_model_net_dict_tf(extern_data: TensorDict, get_model: rf.GetModelFunc, forward_step: rf.StepFunc) -> TensorDict:
     """run"""
-    extern_data_raw = extern_data.as_raw_tensor_dict()
+    extern_data_raw = extern_data.as_raw_tensor_dict(expected_type=numpy.ndarray)
     extern_data.reset_content()
     rf.select_backend_returnn_layers_tf()
     rf.set_random_seed(42)
@@ -158,9 +159,9 @@ def run_model_net_dict_tf(extern_data: TensorDict, get_model: rf.GetModelFunc, f
             layer = net.get_layer(layer_name)
             outputs_tf.data[k] = layer.output.copy()
 
-        fetches = outputs_tf.as_raw_tensor_dict()
+        fetches = outputs_tf.as_raw_tensor_dict(expected_type=tf.Tensor)
         assert set(extern_data.data.keys()) == set(net.extern_data.data.keys())
-        extern_data_tf_placeholders = net.extern_data.as_raw_tensor_dict()
+        extern_data_tf_placeholders = net.extern_data.as_raw_tensor_dict(expected_type=tf.Tensor)
         assert set(extern_data_tf_placeholders.keys()) == set(extern_data_raw.keys())
         feed_dict = {extern_data_tf_placeholders[k]: v for k, v in extern_data_raw.items()}
 

--- a/tests/test_TFNetworkLayer.py
+++ b/tests/test_TFNetworkLayer.py
@@ -7823,6 +7823,8 @@ def test_SliceNdLayer():
     size = 5
     with make_scope() as session:
         net = TFNetwork(extern_data=ExternData())
+        batch = BatchInfo.make_global_batch_info(tf.constant(n_batch))
+        net.extern_data.set_batch_info(batch)
         src = InternalLayer(name="src", network=net, output=Data(name="src", dim=n_dim))
         src.output.placeholder = tf.constant(seqs)
         src.output.size_placeholder = {0: tf.constant(seq_lens)}
@@ -9295,6 +9297,7 @@ def test_PostfixInTimeLayer():
 
         net = TFNetwork(extern_data=ExternData())
         batch = BatchInfo.make_global_batch_info(tf.constant(2))
+        net.extern_data.set_batch_info(batch)
         src = InternalLayer(name="src", network=net, output=Data(name="src", dim=2, dtype="int32", batch=batch))
         src_seqs = np.array([[[1, 1], [2, 2], [3, 3], [4, 4], [5, 5]], [[6, 6], [7, 7], [8, 8], [0, 0], [0, 0]]])
         src_seq_lens = [5, 3]


### PR DESCRIPTION
https://github.com/rwth-i6/returnn/issues/1333#issuecomment-1563052008
https://github.com/rwth-i6/returnn/issues/1333#issuecomment-1590965034

It was mentioned that the recreation of the batch dim was unexpected and caused problems because in PyTorch engine, we would set the `dyn_size_ext` of the batch dim, and otherwise not use the batch info mechanism, so a separate instance of such dim tag would not correctly have the `dyn_size_ext`. The recreation happens here: https://github.com/rwth-i6/returnn/blob/04c14d6a3745f90f0bd10b28ce4d51b1d61afb82/returnn/tensor/_tensor_extra.py#L3577

This is only for `model_outputs`.

It is anyway a bit bad that we have all that special handling for batch dim tags, so that the behavior depends so much on the dim tag type.
