### PR TITLE
Dim equality without derived_from_op logic

### DIFF
--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -5,6 +5,7 @@ or just rarely used attribs, such that we can save memory for the common case.
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Union, Tuple, Sequence, Dict, List, Callable
+import operator
 
 from returnn.util.basic import Entity
 from returnn.util import basic as util
@@ -2222,6 +2223,18 @@ class _DimMixin:
         """
         return self.derived_from_op and self.derived_from_op.kind == "constant"
 
+    def _cache_dim_math_get(
+        self: Dim, op_kind: str, operand: Union[Dim, int]
+    ) -> Tuple[Dict[Tuple[str, Union[Dim, int]], Dim], Tuple[str, Union[Dim, int]], Optional[Dim]]:
+        same_base = self.get_same_base()
+        # noinspection PyProtectedMember
+        extra = same_base._make_extra()
+        if isinstance(operand, _d.Dim) and operand.is_constant_static_dim():
+            operand = operand.dimension
+        cache = extra.cache_dim_math
+        cache_key = (op_kind, operand)
+        return cache, cache_key, cache.get(cache_key, None)
+
 
 def _make_constant_static_dim(value, kind=None):
     """
@@ -2236,6 +2249,32 @@ def _make_constant_static_dim(value, kind=None):
         derived_from_op=Op(kind="constant", inputs=[], attribs={"value": value}),
         auto_generated=True,
     )
+
+
+def _math_get_dim_via_bin_op(a: Dim, b: Dim, op_kind: str) -> Dim:
+    assert op_kind in {"add", "mul"}
+    op_kind_ = op_kind
+    a_, b_ = a, b
+    if a.is_constant_static_dim() and not b.is_constant_static_dim():
+        op_kind_ = op_kind + "_left"
+        a_, b_ = b, a
+    # noinspection PyProtectedMember
+    cache, cache_key, res = a_._cache_dim_math_get(op_kind_, b_)
+    if res:
+        return res
+    if a.dimension is not None and b.dimension is not None:
+        dim_value = getattr(operator, op_kind)(a.dimension, b.dimension)
+    else:
+        dim_value = None
+    res = _d.Dim(
+        kind=_get_merged_dim_kind((a, b)),
+        description=_get_description(a) + {"add": "+", "mul": "*"}[op_kind] + _get_description(b),
+        dimension=dim_value,
+        derived_from_op=Op(kind=op_kind, inputs=[a, b]),
+        derived_from_tag=_representative_tag((a, b)),
+    )
+    cache[cache_key] = res
+    return res
 
 
 class Op:
@@ -2551,6 +2590,10 @@ class _OpMultTerm:
                     kind = "floordiv"  # for nicer description, and does not matter
             else:
                 raise ValueError("invalid kind %r" % (kind,))
+        # noinspection PyProtectedMember
+        cache, cache_key, res = numerator._cache_dim_math_get(kind + ("" if right else "_left"), denominator)
+        if res:
+            return res
         if kind == "floordiv" and right:
             description = "%s//%s" % (_get_description(numerator), _get_description(denominator))
         elif kind == "ceildiv" and right:
@@ -2566,13 +2609,15 @@ class _OpMultTerm:
         if a is not None and b is not None and a % b == 0:
             op_kind = "truediv"  # makes some other checks simpler
         op_kind += "_" + ("right" if right else "left")
-        return _d.Dim(
+        res = _d.Dim(
             description=description,
             kind=numerator.kind,
             dimension=dim_value,
             derived_from_op=Op(kind=op_kind, inputs=[numerator, denominator]),
             derived_from_tag=numerator,
         )
+        cache[cache_key] = res
+        return res
 
     def as_dim(self):
         """
@@ -2582,37 +2627,16 @@ class _OpMultTerm:
             return _make_constant_static_dim(1)
         if len(self.terms) == 1:
             return self.terms[0]
-        dim_kind = _get_merged_dim_kind(self.terms)
-        return _d.Dim(
-            kind=dim_kind,
-            description="*".join(map(_get_description, self.terms)),
-            dimension=self.dimension,
-            derived_from_op=Op(kind="mul", inputs=list(self.terms)),
-            derived_from_tag=self.representative_tag(),
-        )
-
-    def representative_tag(self):
-        """
-        :rtype: Dim|None
-        """
-        # Also see _OpLinearTerm.representative_tag().
-        # First find any dynamic.
-        for term_ in self.terms:
-            if term_.is_dynamic():
-                return term_
-        # Now find non-unspecified.
-        for term_ in self.terms:
-            if term_.kind != DimTypes.Unspecified:
-                return term_
-        # Now find any.
-        for term_ in self.terms:
-            return term_
-        return None
+        res = self.terms[0]
+        for operand in self.terms[1:]:
+            res = _math_get_dim_via_bin_op(res, operand, "mul")
+        return res
 
 
 class _OpLinearTerm:
     """
-    represents sth like a * b + c
+    Linear combination of :class:`_OpMultTerm`.
+    Represents sth like a * b + c of :class:`Dim`.
     """
 
     @classmethod
@@ -2647,26 +2671,10 @@ class _OpLinearTerm:
             return _make_constant_static_dim(0)
         if len(self.terms) == 1:
             return self.terms[0].as_dim()
-        add_parts = []
-        desc_parts = []
-        dim = 0
-        for term in self.terms:
-            s = term.as_dim()
-            add_parts.append(s)
-            desc_parts.append(_get_description(s))
-            if dim is not None and s.dimension is not None:
-                dim += s.dimension
-            else:
-                dim = None
-        if len(add_parts) == 1:
-            return add_parts[0]
-        return _d.Dim(
-            kind=_get_merged_dim_kind(add_parts),
-            description="+".join(desc_parts),
-            dimension=dim,
-            derived_from_op=Op(kind="add", inputs=add_parts),
-            derived_from_tag=self.representative_tag(),
-        )
+        res = self.terms[0].as_dim()
+        for operand in self.terms[1:]:
+            res = _math_get_dim_via_bin_op(res, operand.as_dim(), "add")
+        return res
 
     def __repr__(self):
         return "Dim._OpLinearTerm(%r)" % (self.terms,)
@@ -2709,6 +2717,10 @@ class _OpLinearTerm:
                 # Merge terms
                 a = _OpMultTerm.from_dim_factors(most_recent_term.terms[:-1]).as_dim()
                 b = _OpMultTerm.from_dim_factors(term.terms[:-1]).as_dim()
+                if a.is_constant_static_dim() and not b.is_constant_static_dim():
+                    a = a.dimension
+                elif b.is_constant_static_dim() and not a.is_constant_static_dim():
+                    b = b.dimension
                 res = _OpMultTerm.from_dim((a + b) if right else (b + a))
                 res.extend_mul_div_(term.terms[-1], kind="mul", right=True)
                 self.terms[-1 if right else 0] = res
@@ -2760,21 +2772,8 @@ class _OpLinearTerm:
         """
         :rtype: Dim|None
         """
-        # First find any dynamic.
-        for term in self.terms:
-            for term_ in term.terms:
-                if term_.is_dynamic():
-                    return term_
-        # Now find non-unspecified.
-        for term in self.terms:
-            for term_ in term.terms:
-                if term_.kind != DimTypes.Unspecified:
-                    return term_
-        # Now find any.
-        for term in self.terms:
-            for term_ in term.terms:
-                return term_
-        return None
+        terms = [_representative_tag(term.terms) for term in self.terms]
+        return _representative_tag([term for term in terms if term])
 
 
 def _get_merged_dim_kind(dim_tags):
@@ -2789,6 +2788,22 @@ def _get_merged_dim_kind(dim_tags):
         return DimTypes.Feature
     else:
         return DimTypes.Spatial
+
+
+def _representative_tag(terms: Sequence[Dim]) -> Optional[Dim]:
+    # Also see _OpLinearTerm.representative_tag().
+    # First find any dynamic.
+    for term_ in terms:
+        if term_.is_dynamic():
+            return term_
+    # Now find non-unspecified.
+    for term_ in terms:
+        if term_.kind != DimTypes.Unspecified:
+            return term_
+    # Now find any.
+    for term_ in terms:
+        return term_
+    return None
 
 
 def dim_cmp_value(obj):

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -1308,9 +1308,6 @@ class _DimMixin:
         other_base = other.get_same_derived_base(same_dim=True) if derived_matches else other.get_same_base()
         if self_base is other_base:
             return True
-        if self_base.derived_from_op and other_base.derived_from_op:
-            if self_base.derived_from_op == other_base.derived_from_op:
-                return True
         self_kind = self.kind
         other_kind = other.kind
         if self_kind == other_kind == DimTypes.Feature and ignore_feature_dim:
@@ -1404,11 +1401,6 @@ class _DimMixin:
                 if self_extra.kind == other_extra.kind == DimTypes.Batch:
                     return True
                 # noinspection PyProtectedMember
-                if self_extra.derived_from_op and other_extra.derived_from_op:
-                    # noinspection PyProtectedMember
-                    if self_extra.derived_from_op == other_extra.derived_from_op:
-                        return True
-                # noinspection PyProtectedMember
                 if self_extra.auto_generated and other_extra.auto_generated and self.description == other.description:
                     return True
             return False
@@ -1439,8 +1431,6 @@ class _DimMixin:
                 return hash(id(self))
             if self_extra.kind == DimTypes.Batch:
                 return hash(())
-            if self_extra.derived_from_op:
-                return hash(self_extra.derived_from_op)
             if self_extra.auto_generated:
                 return hash((self_extra.kind, self.size, self.name))
         return hash(id(self))


### PR DESCRIPTION
Speed up eager execution (#1402) by simplifying `Dim.__hash__` and `Dim.__eq__` by not using a separate check on `derived_from_op` (dim math #853).

The dim math cache (#1416) was another preparation for this, which leads to dim equality in many cases where we had the special equality check on `derived_from_op` before.

This also simplifies the dim tag internals a bit (see #975) (although, the caching logic also made it more complex on the other side, so #975 is still open and relevant, although not really sure how to do that).
