### PR TITLE
fix HDFDataset.is_data_sparse

### DIFF
--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -438,7 +438,7 @@ class HDFDataset(CachedDataset):
         :param str key:
         :rtype: bool
         """
-        if self.get_data_dtype(key).startswith("int"):
+        if "int" in self.get_data_dtype(key):
             if key in self.num_outputs:
                 return self.num_outputs[key][1] <= 1
         return False


### PR DESCRIPTION
I have an `HDFDataset` with `"classes": {"dim": 88, "dtype": "uint16", "sparse": True}`. Currently, the sparsity check returns `False` because of the `uint`.