### PR TITLE
Check for learning_rate_control is not None during cleanup

### DIFF
--- a/returnn/engine/base.py
+++ b/returnn/engine/base.py
@@ -281,7 +281,7 @@ class EngineBase:
 
         opts = CollectionReadCheckCovered(self.config.get_of_type("cleanup_old_models", dict, {}))
         existing_models = self.get_existing_models(config=self.config)
-        if hasattr(self, "learning_rate_control"):
+        if hasattr(self, "learning_rate_control") and self.learning_rate_control is not None:
             lr_control = self.learning_rate_control
         else:
             lr_control = load_learning_rate_control_from_config(self.config)


### PR DESCRIPTION
When using the cleanup old models tool it happens that `self.learning_rate_control` is not set yet. This check then causes proper loading of the lr control for cleanup.