### PR TITLE
Pass random_seed_offset via env var

### DIFF
--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -28,6 +28,9 @@ from returnn.util.basic import try_run, NumbersDict, OptionalNotImplementedError
 from returnn.tensor import TensorDict
 
 
+RANDOM_SEED_OFFSET_ENV_VAR = "RETURNN_RANDOM_SEED_OFFSET"
+
+
 class Dataset(object):
     """
     Base class for any dataset. This defines the dataset API.
@@ -245,6 +248,13 @@ class Dataset(object):
         config = get_global_config(raise_exception=False)
         if not config:
             return 0
+
+        env_val = os.environ.get(RANDOM_SEED_OFFSET_ENV_VAR)
+        if env_val is not None:
+            try:
+                return int(env_val)
+            except ValueError:
+                pass
         if config.typed_value("torch_distributed") is not None:
             import returnn.torch.distributed
 

--- a/returnn/datasets/concat_files.py
+++ b/returnn/datasets/concat_files.py
@@ -434,6 +434,7 @@ class _WorkerProcParent:
         parent_conn, child_conn = _mp.Pipe()
         self.parent_conn: mpConnection = parent_conn
 
+        # the env will be forwarded to the child process
         with override_env_var(RANDOM_SEED_OFFSET_ENV_VAR, dataset_dict["random_seed_offset"]):
             self.worker_proc = _mp.Process(
                 name=f"{name} worker ep {epoch}",

--- a/returnn/datasets/concat_files.py
+++ b/returnn/datasets/concat_files.py
@@ -423,6 +423,7 @@ class _WorkerProcParent:
         buffer_size: int,
         exit_hook: Optional[Callable[[], None]] = None,
     ):
+        # the dataset makes sure this is set
         assert "random_seed_offset" in dataset_dict
 
         self.epoch = epoch

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -949,7 +949,15 @@ class CombinedDataset(CachedDataset2):
         self.sampling_sizes = sampling_sizes
 
         # This will only initialize datasets needed for features occurring in data_map
-        self.datasets = {key: init_dataset(datasets[key]) for key in self.dataset_keys}
+        self.datasets = {
+            key: init_dataset(
+                {
+                    **datasets[key],
+                    "random_seed_offset": datasets[key].get("random_seed_offset", self.random_seed_offset),
+                }
+            )
+            for key in self.dataset_keys
+        }
 
         self._estimated_num_seqs = sum([self.datasets[k].estimated_num_seqs for k in sorted(self.datasets.keys())])
         self.estimated_num_seq_per_subset = [self.datasets[k].estimated_num_seqs for k in sorted(self.datasets.keys())]

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -4519,3 +4519,19 @@ def find_libcudart_from_runtime():
             return fn
     _find_libcudart_from_runtime_cached = [None]
     return None
+
+
+@contextlib.contextmanager
+def override_env_var(var_name: str, value: str):
+    """
+    context manager for temporarily overriding the value of an env var
+    :param str var_name: the name of the environment variable to override
+    :param str value: the value to set while the context mgr is active
+    """
+
+    cur_val = os.environ.get(var_name)
+    os.environ[var_name] = value
+    try:
+        yield
+    finally:
+        os.environ[var_name] = cur_val

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -4534,4 +4534,7 @@ def override_env_var(var_name: str, value: str):
     try:
         yield
     finally:
-        os.environ[var_name] = cur_val
+        if cur_val is not None:
+            os.environ[var_name] = cur_val
+        else:
+            os.environ.pop(var_name)


### PR DESCRIPTION
Also correctly forward random_seed_offset in MetaDataset. Note this PR currently does not implement setting the environment variable _within_ one RETURNN process, the environment variable is currently only ever set for child processes spawned for dataset handling.