### PR TITLE
Check for torch version before average

### DIFF
--- a/tools/torch_avg_checkpoints.py
+++ b/tools/torch_avg_checkpoints.py
@@ -67,7 +67,12 @@ def merge_checkpoints(in_ckpts: Sequence[str], out_ckpt: str, extra_state: Optio
     out_state: Dict[str, Any] = {"model": out_model_state, "merged_epochs": [], "merged_steps": []}
     for in_ckpt in in_ckpts:
         print("read ckpt:", in_ckpt)
-        in_state = torch.load(in_ckpt, map_location=torch.device("cpu"), mmap=True)
+        torch_version = torch.__version__.split(".")
+        # mmap flag only introduced from 2.1.0 onwards
+        if int(torch_version[0]) < 2 or int(torch_version[0]) == 2 and int(torch_version[1]) < 1:
+            in_state = torch.load(in_ckpt, map_location=torch.device("cpu"))
+        else:
+            in_state = torch.load(in_ckpt, map_location=torch.device("cpu"), mmap=True)
         assert isinstance(in_state, dict)
 
         assert "model" in in_state and isinstance(in_state["model"], dict)

--- a/tools/torch_avg_checkpoints.py
+++ b/tools/torch_avg_checkpoints.py
@@ -67,7 +67,7 @@ def merge_checkpoints(in_ckpts: Sequence[str], out_ckpt: str, extra_state: Optio
     out_state: Dict[str, Any] = {"model": out_model_state, "merged_epochs": [], "merged_steps": []}
     for in_ckpt in in_ckpts:
         print("read ckpt:", in_ckpt)
-        torch_version = torch.__version__.split(".")
+        torch_version = tuple(int(s) for s in str(torch.__version__).split(".")[:2])
         # mmap flag only introduced from 2.1.0 onwards
         if int(torch_version[0]) < 2 or int(torch_version[0]) == 2 and int(torch_version[1]) < 1:
             in_state = torch.load(in_ckpt, map_location=torch.device("cpu"))

--- a/tools/torch_avg_checkpoints.py
+++ b/tools/torch_avg_checkpoints.py
@@ -68,11 +68,10 @@ def merge_checkpoints(in_ckpts: Sequence[str], out_ckpt: str, extra_state: Optio
     for in_ckpt in in_ckpts:
         print("read ckpt:", in_ckpt)
         torch_version = tuple(int(s) for s in str(torch.__version__).split(".")[:2])
-        # mmap flag only introduced from 2.1.0 onwards
-        if int(torch_version[0]) < 2 or int(torch_version[0]) == 2 and int(torch_version[1]) < 1:
-            in_state = torch.load(in_ckpt, map_location=torch.device("cpu"))
-        else:
-            in_state = torch.load(in_ckpt, map_location=torch.device("cpu"), mmap=True)
+        load_kwargs = dict(map_location=torch.device("cpu"), mmap=True)
+        if torch_version < (2, 1):
+            load_kwargs.pop("mmap")  # mmap flag only introduced from 2.1.0 onwards
+        in_state = torch.load(in_ckpt, **load_kwargs)
         assert isinstance(in_state, dict)
 
         assert "model" in in_state and isinstance(in_state["model"], dict)


### PR DESCRIPTION
Currently the tool uses the flag `mmap` which was only introduced in torch 2.1.0. 
This change makes the tool also useable with versions below 2.1.0.