### PR TITLE
RETURNN frontend native helpers

### DIFF
--- a/returnn/frontend/_backend.py
+++ b/returnn/frontend/_backend.py
@@ -1222,6 +1222,10 @@ def select_backend_torch():
     global_backend.__class__ = backend
     BehaviorVersion.set_min_behavior_version(16)
 
+    from returnn.frontend import _native
+
+    _native.setup()
+
 
 def get_backend_by_tensor(tensor: Tensor, *, fallback: Optional[T2] = None) -> Union[Type[Backend[T]], T2]:
     """

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -37,7 +37,9 @@ def get_module(*, verbose: bool = False):
         is_cpp=True,
         verbose=verbose,
     )
-    _module = compiler.load_py_module()
+    module = compiler.load_py_module()
+    if not _module:
+        _module = module
     return _module
 
 

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -89,6 +89,6 @@ def setup():
         if not callable(cur_func):
             continue
         assert name.startswith("__") and name.endswith("__")
-        native_func = getattr(mod, "tensor_" + name[2:-2])
+        native_func = getattr(mod, "_tensor_" + name[2:-2] + "_instancemethod")
         assert callable(native_func)
         setattr(_TensorOpOverloadsMixin, name, native_func)

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -79,8 +79,6 @@ def setup():
         print("This is optional (although very recommended), so we continue without it.")
         return
 
-    from returnn.tensor import Tensor
-
     Tensor.raw_tensor = property(Tensor._raw_tensor.__get__, mod.tensor_raw_tensor_setter)  # noqa
     Tensor._raw_backend = property(mod.get_backend_for_tensor)  # noqa
 
@@ -94,3 +92,36 @@ def setup():
         native_func = getattr(mod, "_tensor_" + name[2:-2] + "_instancemethod")
         assert callable(native_func)
         setattr(_TensorOpOverloadsMixin, name, native_func)
+
+    import returnn.frontend as rf
+    from returnn.frontend import math_ as rf_math
+
+    for rf_name, native_name in {
+        "compare": "tensor_compare",
+        "combine": "tensor_combine",
+        "equal": "tensor_eq",
+        "not_equal": "tensor_ne",
+        "less": "tensor_lt",
+        "less_equal": "tensor_le",
+        "greater": "tensor_gt",
+        "greater_equal": "tensor_ge",
+        "add": "tensor_add",
+        "sub": "tensor_sub",
+        "mul": "tensor_mul",
+        "true_divide": "tensor_truediv",
+        "floor_divide": "tensor_floordiv",
+        "neg": "tensor_neg",
+        "mod": "tensor_mod",
+        "pow": "tensor_pow",
+        "logical_and": "tensor_and",
+        "logical_or": "tensor_or",
+        "logical_not": "tensor_invert",
+        "abs": "tensor_abs",
+        "ceil": "tensor_ceil",
+        "floor": "tensor_floor",
+    }.items():
+        assert hasattr(rf, rf_name)
+        assert hasattr(rf_math, rf_name)
+        native_func = getattr(mod, native_name)
+        setattr(rf, rf_name, native_func)
+        setattr(rf_math, rf_name, native_func)

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -83,7 +83,7 @@ def setup():
     Tensor._raw_backend = property(mod.get_backend_for_tensor)  # noqa
 
     # noinspection PyProtectedMember
-    from returnn.tensor.tensor import _TensorOpOverloadsMixin
+    from returnn.tensor.tensor import _TensorOpOverloadsMixin, _TensorMixin
 
     for name, cur_func in _TensorOpOverloadsMixin.__dict__.items():
         if not callable(cur_func):
@@ -92,6 +92,14 @@ def setup():
         native_func = getattr(mod, "_tensor_" + name[2:-2] + "_instancemethod")
         assert callable(native_func)
         setattr(_TensorOpOverloadsMixin, name, native_func)
+
+    for rf_name, native_name in {
+        "copy": "tensor_copy",
+        "copy_template": "tensor_copy_template",
+    }.items():
+        assert hasattr(_TensorMixin, rf_name)
+        native_func = getattr(mod, "_" + native_name + "_instancemethod")
+        setattr(_TensorMixin, rf_name, native_func)
 
     import returnn.frontend as rf
     from returnn.frontend import math_ as rf_math

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -79,4 +79,5 @@ def setup():
 
     from returnn.tensor import Tensor
 
+    Tensor.raw_tensor = property(Tensor._raw_tensor.__get__, mod.tensor_raw_tensor_setter)  # noqa
     Tensor._raw_backend = property(mod.get_backend_for_tensor)  # noqa

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -81,3 +81,14 @@ def setup():
 
     Tensor.raw_tensor = property(Tensor._raw_tensor.__get__, mod.tensor_raw_tensor_setter)  # noqa
     Tensor._raw_backend = property(mod.get_backend_for_tensor)  # noqa
+
+    # noinspection PyProtectedMember
+    from returnn.tensor.tensor import _TensorOpOverloadsMixin
+
+    for name, cur_func in _TensorOpOverloadsMixin.__dict__.items():
+        if not callable(cur_func):
+            continue
+        assert name.startswith("__") and name.endswith("__")
+        native_func = getattr(mod, "tensor_" + name[2:-2])
+        assert callable(native_func)
+        setattr(_TensorOpOverloadsMixin, name, native_func)

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -44,10 +44,18 @@ def get_module():
     return _module
 
 
+_is_set_up = False
+
+
 def setup():
     """
     Setup the native code.
     """
+    global _is_set_up
+    if _is_set_up:
+        return
+    _is_set_up = True  # only try once
+
     try:
         mod = get_module()
     except Exception as exc:

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -1,0 +1,44 @@
+"""
+Native code as Python extension module for the RETURNN frontend, including tensor methods and ops.
+"""
+
+from __future__ import annotations
+
+import os
+from glob import glob
+from returnn.util.py_ext_mod_compiler import PyExtModCompiler
+
+
+_module = None
+_my_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_module():
+    """
+    :return: native Python extension module
+    """
+    global _module
+    if _module:
+        return _module
+
+    # Put code all together in one big blob.
+    # (Similar logic as in ken_lm.get_tf_mod.)
+    files = sorted(glob(_my_dir + "/*.cpp"))
+    src_code = ""
+    for fn in files:
+        f_code = open(fn).read()
+        src_code += "\n// ------------ %s : BEGIN { ------------\n" % os.path.basename(fn)
+        # https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html#Line-Control
+        src_code += '#line 1 "%s"\n' % os.path.basename(fn)
+        src_code += f_code
+        src_code += "\n// ------------ %s : END } --------------\n\n" % os.path.basename(fn)
+
+    compiler = PyExtModCompiler(
+        base_name="_returnn_frontend_native",
+        code_version=1,
+        code=src_code,
+        include_paths=(_my_dir,),
+        is_cpp=True,
+    )
+    _module = compiler.load_py_module()
+    return _module

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -42,3 +42,22 @@ def get_module():
     )
     _module = compiler.load_py_module()
     return _module
+
+
+def setup():
+    """
+    Setup the native code.
+    """
+    try:
+        mod = get_module()
+    except Exception as exc:
+        if os.environ.get("RETURNN_TEST") == "1":
+            raise
+        print("RETURNN frontend _native backend: Error while getting module:")
+        print(exc)
+        print("This is optional (although very recommended), so we continue without it.")
+        return
+
+    from returnn.tensor import Tensor
+
+    Tensor._raw_backend = property(mod.get_backend_for_tensor)  # noqa

--- a/returnn/frontend/_native/__init__.py
+++ b/returnn/frontend/_native/__init__.py
@@ -60,6 +60,13 @@ def setup():
         return
     _is_set_up = True  # only try once
 
+    from returnn.tensor import Tensor, Dim
+
+    # First we can use some existing native variants, which do not require our own native code.
+    # The raw_tensor getter is replaced here, the raw_tensor setter is replaced below.
+    Tensor.raw_tensor = property(Tensor._raw_tensor.__get__, Tensor.raw_tensor.__set__)  # noqa
+    Dim.dimension = property(Dim.size.__get__)  # noqa
+
     try:
         mod = get_module()
     except Exception as exc:

--- a/returnn/frontend/_native/backend.cpp
+++ b/returnn/frontend/_native/backend.cpp
@@ -1,0 +1,30 @@
+#include "backend.hpp"
+#include "module.hpp"
+
+PyObject* getBackendForTensor(PyObject* module, PyObject* obj) {
+    PyObject* raw_tensor = PyObject_GetAttrString(obj, "_raw_tensor");
+    if(!raw_tensor)
+        return NULL;
+    PyObject* backend = getBackendForRawTensor(module, raw_tensor);
+    Py_DECREF(raw_tensor);
+    return backend;
+}
+
+PyObject* getBackendForRawTensor(PyObject* module, PyObject* obj) {
+    return getBackendForRawTensorType(module, Py_TYPE(obj));
+}
+
+PyObject* getBackendForRawTensorType(PyObject* module, PyObject* obj) {
+    PyModuleState* modState = (PyModuleState*) PyModule_GetState(m);
+    PyObject* dispatchTable = modState->backendTensorTypeDispatchTable(); // borrowed
+    PyObject* backend = PyDict_GetItem(dispatchTable, obj); // borrowed
+    if(backend)
+        return backend;
+
+    PyObject* mod = PyImport_ImportModule("returnn.frontend._backend");
+    if(!mod)
+        return NULL;
+    backend = PyObject_CallMethodObjArgs(mod, "get_backend_by_raw_tensor_type", obj, NULL);
+    Py_XDECREF(backend); // make it borrowed; it will be referenced elsewhere
+    return backend;
+}

--- a/returnn/frontend/_native/backend.cpp
+++ b/returnn/frontend/_native/backend.cpp
@@ -62,6 +62,8 @@ PyObject* getBackendForTensor(PyModuleState* modState, PyObject* obj) {
 }
 
 PyObject* getBackendForRawTensor(PyModuleState* modState, PyObject* obj) {
+    if(obj == Py_None)
+        Py_RETURN_NONE;
     return getBackendForRawTensorType(modState, (PyObject*) Py_TYPE(obj));
 }
 

--- a/returnn/frontend/_native/backend.cpp
+++ b/returnn/frontend/_native/backend.cpp
@@ -1,6 +1,28 @@
 #include "backend.hpp"
 #include "module.hpp"
 
+PyObject* pyGetBackendForTensor(PyObject *self, PyObject *const *args, Py_ssize_t nargs) {
+    if(nargs != 1) {
+        PyErr_SetString(PyExc_TypeError, "get_backend_for_tensor() takes exactly 1 argument: tensor");
+        return NULL;
+    }
+    PyObject* res = getBackendForTensor(self, args[0]);
+    Py_XINCREF(res);
+    return res;
+}
+
+PyObject* pyIsRawTorchTensorType(PyObject *self, PyObject *const *args, Py_ssize_t nargs) {
+    if(nargs != 1) {
+        PyErr_SetString(PyExc_TypeError, "is_raw_torch_tensor_type() takes exactly 1 argument: raw_tensor");
+        return NULL;
+    }
+    PyModuleState* modState = (PyModuleState*) PyModule_GetState(self);
+    if(!modState)
+        return NULL;
+    bool res = modState->isTorchTensorType(args[0]);
+    return PyBool_FromLong(res);
+}
+
 PyObject* getBackendForTensor(PyObject* module, PyObject* obj) {
     PyObject* raw_tensor = PyObject_GetAttrString(obj, "_raw_tensor");
     if(!raw_tensor)
@@ -11,11 +33,13 @@ PyObject* getBackendForTensor(PyObject* module, PyObject* obj) {
 }
 
 PyObject* getBackendForRawTensor(PyObject* module, PyObject* obj) {
-    return getBackendForRawTensorType(module, Py_TYPE(obj));
+    return getBackendForRawTensorType(module, (PyObject*) Py_TYPE(obj));
 }
 
 /*borrowed*/ PyObject* getBackendForRawTensorType(PyObject* module, PyObject* obj) {
-    PyModuleState* modState = (PyModuleState*) PyModule_GetState(m);
+    PyModuleState* modState = (PyModuleState*) PyModule_GetState(module);
+    if(!modState)
+        return NULL;
 
     // fast path 1 -- try some predefined types (faster than dict lookup)
     if(modState->isTorchTensorType(obj))
@@ -31,7 +55,13 @@ PyObject* getBackendForRawTensor(PyObject* module, PyObject* obj) {
     PyObject* mod = PyImport_ImportModule("returnn.frontend._backend");
     if(!mod)
         return NULL;
-    backend = PyObject_CallMethodObjArgs(mod, "get_backend_by_raw_tensor_type", obj, NULL);
+    PyObject* methodName = PyUnicode_InternFromString("get_backend_by_raw_tensor_type");
+    if(!methodName) {
+        Py_DECREF(mod);
+        return NULL;
+    }
+    backend = PyObject_CallMethodObjArgs(mod, methodName, obj, NULL);
+    Py_DECREF(methodName);
     Py_XDECREF(backend); // make it borrowed; it will be referenced elsewhere
     return backend;
 }

--- a/returnn/frontend/_native/backend.cpp
+++ b/returnn/frontend/_native/backend.cpp
@@ -39,7 +39,7 @@ PyObject* pyRawTorchTensorGetDType(PyObject *self, PyObject *const *args, Py_ssi
     if(!PyUnicode_Check(dtypeStr)) {
         PyErr_Format(
             PyExc_TypeError,
-            "raw_torch_tensor_get_dtype: dtype.__str__() did not return a string, from dtype '%R'", dtypeObj.get());
+            "raw_torch_tensor_get_dtype: dtype.__str__() did not return a string, from dtype %R", dtypeObj.get());
         return NULL;
     }
     const char* dtypeStrC = PyUnicode_AsUTF8(dtypeStr);
@@ -47,7 +47,7 @@ PyObject* pyRawTorchTensorGetDType(PyObject *self, PyObject *const *args, Py_ssi
         PyErr_Format(
             PyExc_TypeError,
             "raw_torch_tensor_get_dtype: "
-            "dtype.__str__() did not return a string starting with 'torch.', from dtype '%R', str '%s'",
+            "dtype.__str__() did not return a string starting with 'torch.', from dtype %R, str '%s'",
             dtypeObj.get(), dtypeStrC);
         return NULL;
     }

--- a/returnn/frontend/_native/backend.hpp
+++ b/returnn/frontend/_native/backend.hpp
@@ -3,6 +3,8 @@
 
 #include <Python.h>
 
+class PyModuleState;
+
 // exported Python functions {
 
 PyObject* pyGetBackendForTensor(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
@@ -11,8 +13,10 @@ PyObject* pyIsRawTorchTensorType(PyObject *self, PyObject *const *args, Py_ssize
 // }
 
 // return borrowed references. but for NULL, an exception is raised
-PyObject* getBackendForTensor(PyObject* module, PyObject* obj);
-PyObject* getBackendForRawTensor(PyObject* module, PyObject* obj);
-PyObject* getBackendForRawTensorType(PyObject* module, PyObject* obj);
+PyObject* getBackendForTensor(PyModuleState* modState, PyObject* obj);
+PyObject* getBackendForRawTensor(PyModuleState* modState, PyObject* obj);
+PyObject* getBackendForRawTensorType(PyModuleState* modState, PyObject* obj);
+
+bool isTorchBackendForTensor(PyModuleState* modState, PyObject* obj);
 
 #endif

--- a/returnn/frontend/_native/backend.hpp
+++ b/returnn/frontend/_native/backend.hpp
@@ -1,0 +1,12 @@
+#ifndef __RETURNN_BACKEND_HPP__
+#define __RETURNN_BACKEND_HPP__
+
+// borrowed references. but for NULL, an exception is raised
+PyObject* getBackendForTensor(PyObject* module, PyObject* obj);
+PyObject* getBackendForRawTensor(PyObject* module, PyObject* obj);
+PyObject* getBackendForRawTensorType(PyObject* module, PyObject* obj);
+
+bool isTorchRawTensor(PyObject* obj);
+bool isTorchTensor(PyObject* obj);
+
+#endif

--- a/returnn/frontend/_native/backend.hpp
+++ b/returnn/frontend/_native/backend.hpp
@@ -1,12 +1,18 @@
 #ifndef __RETURNN_BACKEND_HPP__
 #define __RETURNN_BACKEND_HPP__
 
-// borrowed references. but for NULL, an exception is raised
+#include <Python.h>
+
+// exported Python functions {
+
+PyObject* pyGetBackendForTensor(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyIsRawTorchTensorType(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+// }
+
+// return borrowed references. but for NULL, an exception is raised
 PyObject* getBackendForTensor(PyObject* module, PyObject* obj);
 PyObject* getBackendForRawTensor(PyObject* module, PyObject* obj);
 PyObject* getBackendForRawTensorType(PyObject* module, PyObject* obj);
-
-bool isTorchRawTensor(PyObject* obj);
-bool isTorchTensor(PyObject* obj);
 
 #endif

--- a/returnn/frontend/_native/backend.hpp
+++ b/returnn/frontend/_native/backend.hpp
@@ -9,6 +9,7 @@ class PyModuleState;
 
 PyObject* pyGetBackendForTensor(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyIsRawTorchTensorType(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyRawTorchTensorGetDType(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 
 // }
 

--- a/returnn/frontend/_native/module.cpp
+++ b/returnn/frontend/_native/module.cpp
@@ -115,6 +115,7 @@ int PyModuleState::pyInitModuleExec(PyObject* module) {
                 if(!instMethod) return -1; \
                 if(PyModule_AddObject(module, "_tensor_" #name "_instancemethod", instMethod) < 0) \
                     return -1; \
+                instMethod.release(); \
             }
 
         AddInstanceMethod(eq);

--- a/returnn/frontend/_native/module.cpp
+++ b/returnn/frontend/_native/module.cpp
@@ -13,6 +13,8 @@ static PyMethodDef _pyModuleMethods[] = {
     {"is_raw_torch_tensor_type", (PyCFunction) pyIsRawTorchTensorType, METH_FASTCALL,
         "isinstance(raw_tensor, torch.Tensor)"},
     {"raw_torch_tensor_get_dtype", (PyCFunction) pyRawTorchTensorGetDType, METH_FASTCALL, "TorchBackend.get_dtype_name_raw"},
+    {"tensor_raw_tensor_setter", (PyCFunction) pyTensorRawTensorSetter, METH_FASTCALL, "Tensor.raw_tensor.setter"},
+    {"tensor_copy_template", (PyCFunction) pyTensorCopyTemplate, METH_VARARGS | METH_KEYWORDS, "Tensor.copy_template"},
     {"tensor_compare", (PyCFunction) pyTensorCompare, METH_VARARGS | METH_KEYWORDS, "rf.compare"},
     {"tensor_combine", (PyCFunction) pyTensorCombine, METH_VARARGS | METH_KEYWORDS, "rf.combine"},
     {"tensor_eq", (PyCFunction) pyTensorEq, METH_FASTCALL, "Tensor.__eq__"},

--- a/returnn/frontend/_native/module.cpp
+++ b/returnn/frontend/_native/module.cpp
@@ -14,6 +14,8 @@ static PyMethodDef _pyModuleMethods[] = {
         "isinstance(raw_tensor, torch.Tensor)"},
     {"raw_torch_tensor_get_dtype", (PyCFunction) pyRawTorchTensorGetDType, METH_FASTCALL, "TorchBackend.get_dtype_name_raw"},
     {"tensor_raw_tensor_setter", (PyCFunction) pyTensorRawTensorSetter, METH_FASTCALL, "Tensor.raw_tensor.setter"},
+    {"convert_to_raw_torch_tensor_like", (PyCFunction) pyConvertToRawTorchTensorLike, METH_FASTCALL,
+        "torch.tensor(value, dtype=..., device=...)"},
     {"tensor_copy_template", (PyCFunction) pyTensorCopyTemplate, METH_VARARGS | METH_KEYWORDS, "Tensor.copy_template"},
 
     {"tensor_compare", (PyCFunction) pyTensorCompare, METH_VARARGS | METH_KEYWORDS, "rf.compare"},
@@ -263,6 +265,10 @@ bool PyModuleState::_cachedOpInitTorch() {
     #define AddOpAlt(op, name) ops[op] = PyObject_GetAttrString(modAlternatives, name); if(!ops[op]) return false;
 
     AddOp(TOp_ConvertToTensor, "tensor");
+
+    ops[TOp_ConvertToTensorLike] = PyObject_GetAttrString(_module, "convert_to_raw_torch_tensor_like");
+    if(!ops[TOp_ConvertToTensorLike]) return false;
+
     AddOp(TOp_Permute, "permute");
     AddOp(TOp_Reshape, "reshape");
 
@@ -307,7 +313,8 @@ bool PyModuleState::_cachedOpInitTorch() {
 const char* rawOpName(RawOp op) {
     static const char* names[NumTOps] = {NULL};
     if(!names[0]) {
-        names[TOp_ConvertToTensor] = "tensor";
+        names[TOp_ConvertToTensor] = "convert_to_tensor";
+        names[TOp_ConvertToTensorLike] = "convert_to_tensor_like";
         names[TOp_Permute] = "permute";
         names[TOp_Reshape] = "reshape";
         names[TOp_GetShape] = "get_shape";

--- a/returnn/frontend/_native/module.cpp
+++ b/returnn/frontend/_native/module.cpp
@@ -16,6 +16,7 @@ static PyMethodDef _pyModuleMethods[] = {
     {"tensor_raw_tensor_setter", (PyCFunction) pyTensorRawTensorSetter, METH_FASTCALL, "Tensor.raw_tensor.setter"},
     {"convert_to_raw_torch_tensor_like", (PyCFunction) pyConvertToRawTorchTensorLike, METH_FASTCALL,
         "torch.tensor(value, dtype=..., device=...)"},
+    {"tensor_copy", (PyCFunction) pyTensorCopy, METH_VARARGS | METH_KEYWORDS, "Tensor.copy"},
     {"tensor_copy_template", (PyCFunction) pyTensorCopyTemplate, METH_VARARGS | METH_KEYWORDS, "Tensor.copy_template"},
 
     {"tensor_compare", (PyCFunction) pyTensorCompare, METH_VARARGS | METH_KEYWORDS, "rf.compare"},
@@ -65,6 +66,13 @@ static int _pyModuleExec(PyObject *m) {
 
 int PyModuleState::pyInitModuleExec(PyObject* module) {
     _module = module;
+
+    {
+        PyObjectScopedRef mod = PyImport_ImportModule("returnn.util.basic");
+        if(!mod) return -1;
+        _notSpecified = PyObject_GetAttrString(mod, "NotSpecified");
+        if(!_notSpecified) return -1;
+    }
 
     {
         PyObjectScopedRef mod = PyImport_ImportModule("returnn.tensor");
@@ -119,6 +127,9 @@ int PyModuleState::pyInitModuleExec(PyObject* module) {
                     return -1; \
                 instMethod.release(); \
             }
+
+        AddInstanceMethod(copy);
+        AddInstanceMethod(copy_template);
 
         AddInstanceMethod(eq);
         AddInstanceMethod(ne);

--- a/returnn/frontend/_native/module.cpp
+++ b/returnn/frontend/_native/module.cpp
@@ -11,9 +11,15 @@ static PyMethodDef _pyModuleMethods[] = {
         "get RETURNN frontend backend for RETURNN Tensor. like Tensor.raw_tensor"},
     {"is_raw_torch_tensor_type", (PyCFunction) pyIsRawTorchTensorType, METH_FASTCALL,
         "isinstance(raw_tensor, torch.Tensor)"},
-    {"tensor_compare", (PyCFunction) pyCompare, METH_VARARGS | METH_KEYWORDS, "rf.compare"},
-    {"tensor_combine", (PyCFunction) pyCombine, METH_VARARGS | METH_KEYWORDS, "rf.combine"},
-    // ...
+    {"tensor_compare", (PyCFunction) pyTensorCompare, METH_VARARGS | METH_KEYWORDS, "rf.compare"},
+    {"tensor_combine", (PyCFunction) pyTensorCombine, METH_VARARGS | METH_KEYWORDS, "rf.combine"},
+    {"tensor_eq", (PyCFunction) pyTensorEq, METH_FASTCALL, "Tensor.__eq__"},
+    {"tensor_ne", (PyCFunction) pyTensorNe, METH_FASTCALL, "Tensor.__ne__"},
+    {"tensor_lt", (PyCFunction) pyTensorLt, METH_FASTCALL, "Tensor.__lt__"},
+    {"tensor_le", (PyCFunction) pyTensorLe, METH_FASTCALL, "Tensor.__le__"},
+    {"tensor_gt", (PyCFunction) pyTensorGt, METH_FASTCALL, "Tensor.__gt__"},
+    {"tensor_ge", (PyCFunction) pyTensorGe, METH_FASTCALL, "Tensor.__ge__"},
+    // TODO ...
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/returnn/frontend/_native/module.cpp
+++ b/returnn/frontend/_native/module.cpp
@@ -106,6 +106,53 @@ int PyModuleState::pyInitModuleExec(PyObject* module) {
         }
     }
 
+    {
+        #define AddInstanceMethod(name) \
+            { \
+                PyObjectScopedRef func = PyObject_GetAttrString(_module, "tensor_" #name); \
+                if(!func) return -1; \
+                PyObjectScopedRef instMethod = PyInstanceMethod_New(func); \
+                if(!instMethod) return -1; \
+                if(PyModule_AddObject(module, "_tensor_" #name "_instancemethod", instMethod) < 0) \
+                    return -1; \
+            }
+
+        AddInstanceMethod(eq);
+        AddInstanceMethod(ne);
+        AddInstanceMethod(lt);
+        AddInstanceMethod(le);
+        AddInstanceMethod(gt);
+        AddInstanceMethod(ge);
+
+        AddInstanceMethod(add);
+        AddInstanceMethod(radd);
+        AddInstanceMethod(sub);
+        AddInstanceMethod(rsub);
+        AddInstanceMethod(mul);
+        AddInstanceMethod(rmul);
+        AddInstanceMethod(truediv);
+        AddInstanceMethod(rtruediv);
+        AddInstanceMethod(floordiv);
+        AddInstanceMethod(rfloordiv);
+        AddInstanceMethod(mod);
+        AddInstanceMethod(rmod);
+        AddInstanceMethod(pow);
+        AddInstanceMethod(rpow);
+
+        AddInstanceMethod(and);
+        AddInstanceMethod(rand);
+        AddInstanceMethod(or);
+        AddInstanceMethod(ror);
+
+        AddInstanceMethod(neg);
+        AddInstanceMethod(invert);
+        AddInstanceMethod(abs);
+        AddInstanceMethod(ceil);
+        AddInstanceMethod(floor);
+
+        #undef AddInstanceMethod
+    }
+
     return 0;
 }
 

--- a/returnn/frontend/_native/module.cpp
+++ b/returnn/frontend/_native/module.cpp
@@ -181,6 +181,7 @@ bool PyModuleState::_cachedOpInitTorch() {
     #define AddOp(op, name) ops[op] = PyObject_GetAttrString(mod, name); if(!ops[op]) return false;
     #define AddOpAlt(op, name) ops[op] = PyObject_GetAttrString(modAlternatives, name); if(!ops[op]) return false;
 
+    AddOp(TOp_ConvertToTensor, "tensor");
     AddOp(TOp_Permute, "permute");
     AddOp(TOp_Reshape, "reshape");
     {
@@ -212,8 +213,6 @@ bool PyModuleState::_cachedOpInitTorch() {
     #undef AddOp
     #undef AddOpAlt
 
-    Py_DECREF(mod);
-    Py_DECREF(modAlternatives);
     return true;
 }
 

--- a/returnn/frontend/_native/module.cpp
+++ b/returnn/frontend/_native/module.cpp
@@ -295,6 +295,8 @@ bool PyModuleState::_cachedOpInitTorch() {
     AddOp(TOp_FloorDiv, "floor_divide");
     AddOp(TOp_Mod, "remainder");
     AddOp(TOp_Pow, "pow");
+    AddOp(TOp_Maximum, "maximum");
+    AddOp(TOp_Minimum, "minimum");
     AddOpAlt(TOp_SquaredDifference, "squared_difference");
     AddOp(TOp_And, "logical_and");
     AddOp(TOp_Or, "logical_or");
@@ -332,6 +334,8 @@ const char* rawOpName(RawOp op) {
         names[TOp_FloorDiv] = "floordiv";
         names[TOp_Mod] = "mod";
         names[TOp_Pow] = "pow";
+        names[TOp_Maximum] = "maximum";
+        names[TOp_Minimum] = "minimum";
         names[TOp_SquaredDifference] = "squared_difference";
         names[TOp_And] = "logical_and";
         names[TOp_Or] = "logical_or";

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -11,12 +11,16 @@ enum RawOp {
     TOp_GetShape,
     TOp_GetDType,
 
+    // binary compare
+
     TOp_Eq,
     TOp_Ne,
     TOp_Lt,
     TOp_Le,
     TOp_Gt,
     TOp_Ge,
+
+    // binary combine
 
     TOp_Add,
     TOp_Sub,
@@ -30,12 +34,16 @@ enum RawOp {
     TOp_Minimum,
     TOp_SquaredDifference,
 
-    TOp_Neg,
-    TOp_Abs,
-
     TOp_And,
     TOp_Or,
+
+    // unary
+
+    TOp_Neg,
     TOp_Not,
+    TOp_Abs,
+    TOp_Ceil,
+    TOp_Floor,
 
     NumTOps,
 };
@@ -117,7 +125,7 @@ public:
     int pyClear() {
         _module = NULL;
         _rawTensorTypesLen = 0;
-        for(int i = 0; i < sizeof(_rawTensorTypes)/sizeof(_rawTensorTypes[0]); ++i)
+        for(unsigned int i = 0; i < sizeof(_rawTensorTypes)/sizeof(_rawTensorTypes[0]); ++i)
             Py_CLEAR(_rawTensorTypes[i]);
         Py_CLEAR(_tensorType);
         Py_CLEAR(_globalBackend);

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -134,7 +134,10 @@ public:
         if(!_cachedOps[backend * NumTOps + op])
             if(!_cachedOpInit(backend))
                 return NULL;
-        return _cachedOps[backend * NumTOps + op];
+        PyObject* func = _cachedOps[backend * NumTOps + op];
+        if(!func)
+            PyErr_Format(PyExc_RuntimeError, "RETURNN frontend _native: invalid backend %d, op %d, '%s'", backend, op, rawOpName(op));
+        return func;
     }
     inline int rawTensorTypesLen() const { return _rawTensorTypesLen; }
     inline PyObject* rawTensorType(int i) const { return _rawTensorTypes[i]; }

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -8,6 +8,7 @@ enum RawOp {
     TOp_ConvertToTensor,
     TOp_Permute,
     TOp_Reshape,
+    TOp_GetShape,
 
     TOp_Eq,
     TOp_Ne,
@@ -149,6 +150,7 @@ private:
     PyObject* _torchBackend;
 
     bool _torchTensorTypeMaybeInit(PyObject* obj);
+    bool _torchTensorInit();
     bool _cachedOpInit(BackendWithCachedOps backend);
     bool _cachedOpInitTorch();
 };

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -1,0 +1,57 @@
+#ifndef __RETURNN_MODULE_HPP__
+#define __RETURNN_MODULE_HPP__
+
+#include <Python.h>
+
+enum {
+    TOp_Eq,
+    TOp_Ne,
+    TOp_Lt,
+    TOp_Le,
+    TOp_Gt,
+    TOp_Ge,
+
+    TOp_Add,
+    TOp_Sub,
+    TOp_Mul,
+    TOp_TrueDiv,
+    TOp_FloorDiv,
+    TOp_Mod,
+    TOp_Pow,
+
+    TOp_Neg,
+    TOp_Abs,
+
+    TOp_And,
+    TOp_Or,
+
+    NumTOps,
+};
+
+enum {
+    Backend_Generic,
+    Backend_Torch,
+
+    NumBackends,
+};
+
+class PyModuleState {
+public:
+    // borrowed references. NULL means error, exception is raised.
+    inline PyObject* backendTensorTypeDispatchTable() {
+        if(_backendTensorTypeDispatchTable)
+            return _backendTensorTypeDispatchTable;
+        PyObject* mod = PyImport_ImportModule("returnn.frontend._backend");
+        if(!mod)
+            return NULL;
+        _backendTensorTypeDispatchTable = PyObject_GetAttrString(mod, "_backend_tensor_type_dispatch_table");
+        Py_DECREF(mod);
+        return _backendTensorTypeDispatchTable;
+    }
+
+private:
+    PyObject* _backendTensorTypeDispatchTable;
+    PyObject* _torchTensorType;
+};
+
+#endif

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -9,6 +9,7 @@ enum RawOp {
     TOp_Permute,
     TOp_Reshape,
     TOp_GetShape,
+    TOp_GetDType,
 
     TOp_Eq,
     TOp_Ne,
@@ -126,7 +127,7 @@ public:
         return 0;
     }
 
-    int pyInitModuleExec();
+    int pyInitModuleExec(PyObject* module);
 
     inline PyObject* tensorType() const { return _tensorType; }
     inline PyObject* globalBackend() const { return _globalBackend; }
@@ -143,6 +144,7 @@ public:
     inline PyObject* rawTensorType(int i) const { return _rawTensorTypes[i]; }
 
 private:
+    PyObject* _module; // weak
     int _rawTensorTypesLen;
     PyObject* _rawTensorTypes[10];
     PyObject* _tensorType;

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -91,6 +91,24 @@ public:
         return _torchBackend;
     }
 
+    int pyTraverse(visitproc visit, void *arg) {
+        Py_VISIT(_backendTensorTypeDispatchTable);
+        for(int i = 0; i < NumBackendsWithCachedOps * NumTOps; ++i)
+            Py_VISIT(_cachedOps[i]);
+        Py_VISIT(_torchTensorType);
+        Py_VISIT(_torchBackend);
+        return 0;
+    }
+
+    int pyClear() {
+        Py_CLEAR(_backendTensorTypeDispatchTable);
+        for(int i = 0; i < NumBackendsWithCachedOps * NumTOps; ++i)
+            Py_CLEAR(_cachedOps[i]);
+        Py_CLEAR(_torchTensorType);
+        Py_CLEAR(_torchBackend);
+        return 0;
+    }
+
 private:
     PyObject* _backendTensorTypeDispatchTable;
     PyObject* _cachedOps[NumBackendsWithCachedOps * NumTOps];

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -115,7 +115,9 @@ public:
     }
 
     int pyClear() {
-        for(int i = 0; i < _rawTensorTypesLen; ++i)
+        _module = NULL;
+        _rawTensorTypesLen = 0;
+        for(int i = 0; i < sizeof(_rawTensorTypes)/sizeof(_rawTensorTypes[0]); ++i)
             Py_CLEAR(_rawTensorTypes[i]);
         Py_CLEAR(_tensorType);
         Py_CLEAR(_globalBackend);

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -5,6 +5,7 @@
 
 // raw ops
 enum RawOp {
+    TOp_ConvertToTensor,
     TOp_Permute,
     TOp_Reshape,
 
@@ -99,6 +100,10 @@ public:
     }
 
     int pyTraverse(visitproc visit, void *arg) {
+        for(int i = 0; i < _rawTensorTypesLen; ++i)
+            Py_VISIT(_rawTensorTypes[i]);
+        Py_VISIT(_tensorType);
+        Py_VISIT(_globalBackend);
         Py_VISIT(_backendTensorTypeDispatchTable);
         for(int i = 0; i < NumBackendsWithCachedOps * NumTOps; ++i)
             Py_VISIT(_cachedOps[i]);
@@ -108,6 +113,10 @@ public:
     }
 
     int pyClear() {
+        for(int i = 0; i < _rawTensorTypesLen; ++i)
+            Py_CLEAR(_rawTensorTypes[i]);
+        Py_CLEAR(_tensorType);
+        Py_CLEAR(_globalBackend);
         Py_CLEAR(_backendTensorTypeDispatchTable);
         for(int i = 0; i < NumBackendsWithCachedOps * NumTOps; ++i)
             Py_CLEAR(_cachedOps[i]);
@@ -118,16 +127,20 @@ public:
 
     int pyInitModuleExec();
 
-    inline PyObject* tensorType() { return _tensorType; }
-    inline PyObject* globalBackend() { return _globalBackend; }
+    inline PyObject* tensorType() const { return _tensorType; }
+    inline PyObject* globalBackend() const { return _globalBackend; }
     inline PyObject* cachedOp(RawOp op, BackendWithCachedOps backend) {
         if(!_cachedOps[backend * NumTOps + op])
             if(!_cachedOpInit(backend))
                 return NULL;
         return _cachedOps[backend * NumTOps + op];
     }
+    inline int rawTensorTypesLen() const { return _rawTensorTypesLen; }
+    inline PyObject* rawTensorType(int i) const { return _rawTensorTypes[i]; }
 
 private:
+    int _rawTensorTypesLen;
+    PyObject* _rawTensorTypes[10];
     PyObject* _tensorType;
     PyObject* _globalBackend;
     PyObject* _backendTensorTypeDispatchTable;

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -111,6 +111,7 @@ public:
     }
 
     int pyTraverse(visitproc visit, void *arg) {
+        Py_VISIT(_notSpecified);
         for(int i = 0; i < _rawTensorTypesLen; ++i)
             Py_VISIT(_rawTensorTypes[i]);
         Py_VISIT(_tensorType);
@@ -124,7 +125,7 @@ public:
     }
 
     int pyClear() {
-        _module = NULL;
+        Py_CLEAR(_notSpecified);
         _rawTensorTypesLen = 0;
         for(unsigned int i = 0; i < sizeof(_rawTensorTypes)/sizeof(_rawTensorTypes[0]); ++i)
             Py_CLEAR(_rawTensorTypes[i]);
@@ -135,11 +136,13 @@ public:
             Py_CLEAR(_cachedOps[i]);
         Py_CLEAR(_torchTensorType);
         Py_CLEAR(_torchBackend);
+        _module = NULL;
         return 0;
     }
 
     int pyInitModuleExec(PyObject* module);
 
+    inline PyObject* notSpecified() const { return _notSpecified; }
     inline PyObject* tensorType() const { return _tensorType; }
     inline PyObject* globalBackend() const { return _globalBackend; }
     inline PyObject* cachedOp(RawOp op, BackendWithCachedOps backend) {
@@ -156,6 +159,7 @@ public:
 
 private:
     PyObject* _module; // weak
+    PyObject* _notSpecified;
     int _rawTensorTypesLen;
     PyObject* _rawTensorTypes[10];
     PyObject* _tensorType;

--- a/returnn/frontend/_native/module.hpp
+++ b/returnn/frontend/_native/module.hpp
@@ -6,6 +6,7 @@
 // raw ops
 enum RawOp {
     TOp_ConvertToTensor,
+    TOp_ConvertToTensorLike,
     TOp_Permute,
     TOp_Reshape,
     TOp_GetShape,

--- a/returnn/frontend/_native/py_utils.hpp
+++ b/returnn/frontend/_native/py_utils.hpp
@@ -1,0 +1,30 @@
+#ifndef __RETURNN_PY_UTILS_HPP__
+#define __RETURNN_PY_UTILS_HPP__
+
+#include <Python.h>
+
+/* When you call any Python API which returns a new reference, e.g. PyObject_Call or whatever,
+ * you need to Py_DECREF it at some point.
+ * This class is a simple wrapper which does that automatically when it goes out of scope.
+ * Example:
+ *   PyObjectScopedRef result = PyObject_Call(...);
+ *   // do something with ref
+ *   // no need to Py_DECREF(ref) explicitly
+*/
+class PyObjectScopedRef {
+public:
+    PyObjectScopedRef(PyObject* obj = NULL) : _obj(obj) {}
+    PyObjectScopedRef(const PyObjectScopedRef&) = delete;
+    PyObjectScopedRef(PyObjectScopedRef&& other) : _obj(other._obj) { other._obj = NULL; }
+    void operator=(PyObject* obj) { Py_CLEAR(_obj); _obj = obj; }
+    void operator=(const PyObjectScopedRef&) = delete;
+    operator PyObject*() const { return _obj; }
+    PyObject* get() const { return _obj; }
+    PyObject* release() { PyObject* obj = _obj; _obj = NULL; return obj; }
+    ~PyObjectScopedRef() { Py_CLEAR(_obj); }
+
+private:
+    PyObject* _obj;
+};
+
+#endif

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -1,0 +1,21 @@
+
+#include <Python.h>
+#include "tensor_ops.hpp"
+
+PyObject* Tensor_eq() {
+    /* Special implementation for eq:
+    When comparing to some other invalid type, return False, not a Tensor.
+    This is to allow easy equality checks with other random objects.
+    See for example here: https://github.com/rwth-i6/returnn/pull/1284
+    */
+}
+
+template<char... chars>
+PyObject* Tensor_compare() {
+
+}
+
+template<char... chars>
+PyObject* Tensor_combine() {
+
+}

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -268,7 +268,7 @@ PyObject* pyTensorRawTensorSetter(PyObject *self, PyObject *const *args, Py_ssiz
     }
     else if(raw_tensor == Py_None) {}  // nothing to check
     else {
-        PyObject* backend = getBackendForRawTensor(modState, tensor);
+        PyObject* backend = getBackendForRawTensor(modState, raw_tensor);
         if(!backend) return NULL;
         {
             PyObjectScopedRef dtype = PyObject_GetAttrString(tensor, "dtype");

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -153,19 +153,19 @@ static bool _isMatchingDType(PyObject* dtype, PyObject* rawDtype, const char* fu
     if(!PyUnicode_Check(dtype)) {
         PyErr_Format(
             PyExc_TypeError,
-            "%s: tensor.dtype did not return a string, from dtype '%R'", funcName, dtype);
+            "%s: tensor.dtype did not return a string, from dtype %R", funcName, dtype);
         return false;
     }
     if(!PyUnicode_Check(rawDtype)) {
         PyErr_Format(
             PyExc_TypeError,
-            "%s: raw_tensor.dtype did not return a string, from dtype '%R'", funcName, rawDtype);
+            "%s: raw_tensor.dtype did not return a string, from dtype %R", funcName, rawDtype);
         return false;
     }
     if(PyUnicode_Compare(dtype, rawDtype) != 0) {
         PyErr_Format(
             PyExc_ValueError,
-            "%s: tensor.dtype != raw_tensor.dtype, from tensor dtype '%R' and raw_tensor dtype '%R'",
+            "%s: tensor.dtype != raw_tensor.dtype, from tensor dtype %R and raw_tensor dtype %R",
             funcName, dtype, rawDtype);
         return false;
     }
@@ -186,7 +186,7 @@ static bool _isMatchingDimTagsAndRawShape(PyObject* dimTags, PyObject* rawShape,
     if(ndim < 0 || ndim != PyTuple_GET_SIZE(rawShape)) {
         PyErr_Format(
             PyExc_ValueError,
-            "%s: tensor ndim != raw_tensor ndim, from tensor dims '%R' and raw_tensor shape '%R'",
+            "%s: tensor ndim != raw_tensor ndim, from tensor dims %R and raw_tensor shape %R",
             funcName, dimTags, rawShape);
         return false;
     }
@@ -201,7 +201,7 @@ static bool _isMatchingDimTagsAndRawShape(PyObject* dimTags, PyObject* rawShape,
             if(!PyErr_Occurred())
                 PyErr_Format(
                     PyExc_ValueError,
-                    "%s: tensor dim is negative, from tensor dims '%R' and raw_tensor shape '%R'",
+                    "%s: tensor dim is negative, from tensor dims %R and raw_tensor shape %R",
                     funcName, dimTags, rawShape);
             return false;
         }
@@ -210,14 +210,14 @@ static bool _isMatchingDimTagsAndRawShape(PyObject* dimTags, PyObject* rawShape,
             if(!PyErr_Occurred())
                 PyErr_Format(
                     PyExc_ValueError,
-                    "%s: raw_tensor dim is negative, from tensor dims '%R' and raw_tensor shape '%R'",
+                    "%s: raw_tensor dim is negative, from tensor dims %R and raw_tensor shape %R",
                     funcName, dimTags, rawShape);
             return false;
         }
         if(dimInt != rawDimInt) {
             PyErr_Format(
                 PyExc_ValueError,
-                "%s: tensor dim != raw_tensor dim, from tensor dims '%R' and raw_tensor shape '%R'",
+                "%s: tensor dim != raw_tensor dim, from tensor dims %R and raw_tensor shape %R",
                 funcName, dimTags, rawShape);
             return false;
         }

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -327,7 +327,7 @@ PyObject* pyTensorCopyTemplate(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject* tensor;
     const char* name = NULL;
     const char* dtype = NULL;
-    if(!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$zz:tensor_copy_template",
+    if(!PyArg_ParseTupleAndKeywords(args, kwargs, "O|z$z:tensor_copy_template",
             (char**) kwlist, &tensor, &name, &dtype))
         return NULL;
 

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -5,25 +5,36 @@
 #include "tensor_ops.hpp"
 #include "module.hpp"
 
-template<bool resultIsBool, typename TRawOp, typename TPermuteOp, typename TReshapeOp>
-PyObject* compareOrCombine(
+static PyObject* compareOrCombine(
     PyObject* a, PyObject* b,
-    TRawOp rawOp, TPermuteOp permuteOp, TReshapeOp reshapeOp,
+    bool resultIsBool,
+    PyObject* rawOp, PyObject* permuteOp, PyObject* reshapeOp,
     bool allowBroadcastAllSources,
     PyObject* dimOrder
 ) {
 
 }
 
-struct BinCachedOp {
-    PyObject* func;
-    BinCachedOp(PyObject* func_) : func(func_) {}
-    PyObject* operator()(PyObject* a, PyObject* b) const {
-        return PyObject_CallFunction(func, "OO", a, b);
-    }
-};
+static PyObject* compareOrCombineViaCached(
+    PyObject* a, PyObject* b,
+    bool resultIsBool,
+    PyModuleState* modState,
+    BackendWithCachedOps backendId,
+    RawOp rawOp,
+    bool allowBroadcastAllSources,
+    PyObject* dimOrder
+) {
+    return compareOrCombine(
+        a, b,
+        resultIsBool,
+        modState->cachedOp(rawOp, backendId),
+        modState->cachedOp(TOp_Permute, backendId),
+        modState->cachedOp(TOp_Reshape, backendId),
+        allowBroadcastAllSources,
+        dimOrder);
+}
 
-PyObject* pyCompare(PyObject *self, PyObject *args, PyObject *kwargs) {
+PyObject* pyTensorCompare(PyObject *self, PyObject *args, PyObject *kwargs) {
     static const char *kwlist[] = { "a", "kind", "b", "allow_broadcast_all_sources", "dim_order", NULL };
     PyObject* a;
     char* kind;
@@ -69,12 +80,11 @@ PyObject* pyCompare(PyObject *self, PyObject *args, PyObject *kwargs) {
             return NULL;
         }
 
-        BinCachedOp op(modState->cachedOp(it->second, backendId));
-        BinCachedOp permuteOp(modState->cachedOp(TOp_Permute, backendId));
-        BinCachedOp reshapeOp(modState->cachedOp(TOp_Reshape, backendId));
-
-        return compareOrCombine<true>(
-            a, b, op, permuteOp, reshapeOp, (bool) allow_broadcast_all_sources, dim_order);
+        return compareOrCombineViaCached(
+            a, b,
+            true,
+            modState, backendId, it->second,
+            (bool) allow_broadcast_all_sources, dim_order);
     }
 
     PyObject* backend;
@@ -99,24 +109,119 @@ PyObject* pyCompare(PyObject *self, PyObject *args, PyObject *kwargs) {
     return res;
 }
 
-PyObject* pyCombine(PyObject *self, PyObject *args, PyObject *kwargs) {
+PyObject* pyTensorCombine(PyObject *self, PyObject *args, PyObject *kwargs) {
 
 }
 
-PyObject* Tensor_eq() {
+template<RawOp op, bool isCompare>
+static PyObject* _tensorCompareOrCombine(PyModuleState* modState, PyObject* a, PyObject* b) {
+    // fast path -- check predefined backends where we have cached ops
+    if(isTorchBackendForTensor(modState, a) || isTorchBackendForTensor(modState, b)) {
+        return compareOrCombineViaCached(
+            a, b,
+            isCompare,
+            modState, BWCO_Torch, op,
+            false, Py_None);
+    }
+
+    // generic fallback
+    PyObject* backend;
+    if(PyObject_IsInstance(a, modState->tensorType())) {
+        backend = getBackendForTensor(modState, a);
+        if(!backend)
+            return NULL;
+    }
+    else if(PyObject_IsInstance(b, modState->tensorType())) {
+        backend = getBackendForTensor(modState, b);
+        if(!backend)
+            return NULL;
+    }
+    else
+        backend = modState->globalBackend();
+
+    return PyObject_CallMethod(backend, isCompare ? "compare" : "combine", "OsO", a, rawOpName(op), b);
+}
+
+template<RawOp op, bool isCompare>
+static PyObject* _pyTensorCompareOrCombine(PyObject *self, PyObject *const *args, Py_ssize_t nargs) {
+    if(nargs != 2) {
+        PyErr_Format(PyExc_TypeError, "tensor_%s: expected 2 args, got %i", rawOpName(op), nargs);
+        return NULL;
+    }
+
+    PyModuleState* modState = (PyModuleState*) PyModule_GetState(self);
+    if(!modState)
+        return NULL;
+    return _tensorCompareOrCombine<op, isCompare>(modState, args[0], args[1]);
+}
+
+template<RawOp op, bool isCompare>
+static PyObject* _pyTensorCompareOrCombineR(PyObject *self, PyObject *const *args, Py_ssize_t nargs) {
+    if(nargs != 2) {
+        PyErr_Format(PyExc_TypeError, "tensor_r%s: expected 2 args, got %i", rawOpName(op), nargs);
+        return NULL;
+    }
+
+    PyModuleState* modState = (PyModuleState*) PyModule_GetState(self);
+    if(!modState)
+        return NULL;
+    return _tensorCompareOrCombine<op, isCompare>(modState, args[1], args[0]);
+}
+
+
+PyObject* pyTensorEq(PyObject *self, PyObject *const *args, Py_ssize_t nargs) {
     /* Special implementation for eq:
     When comparing to some other invalid type, return False, not a Tensor.
     This is to allow easy equality checks with other random objects.
     See for example here: https://github.com/rwth-i6/returnn/pull/1284
     */
+    if(nargs != 2) {
+        PyErr_Format(PyExc_TypeError, "tensor_eq: expected 2 args, got %i", nargs);
+        return NULL;
+    }
+
+    PyModuleState* modState = (PyModuleState*) PyModule_GetState(self);
+    if(!modState)
+        return NULL;
+
+    // TODO ...
+
+    // default case
+    return _tensorCompareOrCombine<TOp_Eq, true>(modState, args[0], args[1]);
 }
 
-template<char... chars>
-PyObject* Tensor_compare() {
+#define DefinePyTensorCompare(op) \
+    PyObject* pyTensor##op(PyObject *self, PyObject *const *args, Py_ssize_t nargs) { \
+        return _pyTensorCompareOrCombine<TOp_##op, true>(self, args, nargs); \
+    }
 
-}
+DefinePyTensorCompare(Ne)
+DefinePyTensorCompare(Lt)
+DefinePyTensorCompare(Le)
+DefinePyTensorCompare(Gt)
+DefinePyTensorCompare(Ge)
 
-template<char... chars>
-PyObject* Tensor_combine() {
+#define DefinePyTensorCombine(op) \
+    PyObject* pyTensor##op(PyObject *self, PyObject *const *args, Py_ssize_t nargs) { \
+        return _pyTensorCompareOrCombine<TOp_##op, false>(self, args, nargs); \
+    }
 
-}
+#define DefinePyTensorCombineR(op) \
+    PyObject* pyTensorR##op(PyObject *self, PyObject *const *args, Py_ssize_t nargs) { \
+        return _pyTensorCompareOrCombineR<TOp_##op, false>(self, args, nargs); \
+    }
+
+DefinePyTensorCombine(Add)
+DefinePyTensorCombineR(Add)
+DefinePyTensorCombine(Sub)
+DefinePyTensorCombineR(Sub)
+DefinePyTensorCombine(Mul)
+DefinePyTensorCombineR(Mul)
+DefinePyTensorCombine(TrueDiv)
+DefinePyTensorCombineR(TrueDiv)
+DefinePyTensorCombine(FloorDiv)
+DefinePyTensorCombineR(FloorDiv)
+DefinePyTensorCombine(Mod)
+DefinePyTensorCombineR(Mod)
+DefinePyTensorCombine(Pow)
+DefinePyTensorCombineR(Pow)

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -24,7 +24,7 @@ PyObject* tensorCopyTemplate(
     return NULL;
 }
 
-// just copies name, dims, dtype, feature_dim. not sparse_dim, or other things.
+// just copies name, dims, dtype, feature_dim, sparse_dim. no or other things.
 // this is like what bin_op_out_template is doing.
 PyObject* tensorCopyTemplateSimple(
     PyModuleState* modState,
@@ -40,13 +40,19 @@ PyObject* tensorCopyTemplateSimple(
     if(!dims) return NULL;
     PyObjectScopedRef feature_dim_axis = PyObject_GetAttrString(tensor, "_feature_dim_axis");
     if(!feature_dim_axis) return NULL;
+    PyObjectScopedRef sparse_dim = PyObject_GetAttrString(tensor, "sparse_dim");
+    if(!sparse_dim) return NULL;
 
     PyObjectScopedRef res = PyObject_CallFunctionObjArgs(
         modState->tensorType(), name.get(), dims.get(), dtype.get(), NULL);
     if(!res) return NULL;
 
-    if(PyObject_SetAttrString(res, "_feature_dim_axis", feature_dim_axis) < 0)
-        return NULL;
+    if(feature_dim_axis != Py_None)
+        if(PyObject_SetAttrString(res, "_feature_dim_axis", feature_dim_axis) < 0)
+            return NULL;
+    if(sparse_dim != Py_None)
+        if(PyObject_SetAttrString(res, "sparse_dim", sparse_dim) < 0)
+            return NULL;
     return res.release();
 }
 

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -311,7 +311,7 @@ PyObject* pyTensorCopy(PyObject *self, PyObject *args, PyObject *kwargs) {
     static const char *kwlist[] = { "tensor", "name", NULL };
     PyObject* tensor;
     const char* name = NULL;
-    if(!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$z:tensor_copy",
+    if(!PyArg_ParseTupleAndKeywords(args, kwargs, "O|z:tensor_copy",
             (char**) kwlist, &tensor, &name))
         return NULL;
 

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -1,6 +1,107 @@
 
 #include <Python.h>
+#include <map>
+#include <string>
 #include "tensor_ops.hpp"
+#include "module.hpp"
+
+template<bool resultIsBool, typename TRawOp, typename TPermuteOp, typename TReshapeOp>
+PyObject* compareOrCombine(
+    PyObject* a, PyObject* b,
+    TRawOp rawOp, TPermuteOp permuteOp, TReshapeOp reshapeOp,
+    bool allowBroadcastAllSources,
+    PyObject* dimOrder
+) {
+
+}
+
+struct BinCachedOp {
+    PyObject* func;
+    BinCachedOp(PyObject* func_) : func(func_) {}
+    PyObject* operator()(PyObject* a, PyObject* b) const {
+        return PyObject_CallFunction(func, "OO", a, b);
+    }
+};
+
+PyObject* pyCompare(PyObject *self, PyObject *args, PyObject *kwargs) {
+    static const char *kwlist[] = { "a", "kind", "b", "allow_broadcast_all_sources", "dim_order", NULL };
+    PyObject* a;
+    char* kind;
+    PyObject* b;
+    unsigned char allow_broadcast_all_sources = false;
+    PyObject* dim_order = Py_None;
+    if(!PyArg_ParseTupleAndKeywords(args, kwargs, "OsO|$bO:compare", (char**) kwlist,
+            &a, &kind, &b, &allow_broadcast_all_sources, &dim_order))
+        return NULL;
+
+    PyModuleState* modState = (PyModuleState*) PyModule_GetState(self);
+    if(!modState)
+        return NULL;
+
+    bool haveBackendWithCachedOps = false;
+    BackendWithCachedOps backendId;
+    if(isTorchBackendForTensor(modState, a) || isTorchBackendForTensor(modState, b)) {
+        haveBackendWithCachedOps = true;
+        backendId = BWCO_Torch;
+    }
+
+    if(haveBackendWithCachedOps) {
+        // "equal"|"==", "less"|"<", "less_equal"|"<=", "greater"|">", "greater_equal"|">=", "not_equal"|"!="
+        static std::map<std::string, RawOp> kindToCompareFunc;
+        if(kindToCompareFunc.empty()) {
+            kindToCompareFunc["=="] = TOp_Eq;
+            kindToCompareFunc["equal"] = TOp_Eq;
+            kindToCompareFunc["!="] = TOp_Ne;
+            kindToCompareFunc["not_equal"] = TOp_Ne;
+            kindToCompareFunc["<"] = TOp_Lt;
+            kindToCompareFunc["less"] = TOp_Lt;
+            kindToCompareFunc["<="] = TOp_Le;
+            kindToCompareFunc["less_equal"] = TOp_Le;
+            kindToCompareFunc[">"] = TOp_Gt;
+            kindToCompareFunc["greater"] = TOp_Gt;
+            kindToCompareFunc[">="] = TOp_Ge;
+            kindToCompareFunc["greater_equal"] = TOp_Ge;
+        }
+
+        auto it = kindToCompareFunc.find(kind);
+        if(it == kindToCompareFunc.end()) {
+            PyErr_Format(PyExc_ValueError, "compare: invalid kind '%s'", kind);
+            return NULL;
+        }
+
+        BinCachedOp op(modState->cachedOp(it->second, backendId));
+        BinCachedOp permuteOp(modState->cachedOp(TOp_Permute, backendId));
+        BinCachedOp reshapeOp(modState->cachedOp(TOp_Reshape, backendId));
+
+        return compareOrCombine<true>(
+            a, b, op, permuteOp, reshapeOp, (bool) allow_broadcast_all_sources, dim_order);
+    }
+
+    PyObject* backend;
+    if(PyObject_IsInstance(a, modState->tensorType())) {
+        backend = getBackendForTensor(modState, a);
+        if(!backend)
+            return NULL;
+    }
+    else if(PyObject_IsInstance(b, modState->tensorType())) {
+        backend = getBackendForTensor(modState, b);
+        if(!backend)
+            return NULL;
+    }
+    else
+        backend = modState->globalBackend();
+
+    PyObject* func = PyObject_GetAttrString(backend, "compare");
+    if(!func)
+        return NULL;
+    PyObject* res = PyObject_Call(func, args, kwargs);
+    Py_DECREF(func);
+    return res;
+}
+
+PyObject* pyCombine(PyObject *self, PyObject *args, PyObject *kwargs) {
+
+}
 
 PyObject* Tensor_eq() {
     /* Special implementation for eq:

--- a/returnn/frontend/_native/tensor_ops.cpp
+++ b/returnn/frontend/_native/tensor_ops.cpp
@@ -762,12 +762,12 @@ static PyObject* _tensorUnaryFunc(PyModuleState* modState, PyObject* tensor) {
         PyObjectScopedRef actFunc = PyObject_GetAttrString(backend, "activation");
         if(!actFunc) return NULL;
         PyObjectScopedRef opName = PyUnicode_FromString(rawOpName(op));
-        return PyObject_CallFunctionObjArgs(actFunc.get(), rawTensor.get(), opName.get(), NULL);
+        return PyObject_CallFunctionObjArgs(actFunc.get(), tensor, opName.get(), NULL);
     }
     else {
         PyObjectScopedRef func = PyObject_GetAttrString(backend, rawOpName(op));
         if(!func) return NULL;
-        return PyObject_CallFunctionObjArgs(func, rawTensor.get(), NULL);
+        return PyObject_CallFunctionObjArgs(func, tensor, NULL);
     }
 }
 

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -5,8 +5,8 @@
 
 // exported Python functions {
 
-PyObject* pyCompare(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyCombine(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyCompare(PyObject *self, PyObject *args, PyObject *kwargs);
+PyObject* pyCombine(PyObject *self, PyObject *args, PyObject *kwargs);
 
 PyObject* pyTensorEq(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorNe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -1,0 +1,68 @@
+#ifndef __RETURNN_TENSOR_OPS_HPP__
+#define __RETURNN_TENSOR_OPS_HPP__
+
+#include <Python.h>
+
+PyObject* pyCompare(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyCombine(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+PyObject* pyTensorEq(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorNe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorLt(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorLe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorGt(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorGe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+// math binary and unary ops
+
+PyObject* pyTensorAdd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorRAdd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorSub(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorRSub(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorMul(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorRMul(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorTrueDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorRTrueDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorFloorDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorRFloorDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorRMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorPow(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorRPow(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+PyObject* pyTensorNeg(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorAbs(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+PyObject* pyTensorAnd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorRAnd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorOr(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorROr(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+
+// PyTorch specialized ops
+
+PyObject* pyTorchCompare(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchCombine(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+PyObject* pyTorchTensorEq(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorNe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorLt(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorLe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorGt(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorGe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+PyObject* pyTorchTensorAdd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorRAdd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorSub(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorRSub(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorMul(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorRMul(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorTrueDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorRTrueDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorFloorDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorRFloorDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorRMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTorchTensorPow(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+#endif

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -5,8 +5,8 @@
 
 // exported Python functions {
 
-PyObject* pyCompare(PyObject *self, PyObject *args, PyObject *kwargs);
-PyObject* pyCombine(PyObject *self, PyObject *args, PyObject *kwargs);
+PyObject* pyTensorCompare(PyObject *self, PyObject *args, PyObject *kwargs);
+PyObject* pyTensorCombine(PyObject *self, PyObject *args, PyObject *kwargs);
 
 PyObject* pyTensorEq(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorNe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
@@ -15,7 +15,7 @@ PyObject* pyTensorLe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorGt(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorGe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 
-// math binary and unary ops
+// math binary ops
 
 PyObject* pyTensorAdd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorRAdd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
@@ -32,40 +32,15 @@ PyObject* pyTensorRMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorPow(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorRPow(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 
-PyObject* pyTensorNeg(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTensorAbs(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-
 PyObject* pyTensorAnd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorRAnd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorOr(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorROr(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 
+// math unary ops
 
-// PyTorch specialized ops
-
-PyObject* pyTorchCompare(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchCombine(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-
-PyObject* pyTorchTensorEq(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorNe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorLt(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorLe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorGt(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorGe(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-
-PyObject* pyTorchTensorAdd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorRAdd(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorSub(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorRSub(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorMul(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorRMul(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorTrueDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorRTrueDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorFloorDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorRFloorDiv(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorRMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
-PyObject* pyTorchTensorPow(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorNeg(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorAbs(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 
 // }
 

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -49,7 +49,11 @@ PyObject* pyTensorROr(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 // math unary ops
 
 PyObject* pyTensorNeg(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorNot(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTensorAbs(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorCeil(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyTensorFloor(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
 
 // }
 

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -7,10 +7,13 @@ class PyModuleState;
 
 // generic
 
-PyObject* tensorCopyTemplate(PyModuleState* modState, PyObject* tensor);
+PyObject* tensorCopy(PyModuleState* modState, PyObject* tensor, const char* name = NULL);
+PyObject* tensorCopyTemplate(PyModuleState* modState, PyObject* tensor, const char* name = NULL, const char* dtype = NULL);
+PyObject* tensorCopyTemplateSimple(PyModuleState* modState, PyObject* tensor, const char* name_ = NULL, const char* dtype_ = NULL);
 
 // exported Python functions {
 
+PyObject* pyTensorCopy(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject* pyTensorCopyTemplate(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject* pyTensorRawTensorSetter(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyConvertToRawTorchTensorLike(PyObject *self, PyObject *const *args, Py_ssize_t nargs);

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -12,6 +12,7 @@ PyObject* tensorCopyTemplate(PyModuleState* modState, PyObject* tensor);
 // exported Python functions {
 
 PyObject* pyTensorCopyTemplate(PyObject *self, PyObject *args, PyObject *kwargs);
+PyObject* pyTensorRawTensorSetter(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 
 PyObject* pyTensorCompare(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject* pyTensorCombine(PyObject *self, PyObject *args, PyObject *kwargs);

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -3,6 +3,8 @@
 
 #include <Python.h>
 
+// exported Python functions {
+
 PyObject* pyCompare(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyCombine(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 
@@ -64,5 +66,7 @@ PyObject* pyTorchTensorRFloorDiv(PyObject *self, PyObject *const *args, Py_ssize
 PyObject* pyTorchTensorMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTorchTensorRMod(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 PyObject* pyTorchTensorPow(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+
+// }
 
 #endif

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -13,6 +13,7 @@ PyObject* tensorCopyTemplate(PyModuleState* modState, PyObject* tensor);
 
 PyObject* pyTensorCopyTemplate(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject* pyTensorRawTensorSetter(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
+PyObject* pyConvertToRawTorchTensorLike(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 
 PyObject* pyTensorCompare(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject* pyTensorCombine(PyObject *self, PyObject *args, PyObject *kwargs);

--- a/returnn/frontend/_native/tensor_ops.hpp
+++ b/returnn/frontend/_native/tensor_ops.hpp
@@ -3,7 +3,15 @@
 
 #include <Python.h>
 
+class PyModuleState;
+
+// generic
+
+PyObject* tensorCopyTemplate(PyModuleState* modState, PyObject* tensor);
+
 // exported Python functions {
+
+PyObject* pyTensorCopyTemplate(PyObject *self, PyObject *args, PyObject *kwargs);
 
 PyObject* pyTensorCompare(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject* pyTensorCombine(PyObject *self, PyObject *args, PyObject *kwargs);

--- a/returnn/frontend/_utils.py
+++ b/returnn/frontend/_utils.py
@@ -128,6 +128,7 @@ def bin_op_out_template(
         res_dtype = src_dtype
     out = Tensor(name, dims=all_dims, dtype=res_dtype)
     out.feature_dim = res_feature_dim(a, b)
+    out.sparse_dim = res_sparse_dim(a, b)
     if not allow_scalar or a.dims:
         a = a.copy_compatible_to(out, check_dtype=False, check_sparse=False)
     if not allow_scalar or b.dims:
@@ -147,4 +148,19 @@ def res_feature_dim(a: Tensor, b: Tensor) -> Optional[Dim]:
         return b.feature_dim
     if a.feature_dim and b.feature_dim and a.feature_dim == b.feature_dim:
         return a.feature_dim
+    return None
+
+
+def res_sparse_dim(a: Tensor, b: Tensor) -> Optional[Dim]:
+    """
+    :param a:
+    :param b:
+    :return: sparse dim if consistent or None
+    """
+    if a.sparse_dim and not b.sparse_dim:
+        return a.sparse_dim
+    if b.sparse_dim and not a.sparse_dim:
+        return b.sparse_dim
+    if a.sparse_dim and b.sparse_dim and a.sparse_dim == b.sparse_dim:
+        return a.sparse_dim
     return None

--- a/returnn/frontend/audio/specaugment.py
+++ b/returnn/frontend/audio/specaugment.py
@@ -123,7 +123,7 @@ def random_mask(
             y = mask(
                 x_,
                 mask_axis=mask_axis,
-                pos=rf.gather(indices, axis=k_dim, indices=i_),
+                pos=rf.gather(indices, axis=k_dim, indices=rf.copy_to_device(i_, indices.device)),
                 max_amount=max_dims,
                 mask_value=mask_value,
             )

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -152,6 +152,7 @@ class _DimMixin:
         """
         return self.name
 
+    # This is potentially replaced by native implementation (Dim.size.__get__).
     @property
     def dimension(self) -> Optional[int]:
         """

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -227,6 +227,7 @@ class _TensorMixin(_TensorMixinBase):
         self._adapt_batch_consistent_dim_tags()  # TODO where to move this? not needed in general...
         self.sanity_check(assume_complete=False)  # TODO still needed?
 
+    # potentially replaced by native code
     @property
     def _raw_backend(self) -> Optional[Type[Backend]]:
         """

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -621,6 +621,7 @@ class _TensorMixin(_TensorMixinBase):
         dims: Tuple[Dim, ...]
         self._dims = dims
 
+    # Note that this has a native implementation.
     def copy(self, name: Optional[str] = None) -> _t.Tensor:
         """
         :param name: if given, will overwrite this name
@@ -1354,6 +1355,7 @@ class _TensorMixin(_TensorMixinBase):
                 )
         return _t.Tensor(**data_opts)
 
+    # Note that this has a native implementation.
     def copy_template(self, name=None, dtype=None) -> _t.Tensor:
         """
         :param str|None name:

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -446,7 +446,7 @@ class _TensorMixin(_TensorMixinBase):
         """
         return [i for (i, dim) in enumerate(self.shape) if dim is None]
 
-    def get_kwargs(self, include_special_axes=True):
+    def get_kwargs(self, *, include_special_axes=True):
         """
         :param bool include_special_axes: whether to include time and feature special axis marker
         :return: relevant attrib items for copying

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -1358,7 +1358,7 @@ class _TensorMixin(_TensorMixinBase):
         return _t.Tensor(**data_opts)
 
     # Note that this has a native implementation (_native tensor_copy_template).
-    def copy_template(self, *, name=None, dtype=None) -> _t.Tensor:
+    def copy_template(self, name=None, *, dtype=None) -> _t.Tensor:
         """
         :param str|None name:
         :param str|None dtype:

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -624,7 +624,7 @@ class _TensorMixin(_TensorMixinBase):
         self._dims = dims
 
     # Note that this has a native implementation (_native tensor_copy).
-    def copy(self, *, name: Optional[str] = None) -> _t.Tensor:
+    def copy(self, name: Optional[str] = None) -> _t.Tensor:
         """
         :param name: if given, will overwrite this name
         :return: copy of myself, using self.get_kwargs(), and with placeholder and size_placeholder

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -446,6 +446,8 @@ class _TensorMixin(_TensorMixinBase):
         """
         return [i for (i, dim) in enumerate(self.shape) if dim is None]
 
+    # Note that the logic here is replicated for a native copy() and copy_template(),
+    # so keep any changes in sync.
     def get_kwargs(self, *, include_special_axes=True):
         """
         :param bool include_special_axes: whether to include time and feature special axis marker
@@ -621,7 +623,7 @@ class _TensorMixin(_TensorMixinBase):
         dims: Tuple[Dim, ...]
         self._dims = dims
 
-    # Note that this has a native implementation.
+    # Note that this has a native implementation (_native tensor_copy).
     def copy(self, *, name: Optional[str] = None) -> _t.Tensor:
         """
         :param name: if given, will overwrite this name
@@ -1355,7 +1357,7 @@ class _TensorMixin(_TensorMixinBase):
                 )
         return _t.Tensor(**data_opts)
 
-    # Note that this has a native implementation.
+    # Note that this has a native implementation (_native tensor_copy_template).
     def copy_template(self, *, name=None, dtype=None) -> _t.Tensor:
         """
         :param str|None name:

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -622,7 +622,7 @@ class _TensorMixin(_TensorMixinBase):
         self._dims = dims
 
     # Note that this has a native implementation.
-    def copy(self, name: Optional[str] = None) -> _t.Tensor:
+    def copy(self, *, name: Optional[str] = None) -> _t.Tensor:
         """
         :param name: if given, will overwrite this name
         :return: copy of myself, using self.get_kwargs(), and with placeholder and size_placeholder
@@ -1356,7 +1356,7 @@ class _TensorMixin(_TensorMixinBase):
         return _t.Tensor(**data_opts)
 
     # Note that this has a native implementation.
-    def copy_template(self, name=None, dtype=None) -> _t.Tensor:
+    def copy_template(self, *, name=None, dtype=None) -> _t.Tensor:
         """
         :param str|None name:
         :param str|None dtype:

--- a/returnn/tensor/_tensor_op_overloads.py
+++ b/returnn/tensor/_tensor_op_overloads.py
@@ -14,6 +14,9 @@ from ._tensor_mixin_base import _TensorMixinBase
 
 class _TensorOpOverloadsMixin(_TensorMixinBase):
 
+    # Note that all those ops have native implementations as well,
+    # so keep the logic in sync.
+
     # --- comparisons
 
     def __eq__(self: Tensor, other: Union[_rf_types.RawTensorTypes, Tensor]) -> Union[Tensor, bool]:

--- a/returnn/tensor/_tensor_op_overloads.py
+++ b/returnn/tensor/_tensor_op_overloads.py
@@ -50,7 +50,7 @@ class _TensorOpOverloadsMixin(_TensorMixinBase):
     def __ge__(self: Tensor, other: Union[_rf_types.RawTensorTypes, Tensor]) -> Tensor:
         return _rf().compare(self, ">=", other)
 
-    # --- math binary and unary ops
+    # --- math binary ops
 
     def __add__(self: Tensor, other: Union[_rf_types.RawTensorTypes, Tensor]) -> Tensor:
         return _rf().combine(self, "+", other)
@@ -94,22 +94,6 @@ class _TensorOpOverloadsMixin(_TensorMixinBase):
     def __rpow__(self: Tensor, other: Union[_rf_types.RawTensorTypes, Tensor]) -> Tensor:
         return _rf().combine(other, "**", self)
 
-    def __neg__(self: Tensor):  # -x
-        return _rf().neg(self)
-
-    def __invert__(self):  # ~x
-        if True:  # avoid warning: abstract base class...
-            raise NotImplementedError  # TODO
-
-    def __abs__(self: Tensor):
-        return _rf().abs(self)
-
-    def __ceil__(self: Tensor):
-        return _rf().ceil(self)
-
-    def __floor__(self: Tensor):
-        return _rf().floor(self)
-
     def __and__(self: Tensor, other: Union[_rf_types.RawTensorTypes, Tensor]) -> Tensor:
         return _rf().combine(self, "logical_and", other)
 
@@ -121,6 +105,23 @@ class _TensorOpOverloadsMixin(_TensorMixinBase):
 
     def __ror__(self: Tensor, other: Union[_rf_types.RawTensorTypes, Tensor]) -> Tensor:
         return _rf().combine(other, "logical_or", self)
+
+    # --- math unary ops
+
+    def __neg__(self: Tensor):  # -x
+        return _rf().neg(self)
+
+    def __invert__(self: Tensor):  # ~x, but for bool, treat is as logical_not, and otherwise not supported
+        return _rf().logical_not(self)
+
+    def __abs__(self: Tensor):
+        return _rf().abs(self)
+
+    def __ceil__(self: Tensor):
+        return _rf().ceil(self)
+
+    def __floor__(self: Tensor):
+        return _rf().floor(self)
 
 
 def _rf():

--- a/returnn/tensor/tensor.py
+++ b/returnn/tensor/tensor.py
@@ -55,6 +55,7 @@ class Tensor(_TensorMixin, _TensorOpOverloadsMixin, Generic[RawTensorType]):
     version: int
     _extra: Optional[_TensorExtra]
 
+    # This is potentially replaced by native implementation.
     def __init__(
         self,
         name: str,
@@ -153,6 +154,7 @@ class Tensor(_TensorMixin, _TensorOpOverloadsMixin, Generic[RawTensorType]):
         """
         return set(self._dims)
 
+    # This is potentially replaced by native implementation.
     @property
     def raw_tensor(self) -> Optional[RawTensorType]:
         """
@@ -160,6 +162,7 @@ class Tensor(_TensorMixin, _TensorOpOverloadsMixin, Generic[RawTensorType]):
         """
         return self._raw_tensor
 
+    # This is potentially replaced by native implementation.
     @raw_tensor.setter
     def raw_tensor(self, value: Optional[RawTensorType]):
         """

--- a/returnn/tensor/tensor.py
+++ b/returnn/tensor/tensor.py
@@ -154,7 +154,7 @@ class Tensor(_TensorMixin, _TensorOpOverloadsMixin, Generic[RawTensorType]):
         """
         return set(self._dims)
 
-    # This is potentially replaced by native implementation.
+    # This is potentially replaced by native implementation (Tensor._raw_tensor.__get__)
     @property
     def raw_tensor(self) -> Optional[RawTensorType]:
         """
@@ -162,7 +162,7 @@ class Tensor(_TensorMixin, _TensorOpOverloadsMixin, Generic[RawTensorType]):
         """
         return self._raw_tensor
 
-    # This is potentially replaced by native implementation.
+    # This is potentially replaced by native implementation (_native pyTensorRawTensorSetter).
     @raw_tensor.setter
     def raw_tensor(self, value: Optional[RawTensorType]):
         """
@@ -178,7 +178,7 @@ class Tensor(_TensorMixin, _TensorOpOverloadsMixin, Generic[RawTensorType]):
             assert len(raw_shape) == len(self._dims), f"Mismatching shape ndim: Raw tensor {raw_shape} vs Tensor {self}"
             for i, dim in enumerate(self._dims):
                 if dim.dimension is None:
-                    continue  # we allow anything in the placeholder
+                    continue  # we allow anything in the raw_tensor dim
                 if raw_shape[i] != dim.dimension:
                     raise Exception(
                         f"Mismatching shape: Raw tensor {raw_shape} vs Tensor {self};\n"

--- a/returnn/torch/frontend/_backend.py
+++ b/returnn/torch/frontend/_backend.py
@@ -783,7 +783,7 @@ class TorchBackend(Backend[torch.Tensor]):
                 assert dim.dyn_size_ext.dims_set.issubset(
                     indices.dims_set
                 ), f"gather with clip_to_valid: indices ({indices}) dims must be a superset of {dim} dyn-size"
-                size = dim.dyn_size_ext.copy_compatible_to(indices)
+                size = dim.dyn_size_ext.copy_compatible_to(indices, check_sparse=False)
                 indices.raw_tensor = torch.clamp(indices.raw_tensor, torch.tensor(0), size.raw_tensor - 1)
             else:
                 indices.raw_tensor = torch.clamp(indices.raw_tensor, 0, source.raw_tensor.shape[axis_int] - 1)

--- a/returnn/torch/frontend/_backend.py
+++ b/returnn/torch/frontend/_backend.py
@@ -19,6 +19,8 @@ import returnn.frontend as rf
 # noinspection PyProtectedMember
 from returnn.frontend import _random_journal
 
+from . import raw_ops
+
 _TT = Tensor[torch.Tensor]
 
 
@@ -617,6 +619,7 @@ class TorchBackend(Backend[torch.Tensor]):
             else:
                 raise ValueError(f"Parameter {param} assign: Unsupported op: {op}")
 
+    # keep in sync with native implementation
     @staticmethod
     def compare_raw(a: torch.Tensor, kind: str, b: torch.Tensor) -> torch.Tensor:
         """
@@ -631,6 +634,7 @@ class TorchBackend(Backend[torch.Tensor]):
         op = getattr(torch, kind)  # e.g. torch.equal
         return op(a, b)
 
+    # keep in sync with native implementation
     @staticmethod
     def combine_raw(a: torch.Tensor, kind: str, b: torch.Tensor) -> torch.Tensor:
         """
@@ -642,7 +646,7 @@ class TorchBackend(Backend[torch.Tensor]):
         """
         assert a.dim() == b.dim() or a.dim() == 0 or b.dim() == 0
         if kind == "squared_difference":
-            return (a - b) ** 2
+            return raw_ops.squared_difference(a, b)
         kind = {
             "truediv": "true_divide",
             "floordiv": "floor_divide",

--- a/returnn/torch/frontend/raw_ops.py
+++ b/returnn/torch/frontend/raw_ops.py
@@ -1,0 +1,16 @@
+"""
+Combine raw ops which are not directly supported by PyTorch.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def squared_difference(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """
+    :param a:
+    :param b:
+    :return: (a - b) ** 2
+    """
+    return torch.square(a - b)

--- a/returnn/util/py_ext_mod_compiler.py
+++ b/returnn/util/py_ext_mod_compiler.py
@@ -29,8 +29,9 @@ class PyExtModCompiler(NativeCodeCompiler):
     _relevant_info_keys = NativeCodeCompiler._relevant_info_keys + ("py_version",)
 
     def _extra_common_opts(self):
+        base_flags = super()._extra_common_opts()
         py_compile_flags = self._py_compile_vars["CFLAGS"].split() if self._py_compile_vars["CFLAGS"] else []
-        return py_compile_flags
+        return base_flags + py_compile_flags
 
     def _make_info_dict(self):
         d = super()._make_info_dict()

--- a/tests/_setup_test_env.py
+++ b/tests/_setup_test_env.py
@@ -20,6 +20,8 @@ def setup():
     import os
     import sys
 
+    os.environ["RETURNN_TEST"] = "1"
+
     # Enable all logging, up to debug level.
     logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 

--- a/tests/test_rf_loop.py
+++ b/tests/test_rf_loop.py
@@ -185,6 +185,7 @@ def test_scan_changing_dim():
                 # Effectively, this is what you would get with top_k on the logits.
                 beam_dim = Dim(3, name="beam")
                 r = rf.range_over_dim(beam_dim, dtype=x_.dtype)
+                r.sparse_dim = None
                 y_ = rf.combine_bc(y_, "mul", r)
                 y_ = rf.reduce_mean(y_, axis=beam_in_dim)
                 return y_, {"state": y_, "beam_dim": beam_dim}

--- a/tests/test_torch_frontend.py
+++ b/tests/test_torch_frontend.py
@@ -13,6 +13,9 @@ from returnn.tensor import Tensor, Dim
 import returnn.frontend as rf
 
 
+rf.select_backend_torch()
+
+
 def test_dot_scalar_multiplication():
     a_raw = torch.tensor(2.0)
     b_raw = torch.tensor(3.0)

--- a/tests/test_torch_internal_frontend.py
+++ b/tests/test_torch_internal_frontend.py
@@ -13,6 +13,9 @@ from returnn.tensor import Tensor, Dim
 import returnn.frontend as rf
 
 
+rf.select_backend_torch()
+
+
 # Tensor.__eq__ is disabled as per the following error in some TF tests:
 # AssertionError: unhashable type: 'Tensor'.
 # See CI https://github.com/rwth-i6/returnn/actions/runs/4406240591

--- a/tests/test_torch_internal_frontend.py
+++ b/tests/test_torch_internal_frontend.py
@@ -554,6 +554,48 @@ def test_native_torch_tensor_eq():
     assert trace_num_calls == 0
 
 
+def test_native_torch_tensor_eq_op():
+    batch_dim = Dim(2, name="batch_dim")
+    feature_dim = Dim(3, name="feature_dim")
+    tensor_bf = Tensor("tensor", dims=[batch_dim, feature_dim], dtype="float32", raw_tensor=torch.zeros(2, 3))
+    tensor_f = Tensor(
+        "tensor", dims=[feature_dim], dtype="float32", raw_tensor=torch.arange(-1, 2, dtype=torch.float32)
+    )
+
+    from returnn.frontend import _native
+
+    mod = _native.get_module(verbose=True)
+
+    assert Tensor.__eq__ is mod.tensor_eq
+
+    # Check that there is no Python code executed via sys.settrace.
+    trace_num_calls = 0
+
+    def tracefunc(frame, event, arg):
+        print("*** trace:", frame, event, arg)
+        if frame.f_globals is vars(typing):
+            print("   (ignore typing module)")
+            return
+        if frame.f_code is Tensor.__init__.__code__:
+            print("   (ignoring Tensor.__init__ for now, remains to be implemented...)")  # TODO
+            return
+        nonlocal trace_num_calls
+        trace_num_calls += 1
+
+    old_tracefunc = sys.gettrace()
+    try:
+        sys.settrace(tracefunc)
+        res = tensor_bf == tensor_f
+    finally:
+        sys.settrace(old_tracefunc)
+
+    assert isinstance(res, Tensor) and isinstance(res.raw_tensor, torch.Tensor)
+    assert res.dims == (batch_dim, feature_dim)
+    assert res.raw_tensor.detach().numpy().tolist() == [[False, True, False], [False, True, False]]
+
+    assert trace_num_calls == 0
+
+
 def test_native_torch_tensor_neg():
     batch_dim = Dim(2, name="batch_dim")
     feature_dim = Dim(3, name="feature_dim")

--- a/tests/test_torch_internal_frontend.py
+++ b/tests/test_torch_internal_frontend.py
@@ -645,6 +645,8 @@ def test_native_torch_tensor_sub_permute_more_dims():
 
 # TODO test case for Dim with declare_same_as (so fast paths would not apply, fallback to generic)
 
+# TODO test case with duplicated dims with match_priority
+
 
 if __name__ == "__main__":
     better_exchook.install()

--- a/tests/test_torch_internal_frontend.py
+++ b/tests/test_torch_internal_frontend.py
@@ -526,6 +526,9 @@ def test_native_torch_tensor_eq():
         if frame.f_globals is vars(typing):
             print("   (ignore typing module)")
             return
+        if frame.f_code is Tensor.__init__.__code__:
+            print("   (ignoring Tensor.__init__ for now, remains to be implemented...)")  # TODO
+            return
         nonlocal trace_num_calls
         trace_num_calls += 1
 

--- a/tests/test_torch_internal_frontend.py
+++ b/tests/test_torch_internal_frontend.py
@@ -9,6 +9,7 @@ import sys
 import torch
 import pytest
 import unittest
+import typing
 
 from returnn.util import better_exchook
 from returnn.tensor import Tensor, Dim
@@ -522,6 +523,9 @@ def test_native_torch_tensor_eq():
 
     def tracefunc(frame, event, arg):
         print("*** trace:", frame, event, arg)
+        if frame.f_globals is vars(typing):
+            print("   (ignore typing module)")
+            return
         nonlocal trace_num_calls
         trace_num_calls += 1
 

--- a/tests/test_torch_internal_frontend.py
+++ b/tests/test_torch_internal_frontend.py
@@ -535,11 +535,22 @@ def test_native_torch_tensor_eq():
     old_tracefunc = sys.gettrace()
     try:
         sys.settrace(tracefunc)
-        mod.tensor_eq(tensor_bf, tensor_bf)
-        mod.tensor_eq(tensor_bf, tensor_f)
-        mod.tensor_eq(tensor_bf, 0.0)
+        res1 = mod.tensor_eq(tensor_bf, tensor_bf)
+        res2 = mod.tensor_eq(tensor_bf, tensor_f)
+        res3 = mod.tensor_eq(tensor_bf, 0.0)
     finally:
         sys.settrace(old_tracefunc)
+
+    assert isinstance(res1, Tensor) and isinstance(res1.raw_tensor, torch.Tensor)
+    assert res1.dims == (batch_dim, feature_dim)
+    assert res1.raw_tensor.detach().numpy().tolist() == [[True, True, True], [True, True, True]]
+    assert isinstance(res2, Tensor) and isinstance(res2.raw_tensor, torch.Tensor)
+    assert res2.dims == (batch_dim, feature_dim)
+    assert res2.raw_tensor.detach().numpy().tolist() == [[False, True, False], [False, True, False]]
+    assert isinstance(res3, Tensor) and isinstance(res3.raw_tensor, torch.Tensor)
+    assert res3.dims == (batch_dim, feature_dim)
+    assert res3.raw_tensor.detach().numpy().tolist() == [[True, True, True], [True, True, True]]
+
     assert trace_num_calls == 0
 
 


### PR DESCRIPTION
Some of the most often called functions (`Tensor._raw_backend`, `rf.combine`, `rf.compare`, etc) are replaced by native pure C++ implementations.

For #1402.

* [x] `rf.combine` -> `tensor_combine`
* [x] `rf.compare` -> `tensor_compare`
* [x] `Tensor.__eq__`, `Tensor.__ne__`, ..., `Tensor.__add__`, ... (all in `_TensorOpOverloadsMixin`) -> `tensor_eq` etc
* [x] `rf.equal`, `rf.not_equal`, ..., `Tensor.add`, ... -> `tensor_eq` etc
* [x] `rf.logical_not` -> `tensor_invert`
* [x] `rf.abs` -> `tensor_abs`
* [x] `rf.neg` ->  `tensor_neg`
* [x] `rf.ceil` -> `tensor_ceil`
* [x] `rf.floor` -> `tensor_floor`
* [x] `Tensor._raw_backend`
* [x] `Tensor.raw_tensor` setter
* [x] `Tensor.copy`
* [x] `Tensor.copy_template`

I think this is good already for this PR, and already shows great speedup. We can do further work in other separate PRs.

* [ ] `Tensor.__init__`
* [ ] `Tensor.copy_compatible_to`, `Tensor.copy_compatible_to_raw`, `Tensor.copy_compatible_to_dims`, mostly reusing the same logic as in `combine` and `compare` if possible, but then also falling back to the generic code
* [ ] `Dim.__init__`
* [ ] `Dim.__eq__`
* [ ] `Dim.__hash__`
