### PR TITLE
Dim eq, batch dim eq only for old behavior version

### DIFF
--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -454,9 +454,7 @@ class _DimMixin:
             # We ignore the ctx for the batch dim currently.
             if self.batch == batch:
                 return self
-            if batch.is_global_batch():
-                return _d.batch_dim  # reuse global batch dim if possible
-            return _d.Dim(kind=DimTypes.Batch, description="batch:%s" % batch.short_repr(), batch=batch, dimension=None)
+            return batch.batch_dim_tag
         if not self.is_dynamic():
             # If static dim, no effect.
             assert not self.batch

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -1246,12 +1246,6 @@ class _DimMixin:
                 return False
         if self_kind != other_kind:
             return False
-        if self_kind == other_kind == DimTypes.Batch:
-            # Note: This might be incorrect in some cases,
-            # e.g. for beam search when we have the beam hidden in the batch dim,
-            # or when we used MergeDimsLayer on the batch axis, or so.
-            # We might need to extend the logic here later.
-            return True
         if BehaviorVersion.get() >= 16:
             # Either self or other is some dim tag explicitly created by the user,
             # and they are not the same, so we never treat them as equal.
@@ -1262,6 +1256,12 @@ class _DimMixin:
                     pass  # exception, allow broadcast logic
                 else:
                     return False
+        if self_kind == other_kind == DimTypes.Batch:
+            # Note: This might be incorrect in some cases,
+            # e.g. for beam search when we have the beam hidden in the batch dim,
+            # or when we used MergeDimsLayer on the batch axis, or so.
+            # We might need to extend the logic here later.
+            return True
         if self_kind == other_kind == DimTypes.Feature:
             if allow_same_feature_dim:
                 return True

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -3115,6 +3115,12 @@ class _TensorMixin(_TensorMixinBase):
         all_dim_tags, tags_dict = Dim.get_all_dimension_tags(sources, is_equal_opts=is_equal_opts)
         # Check for missing tags, and add those.
         for dim_tag in all_dim_tags:
+            if dim_tag.is_batch_dim():
+                if common.have_batch_axis():
+                    continue
+                axis = common.get_default_new_axis_for_dim_tag(dim_tag)
+                common = common.copy_add_dim_by_tag(dim_tag, unbroadcast=True, axis=axis)
+                continue
             common_tag = Dim.get_existing_tag_from_collection(dim_tag, common.dim_tags, is_equal_opts=is_equal_opts)
             if common_tag:
                 # Already have this tag. However, maybe we have a better one.

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -878,6 +878,8 @@ class _TensorMixin(_TensorMixinBase):
             assert dim_tag.batch == batch
             if batch:
                 assert dim_tag.dimension == batch.static_dim or dim_tag.dimension is None
+        elif batch:
+            dim_tag = batch.batch_dim_tag
         else:
             dim_tag = Dim(
                 kind=Dim.Types.Batch, description="batch", dimension=batch.static_dim if batch else None, batch=batch

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -842,6 +842,11 @@ class _TensorMixin(_TensorMixinBase):
         :param Dim|None dim_tag:
         :return: copy of myself with added batch-dim
         """
+        if self.have_batch_axis():
+            raise Exception(
+                f"{self} copy_add_batch_dim: already has batch-dim at axis {self.batch_dim_axis},"
+                f" cannot add tag {dim_tag!r}"
+            )
         assert self.batch_dim_axis is None
         if batch_dim_axis < 0:
             assert batch_dim_axis + self.batch_ndim + 1 >= 0


### PR DESCRIPTION
This changes the behavior of equality of batch dim for behavior version >=16 to be more strict, and treat batch dim just like any other dim type, i.e. equality only if it is the same instance or via same_as.

With behavior version <=15, nothing changes.

We could have introduced another behavior version for this change. However, this should not affect much (or only internal things; let's wait for tests) and this keeps it much simpler. **Edit** Unfortunately, too much internal code depends on this and would require more complicated logic in other places, so we don't do this.
