### PR TITLE
rename _get_data to get_data in MetaDataset

### DIFF
--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -471,7 +471,7 @@ class MetaDataset(CachedDataset2):
         self_seq_tag = self.seq_list_ordered[dataset_key][seq_idx]
         assert dataset_seq_tag == self_seq_tag
 
-    def _get_data(self, seq_idx, data_key):
+    def get_data(self, seq_idx, data_key):
         """
         :type seq_idx: int
         :type data_key: str
@@ -487,7 +487,7 @@ class MetaDataset(CachedDataset2):
         :rtype: DatasetSeq
         """
         seq_tag = self.seq_list_ordered[self.default_dataset_key][seq_idx]
-        features = {data_key: self._get_data(seq_idx, data_key) for data_key in self.data_keys}
+        features = {data_key: self.get_data(seq_idx, data_key) for data_key in self.data_keys}
         return DatasetSeq(seq_idx=seq_idx, seq_tag=seq_tag, features=features)
 
     def get_seq_length(self, sorted_seq_idx):


### PR DESCRIPTION
Original problem was that `MultiProcDataset` calls the `get_data` method of the included dataset. Since `MetaDataset` does not implement it, the method of `CachedDataset2` is used, which does not work with `MetaDataset`.

But then I noticed that in almost all other datasets the equivalent method is called `get_data` and only the datasets from `meta.py` and `lm.py` have `_get_data` instead. Is there any reason for this? if not, I propose to rename it.