### PR TITLE
torch onnx export: load model on device

### DIFF
--- a/tools/torch_export_to_onnx.py
+++ b/tools/torch_export_to_onnx.py
@@ -172,7 +172,7 @@ def main():
     get_model_func = config.typed_value("get_model")
     assert get_model_func, "get_model() isn't specified in the config passed as a parameter."
     model = get_model_func()
-    loaded_checkpoint = torch.load(args.checkpoint)
+    loaded_checkpoint = torch.load(args.checkpoint, map_location=torch.device(args.device))
 
     is_rf_module = isinstance(model, rf.Module)
     is_pt_module = isinstance(model, torch.nn.Module)


### PR DESCRIPTION
When running this script in a CPU-only image, I got
```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu
') to map your storages to the CPU.
```
even though I specified `--device cpu`. This PR should fix this.