### PR TITLE
PyTorch engine: print total number of model params

### DIFF
--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -533,6 +533,8 @@ class Engine(EngineBase):
             raise TypeError(f"get_model returned {model} of type {type(model)}, expected rf.Module or torch.nn.Module")
         assert isinstance(self._pt_model, torch.nn.Module)
         print("Model:", self._pt_model, file=log.v4)
+        params = sum([parameter.data.size().numel() for parameter in self._pt_model.parameters()])
+        print(f"Total number of parameters: {params}", file=log.v4)
 
         if checkpoint_state is not None:
             self._pt_model.load_state_dict(checkpoint_state["model"])

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -533,8 +533,8 @@ class Engine(EngineBase):
             raise TypeError(f"get_model returned {model} of type {type(model)}, expected rf.Module or torch.nn.Module")
         assert isinstance(self._pt_model, torch.nn.Module)
         print("Model:", self._pt_model, file=log.v4)
-        params = sum([parameter.data.size().numel() for parameter in self._pt_model.parameters()])
-        print(f"Total number of parameters: {params}", file=log.v4)
+        num_params = sum([parameter.numel() for parameter in self._pt_model.parameters()])
+        print(f"net params #: {num_params}", file=log.v2)
 
         if checkpoint_state is not None:
             self._pt_model.load_state_dict(checkpoint_state["model"])


### PR DESCRIPTION
In TF, the total number of model parameters was printed at startup. I think it would be nice to add this for the torch engine, too.