### PR TITLE
ConvLayer and co: use_time_mask and same_static padding

### DIFF
--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 from typing import Optional, Union, Sequence, List, Tuple, Dict
 import typing
-
-import numpy
 import tensorflow as tf
 import contextlib
 import returnn.tf.compat as tf_compat

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6567,7 +6567,7 @@ class ConvLayer(_ConcatInputLayer):
                     continue
                 axis = input_data.get_axis_from_description(dim)
                 mask = input_data.get_sequence_mask_broadcast(axis=axis)
-                x = tf_util.where_bc(mask, x, 0.)
+                x = tf_util.where_bc(mask, x, 0.0)
 
             input_data.placeholder = x
 
@@ -6582,6 +6582,15 @@ class ConvLayer(_ConcatInputLayer):
         strides,
         out_batch_feature_major,
     ):
+        """
+        Returns the placeholder of input_data with same_static padding applied to it.
+        :param input_data:
+        :param num_batch_dims:
+        :param filter_size:
+        :param strides:
+        :param out_batch_feature_major:
+        :return:
+        """
         paddings = [[0, 0] for _ in range(input_data.batch_ndim)]
         for axis, dim in enumerate(input_data.dims):
             if axis < num_batch_dims:
@@ -6599,8 +6608,9 @@ class ConvLayer(_ConcatInputLayer):
                 padding_size_for_axis = filter_size_for_axis - 1
             else:  # dim is static
                 # use standard same padding
-                padding_size_for_axis = filter_size_for_axis - 1 - (
-                    dim.dimension + stride_size_for_axis - 1) % stride_size_for_axis
+                padding_size_for_axis = (
+                    filter_size_for_axis - 1 - (dim.dimension + stride_size_for_axis - 1) % stride_size_for_axis
+                )
 
             if dim.is_dynamic():
                 # Smallest possible padding_size_for_axis is filter_size_for_axis - stride_size_for_axis,

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6580,7 +6580,7 @@ class ConvLayer(_ConcatInputLayer):
         filter_size: Sequence[int],
         strides: Sequence[int],
         out_batch_feature_major: bool,
-    )- > tf.Tensor:
+    ) -> tf.Tensor:
         """
         Returns the placeholder of input_data with same_static padding applied to it.
 

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6882,8 +6882,9 @@ class PoolLayer(_ConcatInputLayer):
             For static axes, "same_static" padding is the same as "same" padding,
             i.e. filter_size - 1 - (T + strides - 1) % strides.
             For dynamic axes, "same_static" calculates the total padding size as
-            filter_size - 1, i.e. it is independent of the length T of the axis and the striding. To avoid skipping
-            any frames on the right, we set left_padding = (filter_size - strides) // 2.
+            filter_size - 1, i.e. it is independent of the length T of the axis and the striding.
+            For dynamic axes, to avoid skipping any frames on the right,
+            we set left_padding = (filter_size - strides) // 2.
         :param tuple[int]|int dilation_rate:
         :param tuple[int]|int|None strides: in contrast to tf.nn.pool, the default (if it is None)
             will be set to pool_size

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -6114,7 +6114,7 @@ class ConvLayer(_ConcatInputLayer):
         filter=None,
         filter_perm=None,
         bias=None,
-        use_time_mask=None,
+        use_time_mask=False,
         **kwargs,
     ):
         """
@@ -6127,8 +6127,9 @@ class ConvLayer(_ConcatInputLayer):
             For static axes, "same_static" padding is the same as "same" padding,
             i.e. filter_size - 1 - (T + strides - 1) % strides.
             For dynamic axes, "same_static" calculates the total padding size as
-            filter_size - 1, i.e. it is independent of the length T of the axis and the striding. To avoid skipping
-            any frames on the right, we set left_padding = (filter_size - strides) // 2.
+            filter_size - 1, i.e. it is independent of the length T of the axis and the striding.
+            For dynamic axes, to avoid skipping any frames on the right,
+            we set left_padding = (filter_size - strides) // 2.
         :param int|Sequence[int] strides: strides for the spatial dims,
             i.e. length of this tuple should be the same as filter_size, or a single int.
         :param int|Sequence[int] dilation_rate: dilation for the spatial dims
@@ -6454,7 +6455,7 @@ class ConvLayer(_ConcatInputLayer):
         input_expand_dims=0,
         input_split_feature_dim=None,
         input_add_feature_dim=False,
-        use_time_mask=None,
+        use_time_mask=False,
     ):
         """
         :param Data input_data:
@@ -6574,20 +6575,20 @@ class ConvLayer(_ConcatInputLayer):
     @classmethod
     def get_input_placeholder_with_same_static_padding(
         cls,
-        input_data,
-        num_batch_dims,
-        filter_size,
-        strides,
-        out_batch_feature_major,
-    ):
+        input_data: Data,
+        num_batch_dims: int,
+        filter_size: Sequence[int],
+        strides: Sequence[int],
+        out_batch_feature_major: bool,
+    )- > tf.Tensor:
         """
         Returns the placeholder of input_data with same_static padding applied to it.
+
         :param input_data:
         :param num_batch_dims:
         :param filter_size:
         :param strides:
         :param out_batch_feature_major:
-        :return:
         """
         paddings = [[0, 0] for _ in range(input_data.batch_ndim)]
         for axis, dim in enumerate(input_data.dims):
@@ -6870,7 +6871,7 @@ class PoolLayer(_ConcatInputLayer):
         out_dim=None,
         out_spatial_dims=None,
         use_channel_first=NotSpecified,
-        use_time_mask=None,
+        use_time_mask=False,
         **kwargs,
     ):
         """
@@ -7133,7 +7134,7 @@ class TransposedConvLayer(_ConcatInputLayer):
         filter=None,
         filter_perm=None,
         bias=None,
-        use_time_mask=None,
+        use_time_mask=False,
         **kwargs,
     ):
         """

--- a/returnn/tf/layers/signal_processing.py
+++ b/returnn/tf/layers/signal_processing.py
@@ -765,7 +765,7 @@ class StftLayer(_ConcatInputLayer):
         in_spatial_dims=None,
         out_spatial_dims=None,
         out_dim=None,
-        use_time_mask=None,
+        use_time_mask=False,
         **kwargs,
     ):
         """
@@ -876,7 +876,7 @@ class IstftLayer(_ConcatInputLayer):
         in_spatial_dims=None,
         out_spatial_dims=None,
         out_dim=None,
-        use_time_mask=None,
+        use_time_mask=False,
         **kwargs,
     ):
         """

--- a/returnn/tf/layers/signal_processing.py
+++ b/returnn/tf/layers/signal_processing.py
@@ -765,6 +765,7 @@ class StftLayer(_ConcatInputLayer):
         in_spatial_dims=None,
         out_spatial_dims=None,
         out_dim=None,
+        use_time_mask=None,
         **kwargs,
     ):
         """
@@ -774,6 +775,7 @@ class StftLayer(_ConcatInputLayer):
         :param list[Dim|str]|None in_spatial_dims:
         :param list[Dim]|None out_spatial_dims:
         :param Dim|None out_dim:
+        :param bool use_time_mask:
         """
         fft_size = fft_size or frame_size
         assert "n_out" not in kwargs
@@ -790,7 +792,11 @@ class StftLayer(_ConcatInputLayer):
         assert self.input_data.have_time_axis()
         in_dim = self.input_data.feature_dim_or_sparse_dim
         input_data, num_batch_dims = ConvLayer.transform_input(
-            self.input_data, network=self.network, in_dim=in_dim, in_spatial_dims=in_spatial_dims
+            self.input_data,
+            network=self.network,
+            in_dim=in_dim,
+            in_spatial_dims=in_spatial_dims,
+            use_time_mask=use_time_mask,
         )
         x = input_data.placeholder
         if input_data.have_feature_axis():
@@ -870,6 +876,7 @@ class IstftLayer(_ConcatInputLayer):
         in_spatial_dims=None,
         out_spatial_dims=None,
         out_dim=None,
+        use_time_mask=None,
         **kwargs,
     ):
         """
@@ -879,6 +886,7 @@ class IstftLayer(_ConcatInputLayer):
         :param list[Dim|str]|None in_spatial_dims:
         :param list[Dim]|None out_spatial_dims:
         :param Dim|None out_dim:
+        :param bool use_time_mask:
         """
         fft_size = fft_size or frame_size
         assert "n_out" not in kwargs
@@ -891,7 +899,11 @@ class IstftLayer(_ConcatInputLayer):
         in_dim = self.input_data.feature_dim_or_sparse_dim
         assert in_dim.dimension == fft_size // 2 + 1
         input_data, num_batch_dims = ConvLayer.transform_input(
-            self.input_data, network=self.network, in_dim=in_dim, in_spatial_dims=in_spatial_dims
+            self.input_data,
+            network=self.network,
+            in_dim=in_dim,
+            in_spatial_dims=in_spatial_dims,
+            use_time_mask=use_time_mask,
         )
         # shape should be (B, ..., T, F)
         input_data = input_data.copy_with_feature_dim_axis(-1)


### PR DESCRIPTION
As for other layers, this adds the 'use_time_mask' parameter to the ConvLayer, PoolLayer, TransposedConvLayer, StftLayer and IstftLayer.

Additionally, we add the 'same_static' option for the padding parameter of the ConvLayer and PoolLayer. This padding leads to the same output dims as 'same' padding but changes the left/right distribution of the padding for dynamic axes (i.e. see documentation of ConvLayer). We add this to guarantee that the convolution and pooling operations lead to the same output for single seqs and batched seqs, which previously was not the case.