### PR TITLE
Fix compilation of native ops in TF 2.13

### DIFF
--- a/returnn/tf/native_op.py
+++ b/returnn/tf/native_op.py
@@ -267,7 +267,7 @@ class OpMaker(object):
       if(c->num_outputs() != %(num_outputs)i)
         return errors::InvalidArgument("wrong number of outputs. required %(num_outputs)i but got ", c->num_outputs());
       %(code_set_out_shape)s
-      return Status::OK();
+      return Status();
     })
     """ % {
             "num_inputs": len(in_info),


### PR DESCRIPTION
Looks like Status::OK was deprecated and is no longer available in newer versions of TF (at least in TF 2.13). Horovod had a similar issue and I use the same solution they agreed on: https://github.com/horovod/horovod/pull/3767