### PR TITLE
enable both gloo and nccl backend for torch distributed

### DIFF
--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -27,7 +27,7 @@ class DistributedContext:
         """
         import torch.distributed as dist
 
-        dist.init_process_group("nccl")
+        dist.init_process_group("gloo")
 
         self._config = config
         self._local_rank = os.environ["LOCAL_RANK"]

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -27,7 +27,10 @@ class DistributedContext:
         """
         import torch.distributed as dist
 
-        dist.init_process_group()
+        # when no backend is specified, both gloo and nccl backends will be created
+        # the gloo backend will be used for collectives with CPU tensors and
+        # the nccl backend will be used for collectives with CUDA tensors
+        dist.init_process_group(backend=None)
 
         self._config = config
         self._local_rank = os.environ["LOCAL_RANK"]

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -27,7 +27,7 @@ class DistributedContext:
         """
         import torch.distributed as dist
 
-        dist.init_process_group("gloo")
+        dist.init_process_group()
 
         self._config = config
         self._local_rank = os.environ["LOCAL_RANK"]

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -248,11 +248,7 @@ class Engine(EngineBase):
 
         while True:
             extern_data_raw = next(data_iter, None)
-            # WARNING: torch.distributed works only for the registered device,
-            # as it uses only one mechanism for communication, like NCCL.
-            # This is suboptimal here as we have the roundtrip CPU -> GPU -> NCCL -> GPU -> CPU.
-            # TODO: Use more direct CPU -> Ethernet -> CPU communication.
-            _has_data = torch.tensor([extern_data_raw is not None], dtype=torch.int8).to(self._device)
+            _has_data = torch.tensor([extern_data_raw is not None], dtype=torch.int8)
 
             if self._use_torch_distributed:
                 # use all reduce to check if all workers have data, if at least one worker does not have data,


### PR DESCRIPTION
This PR enables both nccl and gloo backend for torch.distributed. The gloo backend will be used for collectives with CPU tensors and the nccl backend will be used for collectives with CUDA tensors. Before this PR, we only used nccl backend which is only  available with CUDA tensors. Thus for the has_data all reduce operation at the beginning of each training step iteration, we have to make a roundtrip to send has_data Tensor through CPU -> GPU -> NCCL -> GPU -> CPU, which is very inefficient.  With this PR, gloo backed is available for the CPU tensors. Therefore, has_data all reduce can be operated on cpu directly and save the detour.