### PR TITLE
HDFDataset, use bisect in _get_file_index()

### DIFF
--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -457,10 +457,10 @@ class HDFDataset(CachedDataset):
         return ", ".join(["HDF dataset", "sequences: %i" % self.num_seqs, "frames: %i" % self.get_num_timesteps()])
 
     def _get_file_index(self, real_seq_idx):
-        file_index = 0
-        while file_index < len(self.file_start) - 1 and real_seq_idx >= self.file_start[file_index + 1]:
-            file_index += 1
-        return file_index
+        # bisect() returns the position for which all elements to the left of the returned index are <= real_seq_idx,
+        # so it actually returns the next file index in which the sequence can be found.
+        # Therefore, we subtract 1 to the index provided.
+        return bisect.bisect(self.file_start, real_seq_idx) - 1
 
 
 # ------------------------------------------------------------------------------

--- a/returnn/datasets/hdf.py
+++ b/returnn/datasets/hdf.py
@@ -3,6 +3,7 @@ Provides :class:`HDFDataset`.
 """
 
 from __future__ import annotations
+import bisect
 import typing
 import collections
 import gc


### PR DESCRIPTION
Helps in managing the training of big datasets (#1519).

Tests in a big dataset (1000 - 2000 HDF files, ~28 M segments) show that the time taken went from 50 minutes down to 15 minutes (approximately).

This code has been previously tested with an assertion that all file indices returned by the current implementation should be equal to those returned by the previous implementation. Either way, I think the implementation makes enough sense by itself.

As per `numpy.searchsorted` vs `bisect.bisect`, I looked into this, and it seems that `searchsorted` fails to give the best performance in single searches nested in a loop (as shown [here](https://stackoverflow.com/questions/62753467/is-python-bisect-faster-than-numpy-searchsorted)), which is pretty much the current use case. Either way, I assume both approaches would be fine since they would yield the same temporal cost.

Note that the current temporal cost of `get_file_index` is `O(log(num_hdf_files))`. This could in theory be reduced to `O(1)` by creating a dense dictionary with all real sequence indices pointing to their corresponding file indices. However, this would imply a spatial cost of `O(num_seqs)` dumped into a single variable, which in our case would definitely be non-negligible (28+ MB for a single variable).

PS: I tried implementing the `O(1)` temporal cost approach but so far I haven't succeeded. I only invested a short amount of time on this issue so I can look into it for longer if you really want, but I find that the speedup that this implementation provides with minimal changes is really valuable.