### PR TITLE
Remove shortform of averaging in average tool

### DIFF
--- a/tools/torch_avg_checkpoints.py
+++ b/tools/torch_avg_checkpoints.py
@@ -111,7 +111,7 @@ def merge_checkpoints(in_ckpts: Sequence[str], out_ckpt: str, extra_state: Optio
 
     # Average
     for k in out_model_state:
-        out_model_state[k] /= out_model_state_num[k]
+        out_model_state[k] = out_model_state[k] / out_model_state_num[k]
 
     if extra_state:
         out_state.update(extra_state)


### PR DESCRIPTION
I encountered this weird issue that this line would crash with `RuntimeError: result type Float can't be cast to the desired output type Long` when `out_model_state[k]` was of type `int64`. 
Can be reproduced like:
```
import torch
x = torch.Tensor([1]).to(torch.int64)
x /= 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: result type Float can't be cast to the desired output type Long
```
Not doing the short form but instead `x  = x / 1` works.