### PR TITLE
Dim broadcasting only allowed for auto-generated dims

### DIFF
--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -1234,7 +1234,13 @@ class _DimMixin:
             if other_kind == DimTypes.Feature or not other_kind:
                 other_kind = DimTypes.Spatial
         if self.dimension != other.dimension:
-            if broadcast_matches and (self.dimension == 1 or other.dimension == 1):
+            if broadcast_matches and (
+                # Only auto-generated dim tags are allowed to be treated as broadcastable.
+                # This was another suggestion from here: https://github.com/rwth-i6/returnn/issues/666
+                # It was not implemented like this because the auto_generated flag was only introduced later.
+                (self.dimension == 1 and self.auto_generated)
+                or (other.dimension == 1 and other.auto_generated)
+            ):
                 pass  # pass on
             else:
                 return False

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -977,7 +977,13 @@ class _TensorMixin(_TensorMixinBase):
                 if dim_tag and dim_tag.dimension == 1 and dim_tag.batch == batch_info:
                     pass  # keep it
                 else:
-                    dim_tag = Dim(kind=Dim.Types.Batch, description="batch-broadcast", dimension=1, batch=batch_info)
+                    dim_tag = Dim(
+                        kind=Dim.Types.Batch,
+                        description="batch-broadcast",
+                        dimension=1,
+                        batch=batch_info,
+                        auto_generated=True,
+                    )
                 return self.copy_add_batch_dim(batch_dim_axis=axis, batch=batch_info, dim_tag=dim_tag)
 
         data_opts = self.get_kwargs()


### PR DESCRIPTION
Auto-generated dims are those via the legacy n_out or all other internal dims.

Any dim tags created explicitly by the user should never be treated as broadcast dims.

See also #666.
