### PR TITLE
PT dynamic_learning_rate support

### DIFF
--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -305,8 +305,7 @@ class Engine(EngineBase):
 
             # update the learning rate per step
             if self._use_dynamic_lr:
-                lr = self._updater.get_current_step_learning_rate(self.global_train_step)
-                self._updater.set_learning_rate(lr)
+                self._updater.set_current_step_learning_rate(lr)
 
             # only update the weights when every gradient accumulation loop ends
             if (step_idx % self._accum_grad_multiple_step) == (self._accum_grad_multiple_step - 1):

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -305,7 +305,7 @@ class Engine(EngineBase):
 
             # update the learning rate per step
             if self._use_dynamic_lr:
-                self._updater.set_current_step_learning_rate(lr)
+                self._updater.set_current_step_learning_rate(self.global_train_step)
 
             # only update the weights when every gradient accumulation loop ends
             if (step_idx % self._accum_grad_multiple_step) == (self._accum_grad_multiple_step - 1):

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -219,7 +219,9 @@ class Engine(EngineBase):
             self.epoch += 1
             self._epoch_mp_shared.value = self.epoch
 
-            self.init_train_epoch()
+            # update learning rate sub-epoch wise
+            if not self._use_dynamic_lr:
+                self.init_train_epoch()
             self.train_epoch()
 
         print(f"Finished training at epoch {self.epoch}, global train step {self.global_train_step}", file=log.v3)

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -82,9 +82,6 @@ class Engine(EngineBase):
         self._device = _get_device_from_config(config)
         print("Using device:", self._device, file=log.v2)
 
-        self._use_dynamic_lr = False if self.config.typed_value("dynamic_learning_rate", None) is None else True
-        print("Using dynamic learning rate scheduler that updates based on global train steps", file=log.v2)
-
         self._use_torch_distributed = False
         self._torch_distributed_class = None  # type: Optional[Callable]
         self._torch_distributed_options = None  # type: Optional[dict]
@@ -219,9 +216,7 @@ class Engine(EngineBase):
             self.epoch += 1
             self._epoch_mp_shared.value = self.epoch
 
-            # update learning rate sub-epoch wise
-            if not self._use_dynamic_lr:
-                self.init_train_epoch()
+            self.init_train_epoch()
             self.train_epoch()
 
         print(f"Finished training at epoch {self.epoch}, global train step {self.global_train_step}", file=log.v3)
@@ -303,9 +298,8 @@ class Engine(EngineBase):
                 else:
                     total_loss.raw_tensor.backward()
 
-            # update the learning rate per step
-            if self._use_dynamic_lr:
-                self._updater.set_current_step_learning_rate(self.global_train_step)
+            # update the optimizer per step
+            self._updater.set_current_train_step(self.global_train_step)
 
             # only update the weights when every gradient accumulation loop ends
             if (step_idx % self._accum_grad_multiple_step) == (self._accum_grad_multiple_step - 1):

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -105,7 +105,6 @@ class Updater(object):
         """
         for param_group in self.optimizer.param_groups:
             param_group["lr"] = value
-        self.learning_rate = value
 
     def set_current_train_step(self, global_train_step):
         """
@@ -127,7 +126,6 @@ class Updater(object):
 
             for param_group in self.optimizer.param_groups:
                 param_group["lr"] = lr
-            self.learning_rate = lr
 
     def create_optimizer(self):
         """

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -97,6 +97,7 @@ class Updater(object):
             print("Using dynamic learning rate scheduler that updates based on global train steps", file=log.v2)
             if callable(self.learning_rate_function):
                 import inspect
+
                 signature = inspect.signature(self.learning_rate_function)
                 assert any(
                     [arg.kind == inspect.Parameter.VAR_KEYWORD for arg in signature.parameters.values()]

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -103,7 +103,7 @@ class Updater(object):
             param_group["lr"] = value
         self.learning_rate = value
 
-    def get_current_step_learning_rate(self, global_train_step):
+    def set_current_step_learning_rate(self, global_train_step):
         """
         Obtains an updated learning rate for the current training step inside a (sub)epoch.
         """
@@ -119,7 +119,10 @@ class Updater(object):
             lr = learning_rate_function(global_train_step=global_train_step, learning_rate=lr)
         else:
             raise NotImplementedError("not implemented for not callable dynamic_learning_rate")
-        return lr
+
+        for param_group in self.optimizer.param_groups:
+            param_group["lr"] = lr
+        self.learning_rate = lr
 
     def create_optimizer(self):
         """

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -101,6 +101,7 @@ class Updater(object):
         """
         for param_group in self.optimizer.param_groups:
             param_group["lr"] = value
+        self.learning_rate = value
 
     def get_current_step_learning_rate(self, global_train_step):
         """
@@ -117,7 +118,7 @@ class Updater(object):
             ), "please specify **kwargs in dynamic_learning_rate for future compatibility"
             lr = learning_rate_function(global_train_step=global_train_step, learning_rate=lr)
         else:
-            raise NotImplementedError(f"not implemented for not callable dynamic_learning_rate")
+            raise NotImplementedError("not implemented for not callable dynamic_learning_rate")
         return lr
 
     def create_optimizer(self):

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -115,6 +115,7 @@ class Updater(object):
         """
         for param_group in self.optimizer.param_groups:
             param_group["lr"] = value
+        self.learning_rate = value
 
     def set_current_train_step(self, global_train_step):
         """


### PR DESCRIPTION
This PR enables the user to define a custom dynamic learning rate function in the returnn config. At each train step, the current step learning rate will be then calculated based on the dynamic learning rate function and updated at each step. 
One example of the dynamic learning rate function would look like this

```
def dynamic_learning_rate(*, global_train_step, learning_rate, **kwargs):
    max_lr = 5e-4
    end_lr = 1e-8
    total_num_updates = 400000 * 3
    num_warm_up = total_num_updates * 0.2
    if global_train_step <= num_warm_up:
        warmup_factor = global_train_step / num_warm_up
        lr = warmup_factor * max_lr
    elif global_train_step > total_num_updates:
        lr = end_lr
    else:
        lr_range = max_lr - end_lr
        pct_remaining = 1 - (global_train_step - num_warm_up) / (
            total_num_updates - num_warm_up
        )
        lr = lr_range * pct_remaining + end_lr
    return lr
```
