### PR TITLE
Remove additional empty string before special tokens when parsing orthography

### DIFF
--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -1713,7 +1713,10 @@ def parse_orthography_into_symbols(
         else:  # not in_special
             if square_brackets_for_specials and c == "[":
                 in_special = 1
-                ret += ["["]
+                if ret and not ret[-1]:
+                    ret[-1] += c
+                else:
+                    ret += ["["]
             else:
                 if word_based:
                     if c.isspace():


### PR DESCRIPTION
In `returnn/tools/collect-words.py`, orthography is parsed via the `parse_orthography_into_symbols()` function. Specifically, when setting `word_based=True`, an empty string `''` is inserted prior to each special token, leading to incorrect parsing and biased counts. This PR fixes the mismatch.