### PR TITLE
fix the is_first_train_epoch check for preload_from_files 

### DIFF
--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -478,6 +478,7 @@ class Engine(EngineBase):
         # Check existing model. This takes `load` and `load_epoch` into account,
         # and also whether we are in train or eval mode.
         epoch, model_epoch_filename = self.get_epoch_model(self.config)
+        step = None
 
         checkpoint_state = None
         if model_epoch_filename:

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -492,12 +492,13 @@ class Engine(EngineBase):
             # Restore the last step.
             # Below, we will increase the step again in case we are training.
             step -= 1
-        else:
-            step = 0
-            epoch = self._start_epoch or 1
 
         is_training = self.config.value("task", "train") == "train"
         is_first_train_epoch = not epoch and (is_training or self.config.value("task", "train") == "initialize_model")
+
+        if not model_epoch_filename:
+            step = 0
+            epoch = self._start_epoch or 1
 
         # See :mod:`rf.rand` docstring for an explanation of this logic.
         random_seed = self.config.int("random_seed", 42)


### PR DESCRIPTION
This PR was originally pull request #1359. I accidentally closed that PR, so I reopened it again here, I am sorry for the inconvenience.

@albertz I now set 
```
if model_epoch_filename:
    ...
# (no else branch)

is_training = self.config.value("task", "train") == "train"
is_first_train_epoch = not epoch and (is_training or self.config.value("task", "train") == "initialize_model")

if not model_epoch_filename:
    step = 0
    epoch = self._start_epoch or 1
```
because otherwise for the case not model_epoch_filename and not is_first_train_epoch, the step and epoch is still None and we will get error in line `random_seed = (epoch * 193939 + step * 19937 + random_seed * 27644437 + 479001599) % (2**31)`