### PR TITLE
Add Test for MultiProcDataset with MetaDataset

### DIFF
--- a/tests/test_MultiProcDataset.py
+++ b/tests/test_MultiProcDataset.py
@@ -77,6 +77,23 @@ def test_MultiProcDataset_n3_b5_shuffle():
     compare_dataset_seqs(hdf_dataset_seqs, mp_dataset_seqs)
 
 
+def test_MultiProcDataset_meta():
+    hdf_fn = generate_hdf_from_other({"class": "Task12AXDataset", "num_seqs": 23})
+    meta_dataset_dict = {
+        "class": "MetaDataset",
+        "data_map": {"classes": ("hdf", "classes"), "data": ("hdf", "data")},
+        "datasets": {"hdf": {"class": "HDFDataset", "files": [hdf_fn]}},
+    }
+    meta_dataset = init_dataset(meta_dataset_dict)
+    meta_dataset_seqs = dummy_iter_dataset(meta_dataset)
+
+    mp_dataset = MultiProcDataset(dataset=meta_dataset_dict, num_workers=1, buffer_size=1)
+    mp_dataset.initialize()
+    mp_dataset_seqs = dummy_iter_dataset(mp_dataset)
+
+    compare_dataset_seqs(meta_dataset_seqs, mp_dataset_seqs)
+
+
 if __name__ == "__main__":
     better_exchook.install()
     if len(sys.argv) <= 1:


### PR DESCRIPTION
I encountered a problem with `MultiProcDataset` if used in conjunction with a `MetaDataset`. 
I think the problem is related to loading of sequences, more precisely that `child_dataset.load_seqs` is not called by the `MultiProcDataset`.

But I am not sure how to elegantly solve this, so here is a test case that reproduces the error. Please help :)