### PR TITLE
Min and max seq len for Pytorch

### DIFF
--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -240,3 +240,40 @@ class BatchingIterDataPipe(torch.utils.data.IterDataPipe):
 
         if current_batch:
             yield current_batch
+
+
+class LenFilterDataPipe(torch.utils.data.IterDataPipe):
+    """
+    Removes sequences which are either too long or too short from a dataset
+    Returns dataset yielding list of data lengths within the defined range
+    """
+
+    def __init__(self, dataset: torch.utils.data.IterableDataset,
+        min_seq_len: Union[int, NumbersDict] = None,
+        max_seq_len: Union[int, NumbersDict] = None):
+        """
+        :param dataset: dataset to apply the filter to
+        :param min_seq_len: minimum sequence length either in general or per data_key via dict
+        :param max_seq_len: maximum sequence length either in general or per data_key via dict
+        """
+        super().__init__()
+        self._dataset = dataset
+        self._min_seq_len = NumbersDict(0 if min_seq_len is None else min_seq_len)
+        self._max_seq_len = NumbersDict(sys.maxsize if max_seq_len is None else max_seq_len)
+
+    def __iter__(self):
+        """
+        :return: generator providing filtered data where each sequence is a dict
+          data_key -> data_array.
+        :rtype: Iterable[dict[str, numpy.ndarray]]
+        """
+        for data_dict in self._dataset:
+            # TODO: This assumes all data has time as first dimension. Currently we can't know better..
+            sequence_lengths = NumbersDict(
+                {data_key: data.shape[0] for data_key, data in data_dict.items() if data.shape}
+            )
+            if sequence_lengths.any_compare(self._min_seq_len, lambda a, b: a < b):
+                continue
+            if sequence_lengths.any_compare(self._max_seq_len, lambda a,b: a > b):
+                continue
+            yield data_dict

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -248,8 +248,6 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
     Returns dataset yielding list of data lengths within the defined range
     """
 
-    def __getitem__(self, index):
-        raise Exception(f"{self.__class__.__name__}.__getitem__ not supported")
 
     def __init__(
         self,
@@ -283,3 +281,6 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
             if sequence_lengths.any_compare(self._max_seq_length, lambda a, b: a > b):
                 continue
             yield data_dict
+
+    def __getitem__(self, index):
+        raise Exception(f"{self.__class__.__name__}.__getitem__ not supported")      

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -248,7 +248,6 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
     Returns dataset yielding list of data lengths within the defined range
     """
 
-
     def __init__(
         self,
         dataset: torch.utils.data.IterableDataset,

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -26,7 +26,6 @@ from copy import deepcopy
 import numpy
 import torch
 import torch.utils.data
-from torch.utils.data.dataset import T_co
 
 from returnn.util.basic import NumbersDict
 
@@ -249,7 +248,7 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
     Returns dataset yielding list of data lengths within the defined range
     """
 
-    def __getitem__(self, index) -> T_co:
+    def __getitem__(self, index):
         raise Exception(f"{self.__class__.__name__}.__getitem__ not supported")
 
     def __init__(

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -26,6 +26,7 @@ from copy import deepcopy
 import numpy
 import torch
 import torch.utils.data
+from torch.utils.data.dataset import T_co
 
 from returnn.util.basic import NumbersDict
 
@@ -248,21 +249,24 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
     Returns dataset yielding list of data lengths within the defined range
     """
 
+    def __getitem__(self, index) -> T_co:
+        raise Exception(f"{self.__class__.__name__}.__getitem__ not supported")
+
     def __init__(
         self,
         dataset: torch.utils.data.IterableDataset,
-        min_seq_len: Union[int, NumbersDict] = None,
-        max_seq_len: Union[int, NumbersDict] = None,
+        min_seq_length: Union[int, NumbersDict] = None,
+        max_seq_length: Union[int, NumbersDict] = None,
     ):
         """
         :param dataset: dataset to apply the filter to
-        :param min_seq_len: minimum sequence length either in general or per data_key via dict
-        :param max_seq_len: maximum sequence length either in general or per data_key via dict
+        :param min_seq_length: minimum sequence length either in general or per data_key via dict
+        :param max_seq_length: maximum sequence length either in general or per data_key via dict
         """
         super().__init__()
         self._dataset = dataset
-        self._min_seq_len = NumbersDict(0 if min_seq_len is None else min_seq_len)
-        self._max_seq_len = NumbersDict(sys.maxsize if max_seq_len is None else max_seq_len)
+        self._min_seq_length = NumbersDict(0 if min_seq_length is None else min_seq_length)
+        self._max_seq_length = NumbersDict(sys.maxsize if max_seq_length is None else max_seq_length)
 
     def __iter__(self):
         """
@@ -275,8 +279,8 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
             sequence_lengths = NumbersDict(
                 {data_key: data.shape[0] for data_key, data in data_dict.items() if data.shape}
             )
-            if sequence_lengths.any_compare(self._min_seq_len, lambda a, b: a < b):
+            if sequence_lengths.any_compare(self._min_seq_length, lambda a, b: a < b):
                 continue
-            if sequence_lengths.any_compare(self._max_seq_len, lambda a, b: a > b):
+            if sequence_lengths.any_compare(self._max_seq_length, lambda a, b: a > b):
                 continue
             yield data_dict

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -248,9 +248,12 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
     Returns dataset yielding list of data lengths within the defined range
     """
 
-    def __init__(self, dataset: torch.utils.data.IterableDataset,
+    def __init__(
+        self,
+        dataset: torch.utils.data.IterableDataset,
         min_seq_len: Union[int, NumbersDict] = None,
-        max_seq_len: Union[int, NumbersDict] = None):
+        max_seq_len: Union[int, NumbersDict] = None,
+    ):
         """
         :param dataset: dataset to apply the filter to
         :param min_seq_len: minimum sequence length either in general or per data_key via dict
@@ -274,6 +277,6 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
             )
             if sequence_lengths.any_compare(self._min_seq_len, lambda a, b: a < b):
                 continue
-            if sequence_lengths.any_compare(self._max_seq_len, lambda a,b: a > b):
+            if sequence_lengths.any_compare(self._max_seq_len, lambda a, b: a > b):
                 continue
             yield data_dict

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -282,4 +282,4 @@ class LenFilterDataPipe(torch.utils.data.IterDataPipe):
             yield data_dict
 
     def __getitem__(self, index):
-        raise Exception(f"{self.__class__.__name__}.__getitem__ not supported")      
+        raise Exception(f"{self.__class__.__name__}.__getitem__ not supported")

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -3,7 +3,6 @@ Main engine for PyTorch
 """
 
 from __future__ import annotations
-import sys
 from typing import Optional, Union, Callable, Dict
 from contextlib import nullcontext
 

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -58,8 +58,12 @@ class Engine(EngineBase):
 
         self._start_epoch = None  # type: Optional[int]
         self._final_epoch = None  # type: Optional[int]
-        self._min_seq_len = config.typed_value("min_seq_len", None) or config.int("min_seq_len", 0) # type: Union[int,float,Dict[str,int],NumbersDict]
-        self._max_seq_len = config.typed_value("max_seq_len", None) or config.int("max_seq_len", sys.maxsize) # type: Union[int,float,Dict[str,int],NumbersDict]
+        self._min_seq_len = config.typed_value("min_seq_len", None) or config.int(
+            "min_seq_len", 0
+        )  # type: Union[int,float,Dict[str,int],NumbersDict]
+        self._max_seq_len = config.typed_value("max_seq_len", None) or config.int(
+            "max_seq_len", sys.maxsize
+        )  # type: Union[int,float,Dict[str,int],NumbersDict]
         self._orig_model = None  # type: Optional[Union[rf.Module, torch.nn.Module]]
         self._pt_model = None  # type: Optional[torch.nn.Module]
         self._train_step_func = None  # type: Optional[Callable]
@@ -419,8 +423,9 @@ class Engine(EngineBase):
         )
 
         wrapped_dataset = returnn_dataset_wrapper.ReturnnDatasetIterDataPipe(dataset, reset_callback=dataset_reset)
-        wrapped_dataset = data_pipeline.LenFilterDataPipe(wrapped_dataset, min_seq_len=self._min_seq_len,
-            max_seq_len=self._max_seq_len)
+        wrapped_dataset = data_pipeline.LenFilterDataPipe(
+            wrapped_dataset, min_seq_len=self._min_seq_len, max_seq_len=self._max_seq_len
+        )
         chunking = self.config.typed_value("chunking", None)
         if chunking:
             wrapped_dataset = data_pipeline.ChunkingIterDataPipe(wrapped_dataset, chunking)

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -58,11 +58,11 @@ class Engine(EngineBase):
 
         self._start_epoch = None  # type: Optional[int]
         self._final_epoch = None  # type: Optional[int]
-        self._min_seq_len = config.typed_value("min_seq_len", None) or config.int(
-            "min_seq_len", 0
+        self._min_seq_length = config.typed_value("min_seq_length", None) or config.int(
+            "min_seq_length", None
         )  # type: Union[int,float,Dict[str,int],NumbersDict]
-        self._max_seq_len = config.typed_value("max_seq_len", None) or config.int(
-            "max_seq_len", sys.maxsize
+        self._max_seq_length = config.typed_value("max_seq_length", None) or config.int(
+            "max_seq_length", None
         )  # type: Union[int,float,Dict[str,int],NumbersDict]
         self._orig_model = None  # type: Optional[Union[rf.Module, torch.nn.Module]]
         self._pt_model = None  # type: Optional[torch.nn.Module]
@@ -423,9 +423,10 @@ class Engine(EngineBase):
         )
 
         wrapped_dataset = returnn_dataset_wrapper.ReturnnDatasetIterDataPipe(dataset, reset_callback=dataset_reset)
-        wrapped_dataset = data_pipeline.LenFilterDataPipe(
-            wrapped_dataset, min_seq_len=self._min_seq_len, max_seq_len=self._max_seq_len
-        )
+        if (self._min_seq_length is not None) or (self._max_seq_length is not None):
+            wrapped_dataset = data_pipeline.LenFilterDataPipe(
+                wrapped_dataset, min_seq_length=self._min_seq_length, max_seq_length=self._max_seq_length
+            )
         chunking = self.config.typed_value("chunking", None)
         if chunking:
             wrapped_dataset = data_pipeline.ChunkingIterDataPipe(wrapped_dataset, chunking)

--- a/tests/test_torch_engine.py
+++ b/tests/test_torch_engine.py
@@ -54,9 +54,11 @@ def test_torch_engine():
         assert callback.num_seqs == 100
         assert callback.init_called and callback.finish_called
 
+
 def test_min_seq_len():
 
     from returnn.datasets.generating import DummyDataset
+
     config = Config({"min_seq_len": 2})
     dataset = DummyDataset(input_dim=1, output_dim=4, num_seqs=1, seq_len=1)
     engine = Engine(config=config)
@@ -71,9 +73,12 @@ def test_min_seq_len():
     for _ in data_loader:
         return
     assert False, "Should have contained sequences"
+
+
 def test_max_seq_len():
 
     from returnn.datasets.generating import DummyDataset
+
     config = Config({"max_seq_len": 4})
     dataset = DummyDataset(input_dim=1, output_dim=4, num_seqs=1, seq_len=5)
     engine = Engine(config=config)

--- a/tests/test_torch_engine.py
+++ b/tests/test_torch_engine.py
@@ -5,7 +5,6 @@ Tests for PyTorch engine.
 import _setup_test_env  # noqa
 import torch
 
-import returnn.datasets.generating
 from returnn.config import Config, global_config_ctx
 from returnn.tensor import TensorDict, Tensor
 from returnn.torch.engine import Engine
@@ -59,7 +58,7 @@ def test_min_seq_len():
 
     from returnn.datasets.generating import DummyDataset
 
-    config = Config({"min_seq_len": 2})
+    config = Config({"min_seq_length": 2})
     dataset = DummyDataset(input_dim=1, output_dim=4, num_seqs=1, seq_len=1)
     engine = Engine(config=config)
     data_loader = engine._create_data_loader(dataset)
@@ -79,7 +78,7 @@ def test_max_seq_len():
 
     from returnn.datasets.generating import DummyDataset
 
-    config = Config({"max_seq_len": 4})
+    config = Config({"max_seq_length": 4})
     dataset = DummyDataset(input_dim=1, output_dim=4, num_seqs=1, seq_len=5)
     engine = Engine(config=config)
     data_loader = engine._create_data_loader(dataset)

--- a/tests/test_torch_engine.py
+++ b/tests/test_torch_engine.py
@@ -4,6 +4,8 @@ Tests for PyTorch engine.
 
 import _setup_test_env  # noqa
 import torch
+
+import returnn.datasets.generating
 from returnn.config import Config, global_config_ctx
 from returnn.tensor import TensorDict, Tensor
 from returnn.torch.engine import Engine
@@ -51,3 +53,38 @@ def test_torch_engine():
         engine.forward_with_callback(callback=callback, dataset=dataset)
         assert callback.num_seqs == 100
         assert callback.init_called and callback.finish_called
+
+def test_min_seq_len():
+
+    from returnn.datasets.generating import DummyDataset
+    config = Config({"min_seq_len": 2})
+    dataset = DummyDataset(input_dim=1, output_dim=4, num_seqs=1, seq_len=1)
+    engine = Engine(config=config)
+    data_loader = engine._create_data_loader(dataset)
+    for _ in data_loader:
+        assert False, "Should not contain sequences"
+
+    config = Config()
+    dataset = DummyDataset(input_dim=1, output_dim=4, num_seqs=1, seq_len=3)
+    engine = Engine(config=config)
+    data_loader = engine._create_data_loader(dataset)
+    for _ in data_loader:
+        return
+    assert False, "Should have contained sequences"
+def test_max_seq_len():
+
+    from returnn.datasets.generating import DummyDataset
+    config = Config({"max_seq_len": 4})
+    dataset = DummyDataset(input_dim=1, output_dim=4, num_seqs=1, seq_len=5)
+    engine = Engine(config=config)
+    data_loader = engine._create_data_loader(dataset)
+    for _ in data_loader:
+        assert False, "Should not contain sequences"
+
+    config = Config()
+    dataset = DummyDataset(input_dim=1, output_dim=4, num_seqs=1, seq_len=3)
+    engine = Engine(config=config)
+    data_loader = engine._create_data_loader(dataset)
+    for _ in data_loader:
+        return
+    assert False, "Should have contained sequences"


### PR DESCRIPTION
This PR adds `min_seq_length` and `max_seq_length` as parameters to the torch configs, similar to tensorflow. 