### PR TITLE
Torch ONNX export, proper dynamic dims handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,6 +300,7 @@ jobs:
         pip install --user scipy | cat  # for some tests
         pip install --user --upgrade torch==${{ matrix.torch-version }} | cat
         pip install --user torchdata | cat
+        pip install --user onnxruntime | cat
 
     - name: Test Python/Numpy/PyTorch versions.
       run: |

--- a/demos/demo-rf.config
+++ b/demos/demo-rf.config
@@ -23,7 +23,7 @@ in_dim = Dim(9, name="in")
 out_dim = Dim(2, name="out")
 extern_data = {
     "data": {"dims": (batch_dim, time_dim, in_dim), "dtype": "float32"},
-    "classes": {"dims": (batch_dim, time_dim), "sparse_dim": out_dim, "dtype": "int32"},
+    "classes": {"dims": (batch_dim, time_dim), "sparse_dim": out_dim, "dtype": "int32", "available_for_inference": False},
 }
 model_outputs = {
     "output": {"dims": (batch_dim, time_dim, out_dim), "dtype": "float32"},

--- a/demos/demo-torch.config
+++ b/demos/demo-torch.config
@@ -24,7 +24,7 @@ num_inputs = 9
 num_outputs = 2
 extern_data = {
     "data": {"dim": num_inputs},
-    "classes": {"dim": num_outputs, "sparse": True},
+    "classes": {"dim": num_outputs, "sparse": True, "available_for_inference": False},
 }
 model_outputs = {
     "output": {"dim": num_outputs},

--- a/demos/demo-torch.config
+++ b/demos/demo-torch.config
@@ -64,6 +64,7 @@ def forward_step(*, model: Model, extern_data: TensorDict):
     """
     data = extern_data["data"]
     out = model(data.raw_tensor)
+    rf.get_run_ctx().expected_outputs["output"].dims[1].dyn_size_ext.raw_tensor = data.dims[1].dyn_size_ext.raw_tensor
     rf.get_run_ctx().mark_as_default_output(tensor=out)
 
 

--- a/returnn/frontend/run_ctx.py
+++ b/returnn/frontend/run_ctx.py
@@ -8,7 +8,6 @@ or forwarding loop.
 
 from __future__ import annotations
 from typing import Optional, Union, Any, Sequence, Dict
-import logging
 from dataclasses import dataclass
 from returnn.tensor import Tensor, Dim, TensorDict
 import returnn.frontend as rf

--- a/returnn/frontend/run_ctx.py
+++ b/returnn/frontend/run_ctx.py
@@ -400,16 +400,10 @@ def _output_tensor_from_raw(raw_tensor, *, dims: Sequence[Dim], name: str) -> Te
     # however, otherwise, it is ambiguous, so we print a warning that we always use the highest dim size.
     for axis, dim in enumerate(tensor.dims):
         if dim.dyn_size_ext and dim.dyn_size_ext.raw_tensor is None:
-            dim_value_raw = _backend.global_backend.get_shape_tuple_raw(raw_tensor)[axis]
-            dim_value = rf.convert_to_tensor(dim_value_raw, dims=())
-            dim_value = rf.cast(dim_value, dtype=dim.dyn_size_ext.dtype)
+            # Only non-scalar dyn sizes matter.
             if dim.dyn_size_ext.dims:
-                dyn_size = rf.full(dims=dim.dyn_size_ext.dims, fill_value=dim_value)
-                logging.warning(
+                raise Exception(
                     f"Output {name!r} {tensor}: Cannot infer dynamic size for dim {dim}. "
-                    f"Using {dyn_size} as fallback."
+                    f"You must explicitly specify the dyn size by assigning `{dim}.dyn_size_ext.raw_tensor = ...`."
                 )
-            else:
-                dyn_size = dim_value
-            dim.dyn_size_ext.raw_tensor = dyn_size.raw_tensor
     return tensor

--- a/tests/rf_utils.py
+++ b/tests/rf_utils.py
@@ -89,7 +89,7 @@ def run_model(
 
 def run_model_torch(extern_data: TensorDict, get_model: rf.GetModelFunc, forward_step: rf.StepFunc) -> TensorDict:
     """run"""
-    extern_data_raw = extern_data.as_raw_tensor_dict(expected_type=numpy.ndarray)
+    extern_data_raw = extern_data.as_raw_tensor_dict(expected_value_type=numpy.ndarray)
     rf.select_backend_torch()
     rf.set_random_seed(42)
 
@@ -111,7 +111,7 @@ def run_model_torch(extern_data: TensorDict, get_model: rf.GetModelFunc, forward
 
 def run_model_net_dict_tf(extern_data: TensorDict, get_model: rf.GetModelFunc, forward_step: rf.StepFunc) -> TensorDict:
     """run"""
-    extern_data_raw = extern_data.as_raw_tensor_dict(expected_type=numpy.ndarray)
+    extern_data_raw = extern_data.as_raw_tensor_dict(expected_value_type=numpy.ndarray)
     extern_data.reset_content()
     rf.select_backend_returnn_layers_tf()
     rf.set_random_seed(42)
@@ -159,9 +159,9 @@ def run_model_net_dict_tf(extern_data: TensorDict, get_model: rf.GetModelFunc, f
             layer = net.get_layer(layer_name)
             outputs_tf.data[k] = layer.output.copy()
 
-        fetches = outputs_tf.as_raw_tensor_dict(expected_type=tf.Tensor)
+        fetches = outputs_tf.as_raw_tensor_dict(expected_value_type=tf.Tensor)
         assert set(extern_data.data.keys()) == set(net.extern_data.data.keys())
-        extern_data_tf_placeholders = net.extern_data.as_raw_tensor_dict(expected_type=tf.Tensor)
+        extern_data_tf_placeholders = net.extern_data.as_raw_tensor_dict(expected_value_type=tf.Tensor)
         assert set(extern_data_tf_placeholders.keys()) == set(extern_data_raw.keys())
         feed_dict = {extern_data_tf_placeholders[k]: v for k, v in extern_data_raw.items()}
 

--- a/tools/torch_export_to_onnx.py
+++ b/tools/torch_export_to_onnx.py
@@ -172,7 +172,7 @@ def main():
     """
     Main entry point
     """
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
         "config",
         type=str,


### PR DESCRIPTION
This implements proper dynamic dims handling as it was discussed #1333. It also extends some test cases and documentation.

- Test cases: Also perform ONNX inference on the exported ONNX models.
- Handle `available_for_inference` in `extern_data`: They are excluded.
- Handle duplicated dims in `extern_data`: Only the first is used. (First according to the order defined by the dict in the config.)
- Handle scalar dynamic dims in `extern_data` and `model_outputs`: They are excluded.
- It is an error if some dim `dyn_size_ext` in `model_outputs` is specified as not being a scalar (e.g. common seq lens of shape [B]) but its value is not defined.
- Demos are adapted.
- Torch-to-ONNX export documentation extended.
