### PR TITLE
OggZipDataset, speed up init_seq_order with given seq_list

### DIFF
--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -317,7 +317,6 @@ class OggZipDataset(CachedDataset2):
             seqs = {
                 self._get_tag_from_info_dict(seq): i
                 for i, seq in enumerate(self._data)
-                if self._get_tag_from_info_dict(seq) in seq_list
             }
             for seq_tag in seq_list:
                 assert seq_tag in seqs, "did not found all requested seqs. we have eg: %s" % (

--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -314,10 +314,7 @@ class OggZipDataset(CachedDataset2):
         if seq_order is not None:
             self._seq_order = seq_order
         elif seq_list is not None:
-            seqs = {
-                self._get_tag_from_info_dict(seq): i
-                for i, seq in enumerate(self._data)
-            }
+            seqs = {self._get_tag_from_info_dict(seq): i for i, seq in enumerate(self._data)}
             for seq_tag in seq_list:
                 assert seq_tag in seqs, "did not found all requested seqs. we have eg: %s" % (
                     self._get_tag_from_info_dict(self._data[0]),


### PR DESCRIPTION
Removed a line that slows things down when seq_list is large, while not breaking anything. When seq_list is large, it takes a long time to check whether each item is in the list. Also, it doesn't hurt to create a full seq_name:data_index dictionary.