### PR TITLE
convert np.uint16 to np.int32 to allow torch tensor creation

### DIFF
--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -42,6 +42,8 @@ def create_tensor(array: numpy.ndarray) -> Union[torch.Tensor, numpy.ndarray]:
         return array  # keep as-is. e.g. seq_tag
     if array.dtype == numpy.uint32:
         array = numpy.asarray(array, dtype=numpy.int64)
+    elif array.dtype == numpy.uint16:
+        array = numpy.asarray(array, dtype=numpy.int32)
     return torch.tensor(array)
 
 


### PR DESCRIPTION
`RasrAlignmentDumpHDFJob` at https://github.com/rwth-i6/i6_core/blob/74d328f09276447aa9401292dc6b2ec4230f5f9c/returnn/hdf.py#L332 dumps alignment cache hdfs files in `np.uint16` which failed torch tensor create at https://github.com/rwth-i6/returnn/blob/a0453738dba7ee9e85460d8237a65cbd2f24b880/returnn/torch/data/pipeline.py#L33.