### PR TITLE
Add get_current_seq_order to MetaDataset

### DIFF
--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -427,6 +427,13 @@ class MetaDataset(CachedDataset2):
             dataset.init_seq_order(epoch=epoch, seq_list=self.seq_list_ordered[dataset_key])
         return True
 
+    def get_current_seq_order(self):
+        """
+        :return: returnsthe current seq order for the current epoch, after self.init_seq_order was called.
+        :rtype: list[int]
+        """
+        return [self.tag_idx[t] for t in self.seq_list_ordered[self.default_dataset_key]]
+
     def get_all_tags(self):
         """
         :return: list of all seq tags, of the whole dataset, without partition epoch

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -429,10 +429,10 @@ class MetaDataset(CachedDataset2):
 
     def get_current_seq_order(self):
         """
-        :return: returnsthe current seq order for the current epoch, after self.init_seq_order was called.
+        :return: current seq order for the current epoch, after self.init_seq_order was called.
         :rtype: list[int]
         """
-        return [self.tag_idx[t] for t in self.seq_list_ordered[self.default_dataset_key]]
+        return [self.tag_idx[tag] for tag in self.seq_list_ordered[self.default_dataset_key]]
 
     def get_all_tags(self):
         """


### PR DESCRIPTION
This is required by `MultiProcDataset._seq_order_proc_loop` https://github.com/rwth-i6/returnn/blob/1cee4aa1dadb1e216b9311dd65d4753753b7beb6/returnn/datasets/multi_proc.py#L131