### PR TITLE
Ensure transform `axes_split_info` does not assign more dim than is remaining

### DIFF
--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -181,14 +181,16 @@ def transform_param_axes_split_info_to_new_shape(axes_split_info, new_shape, deb
             while sum([d is None for d in new_parts]) > 1:
                 # More than one entry is ambiguous. Assume the next one stayed the same.
                 j = [d is None for d in new_parts].index(True)
-                new_parts[j] = parts[j]
+                current_assigned = sum([d for d in new_parts if d is not None])
+                remaining = new_dim - current_assigned
+                new_parts[j] = min(parts[j], remaining)
             j = [d is None for d in new_parts].index(True)
             new_parts[j] = new_dim - sum([d for d in new_parts if d is not None])
-            assert new_parts[j] > 0, debug_name
+            assert new_parts[j] >= 0, debug_name
         elif sum(new_parts) != new_dim:
             # another heuristic. assume that the first is wrong.
             new_parts[0] = new_dim - sum(new_parts[1:])
-            assert new_parts[0] > 0, debug_name
+            assert new_parts[0] >= 0, debug_name
         assert sum(new_parts) == new_dim, debug_name
         new_axes_split_info.append(new_parts)
     return new_axes_split_info


### PR DESCRIPTION
With this change the issue from `/work/asr3/raissi/shared_workspaces/gunz/2023-05--subsampling-tf2/i6_core/returnn/rasr_training/ReturnnRasrTrainingJob.cf7t8eXaJhu8.cleared.0001` goes away by preventing the code to assign more dimension in the split than is available.

I'm not sure if this is really the right way to approach it, but because this function is a heuristic anyway, it might make sense to add the restriction.

Without this PR the function would try to transform the axes_split_info in `axes_split_info=[[512, 128, 32], [544]], new_shape=(512, 544)` to `[[512, 128, -128], [544]]`. With this PR the function returns `[[512, 0, 0], [544]]` instead.