### PR TITLE
TF layer var scope, fix derived custom getter

### DIFF
--- a/returnn/tf/layers/base.py
+++ b/returnn/tf/layers/base.py
@@ -240,6 +240,7 @@ class LayerBase(object):
             assert sources[0].output.have_dim_tag(
                 in_dim, unique=True
             ), "%s: in_dim %s not found or unique in input %s" % (self, in_dim, sources[0])
+        self.have_params = False
         self.params = {}  # type: typing.Dict[str,tf.Variable]
         self.saveable_param_replace = (
             {}
@@ -1329,6 +1330,7 @@ class LayerBase(object):
         :return: param
         :rtype tf.Variable
         """
+        self.have_params = True
         _param = param
         if isinstance(param, tf.Tensor):
             # This can happen with a custom_getter in tf.compat.v1.get_variable(), e.g. via self.reuse_params.

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1641,10 +1641,11 @@ class TFNetwork(object):
                 "Loss flattened layer %s/%r output: %r" % (opts["network"].name, opts["name"], opts["output"]),
                 file=log.v3,
             )
-            layer__ = layer_cls(**opts)
-            assert isinstance(layer__, LayerBase)
-            layer__.post_init(opts)
-            layer__.output.sanity_check()
+            with self.layer_creation_scope(layer_class=layer_cls, **opts):
+                layer__ = layer_cls(**opts)
+                assert isinstance(layer__, LayerBase)
+                layer__.post_init(opts)
+                layer__.output.sanity_check()
             return layer__
 
         def _layer_deps(layer_):
@@ -1683,7 +1684,7 @@ class TFNetwork(object):
                 return False
             if layer_.recurrent:
                 return False
-            if layer_.have_params:  # in principle, this is ok, just not implemented yet to correctly share params
+            if layer_.have_params:  # in principle, this is ok, just not well-tested
                 return False
             if isinstance(layer_, (SourceLayer, InternalLayer)):
                 return False

--- a/returnn/tf/network.py
+++ b/returnn/tf/network.py
@@ -1683,7 +1683,7 @@ class TFNetwork(object):
                 return False
             if layer_.recurrent:
                 return False
-            if layer_.params:  # in principle, this is ok, just not implemented yet to correctly share params
+            if layer_.have_params:  # in principle, this is ok, just not implemented yet to correctly share params
                 return False
             if isinstance(layer_, (SourceLayer, InternalLayer)):
                 return False


### PR DESCRIPTION
This fixes combinations of reuse_params with other param transformations like param dropout.

Along the way, I also fixed and extended the flatten layer with losses a bit, as the test case triggered some problems there. I would suggest to rebase and not squash.