### PR TITLE
`FileCache`: add generic support for all datasets

### DIFF
--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -29,7 +29,7 @@ from returnn.log import log
 from returnn.config import Config, get_global_config
 from returnn.datasets import Dataset, init_dataset, init_dataset_via_str
 from returnn.datasets.hdf import HDFDataset
-from returnn.util import basic as util, debug as debug_util, file_cache
+from returnn.util import basic as util, debug as debug_util
 from returnn.util.basic import BackendEngine, BehaviorVersion
 
 # These imports are not directly used here, but make them available, as other code imports them from here.

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -136,13 +136,6 @@ def init_log():
     log.init_by_config(config)
 
 
-def init_file_cache():
-    """
-    Initializes the global :class:`FileCache`.
-    """
-    file_cache.init_by_config(config)
-
-
 def get_cache_byte_sizes():
     """
     :rtype: (int,int,int)

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -480,7 +480,6 @@ def init(config_filename=None, command_line_options=(), config_updates=None, ext
         startup_callback = config.typed_value("startup_callback")
         startup_callback(config=config)
     if need_data():
-        init_file_cache()
         if config.bool("use_dummy_datasets", False):
             setup_dummy_datasets()
         init_data()

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -29,9 +29,7 @@ from returnn.log import log
 from returnn.config import Config, get_global_config
 from returnn.datasets import Dataset, init_dataset, init_dataset_via_str
 from returnn.datasets.hdf import HDFDataset
-from returnn.util import debug as debug_util
-from returnn.util import basic as util
-from returnn.util import file_cache
+from returnn.util import basic as util, debug as debug_util, file_cache
 from returnn.util.basic import BackendEngine, BehaviorVersion
 
 # These imports are not directly used here, but make them available, as other code imports them from here.

--- a/returnn/__main__.py
+++ b/returnn/__main__.py
@@ -31,6 +31,7 @@ from returnn.datasets import Dataset, init_dataset, init_dataset_via_str
 from returnn.datasets.hdf import HDFDataset
 from returnn.util import debug as debug_util
 from returnn.util import basic as util
+from returnn.util import file_cache
 from returnn.util.basic import BackendEngine, BehaviorVersion
 
 # These imports are not directly used here, but make them available, as other code imports them from here.
@@ -135,6 +136,13 @@ def init_log():
     Initializes the global :class:`Log`.
     """
     log.init_by_config(config)
+
+
+def init_file_cache():
+    """
+    Initializes the global :class:`FileCache`.
+    """
+    file_cache.init_by_config(config)
 
 
 def get_cache_byte_sizes():
@@ -481,6 +489,7 @@ def init(config_filename=None, command_line_options=(), config_updates=None, ext
         startup_callback = config.typed_value("startup_callback")
         startup_callback(config=config)
     if need_data():
+        init_file_cache()
         if config.bool("use_dummy_datasets", False):
             setup_dummy_datasets()
         init_data()

--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -289,6 +289,10 @@ class Dataset(object):
         return 0
 
     def set_cached_files_for_release(self, files: List[str]):
+        """
+        Registers the given files for release from :class:`FileCache` when the
+        dataset's destructor runs.
+        """
         self._cached_files = files
 
     @staticmethod

--- a/returnn/datasets/distrib_files.py
+++ b/returnn/datasets/distrib_files.py
@@ -6,7 +6,7 @@ https://github.com/rwth-i6/returnn/issues/1519
 
 from __future__ import annotations
 
-from typing import Optional, Any, Dict, Tuple, List, Sequence, Collection, Callable, Union
+from typing import Optional, Any, Dict, Tuple, List, Sequence, Callable, Union
 import os
 import sys
 import numpy

--- a/returnn/datasets/distrib_files.py
+++ b/returnn/datasets/distrib_files.py
@@ -136,7 +136,6 @@ class DistributeFilesDataset(CachedDataset2):
         get_sub_epoch_dataset: Callable[[List[FileTree]], Dict[str, Any]],
         preload_next_n_sub_epochs: int = 1,
         buffer_size: int = 1,
-        file_cache_opts: Optional[Dict[str, Any]] = None,
         distrib_shard_files: bool = False,
         _meta_info_cache: Optional[Dict[str, Any]] = None,
         **kwargs,
@@ -157,13 +156,11 @@ class DistributeFilesDataset(CachedDataset2):
         assert preload_next_n_sub_epochs >= 0
         self.preload_next_n_sub_epochs = preload_next_n_sub_epochs
         self.buffer_size = buffer_size
-        self.file_cache_opts = file_cache_opts or {}
         self._file_sizes: Optional[Dict[str, int]] = None  # key -> size. for equal distribution across sub epochs
         self._data_keys: Optional[List[str]] = None
         self._num_seqs: Optional[int] = None
         self._shard_index, self._num_shards = _get_rank_and_size() if distrib_shard_files else (0, 1)
 
-        self._file_cache: Optional[_FileCacheProc] = None
         self._workers: Dict[int, _WorkerProcParent] = {}  # epoch -> worker
         self._files_order_cache: Dict[int, List[List[FileTree]]] = {}  # full epoch (0-indexed) -> files order
 
@@ -205,15 +202,12 @@ class DistributeFilesDataset(CachedDataset2):
             return
         # First, we need to know the num_inputs, num_outputs, total_num_seqs, labels.
         # Init the dataset with the first file.
-        dataset_dict, exit_hook = self._get_sub_dataset_dict(files=[self.files[0]])
-        try:
-            dataset = init_dataset(dataset_dict, extra_kwargs={"seq_ordering": "default"}, parent_dataset=self)
-            self.num_inputs = dataset.num_inputs
-            self.num_outputs = dataset.num_outputs
-            self.labels = dataset.labels
-            self._data_keys = dataset.get_data_keys()
-        finally:
-            exit_hook()
+        dataset_dict = self._get_sub_dataset_dict(files=[self.files[0]])
+        dataset = init_dataset(dataset_dict, extra_kwargs={"seq_ordering": "default"}, parent_dataset=self)
+        self.num_inputs = dataset.num_inputs
+        self.num_outputs = dataset.num_outputs
+        self.labels = dataset.labels
+        self._data_keys = dataset.get_data_keys()
 
     def _lazy_init_file_sizes(self):
         import tree
@@ -224,17 +218,7 @@ class DistributeFilesDataset(CachedDataset2):
             _get_key_for_file_tree(t): sum((os.path.getsize(fn) for fn in tree.flatten(t)), 0) for t in self.files
         }
 
-    def _lazy_init_file_cache_proc(self):
-        if self._file_cache:
-            return
-        self._file_cache = _FileCacheProc(
-            name=f"{self.__class__.__name__} {self.name}", file_cache_opts=self.file_cache_opts
-        )
-
     def __del__(self):
-        if self._file_cache:
-            try_run(self._file_cache.exit, kwargs={"join": False})
-            self._file_cache = None
         for k, worker in self._workers.items():
             try_run(worker.exit, kwargs={"join": False})
         self._workers.clear()
@@ -256,7 +240,6 @@ class DistributeFilesDataset(CachedDataset2):
             return True
 
         self._lazy_init_file_sizes()
-        self._lazy_init_file_cache_proc()
 
         full_epoch_0idx = (epoch - 1) // self.partition_epoch
 
@@ -300,21 +283,20 @@ class DistributeFilesDataset(CachedDataset2):
             files_order: List[List[FileTree]] = self._files_order_cache[full_epoch_0idx_]
             files_for_subep = files_order[(ep_ - 1) % self.partition_epoch]
             print(f"{self}: using files for epoch {ep_}: {files_for_subep}", file=log.v4)
-            dataset_dict, exit_hook = self._get_sub_dataset_dict(files=files_for_subep)
+            dataset_dict = self._get_sub_dataset_dict(files=files_for_subep)
             worker = _WorkerProcParent(
                 name=f"{self.__class__.__name__} {self.name} ep {epoch}",
                 epoch=ep_,
                 full_epoch_0idx=full_epoch_0idx_,
                 dataset_dict=dataset_dict,
                 buffer_size=self.buffer_size,
-                exit_hook=exit_hook,
             )
             self._workers[ep_] = worker
 
         self._num_seqs = self._workers[epoch].get_num_seqs()
         return True
 
-    def _get_sub_dataset_dict(self, files: List[FileTree]) -> Tuple[Dict[str, Any], _FileCacheExitHook]:
+    def _get_sub_dataset_dict(self, files: List[FileTree]) -> Dict[str, Any]:
         dataset_dict = self.get_sub_epoch_dataset(files)
         dataset_dict = extend_dataset_dict_from_parent_dataset(dataset_dict, parent_dataset=self)
         if dataset_dict.get("partition_epoch", 1) != 1:
@@ -324,9 +306,7 @@ class DistributeFilesDataset(CachedDataset2):
                 f"{self}: sub dataset should have explicit seq_ordering "
                 f"(or seq_order_control_dataset for MetaDataset), got: {dataset_dict}"
             )
-        self._lazy_init_file_cache_proc()
-        dataset_dict, exit_hook = self._file_cache.handle_cached_files_in_config(dataset_dict)
-        return dataset_dict, exit_hook
+        return dataset_dict
 
     @staticmethod
     def _distribute_evenly_by_size(
@@ -417,9 +397,6 @@ class DistributeFilesDataset(CachedDataset2):
                 worker.exit()
             self._workers.clear()
             self._files_order_cache.clear()
-            if self._file_cache:
-                self._file_cache.exit()
-                self._file_cache = None
         else:
             if self.epoch in self._workers:
                 worker = self._workers.pop(self.epoch)
@@ -643,98 +620,6 @@ def _worker_proc_loop(
                 got_init_seq_order = True
                 next_seq_idx = 0
                 cache[:] = []
-            else:
-                raise Exception(f"unknown msg {msg!r}")
-    except KeyboardInterrupt:  # when parent dies
-        pass
-
-
-class _FileCacheProc:
-    def __init__(self, *, name: str, file_cache_opts: Dict[str, Any]):
-        self.file_cache_opts = file_cache_opts
-
-        parent_conn, child_conn = _mp.Pipe()
-        self.parent_conn: mpConnection = parent_conn
-
-        self.proc = _mp.Process(
-            name=f"{name} file cache",
-            target=_file_cache_proc_loop,
-            args=(file_cache_opts, child_conn),
-            daemon=True,
-        )
-        self.proc.start()
-        # Make sure the child connection is closed here.
-        # It stays open in the child, until the child dies.
-        # When that happens, now any consecutive read on the pipe
-        # should yield an exception -- which is what we want,
-        # otherwise it would just hang.
-        child_conn.close()
-
-    def handle_cached_files_in_config(self, config: Dict[str, Any]) -> Tuple[Dict[str, Any], _FileCacheExitHook]:
-        """:func:`FileCache.handle_cached_files_in_config`"""
-        self.parent_conn.send(("handle_cached_files_in_config", {"config": config}))
-        msg, (res, files) = self.parent_conn.recv()
-        assert msg == "config_and_cached_files" and isinstance(config, dict) and isinstance(files, list)
-        return res, _FileCacheExitHook(self, files)
-
-    def release_files(self, filenames: Collection[str]):
-        """:func:`FileCache.release_files`"""
-        self.parent_conn.send(("release_files", {"filenames": filenames}))
-
-    def exit(self, *, join: bool = True):
-        """exit"""
-        if self.proc.exitcode is not None:  # already stopped?
-            return
-        self.parent_conn.send(("exit", {}))
-        if join:
-            self.proc.join()
-
-    def __del__(self):
-        # noinspection PyBroadException
-        try:
-            self.exit(join=False)
-        except Exception:
-            pass
-        else:
-            try_run(self.proc.join)
-
-
-class _FileCacheExitHook:
-    def __init__(self, file_cache_proc: _FileCacheProc, cached_files: List[str]):
-        self.file_cache_proc = file_cache_proc
-        self.cached_files = cached_files
-
-    def __call__(self):
-        if self.file_cache_proc.proc.exitcode is not None:
-            return
-        self.file_cache_proc.release_files(self.cached_files)
-
-
-def _file_cache_proc_loop(
-    file_cache_opts: Dict[str, Any],
-    parent_conn: mpConnection,
-):
-    if sys.platform == "linux":
-        with open("/proc/self/comm", "w") as f:
-            f.write(f"File cache")
-
-    assert isinstance(file_cache_opts, dict)
-    assert isinstance(parent_conn, mpConnection)
-
-    from returnn.util.file_cache import FileCache
-
-    file_cache = FileCache(**file_cache_opts)
-
-    try:
-        while True:
-            msg, kwargs = parent_conn.recv()
-            if msg == "exit":
-                break
-            elif msg == "handle_cached_files_in_config":
-                res, files = file_cache.handle_cached_files_in_config(**kwargs)
-                parent_conn.send(("config_and_cached_files", (res, files)))
-            elif msg == "release_files":
-                file_cache.release_files(**kwargs)
             else:
                 raise Exception(f"unknown msg {msg!r}")
     except KeyboardInterrupt:  # when parent dies

--- a/returnn/util/file_cache.py
+++ b/returnn/util/file_cache.py
@@ -392,7 +392,7 @@ class _TouchFilesThread(Thread):
         self.files = defaultdict(int)  # usage counter
         self.interval = interval
         self.cache_base_dir = cache_base_dir
-        self._started = False
+        self._is_started = False  # careful: `_started` is already a member of the base class
 
     def run(self):
         """thread main loop"""
@@ -408,10 +408,10 @@ class _TouchFilesThread(Thread):
 
     def start_once(self):
         """reentrant variant of start() that can safely be called multiple times"""
-        if self._started:
+        if self._is_started:
             return
+        self._is_started = True
         self.start()
-        self._started = True
 
     def files_extend(self, files: Collection[str]):
         """append"""

--- a/returnn/util/file_cache.py
+++ b/returnn/util/file_cache.py
@@ -338,8 +338,8 @@ def get_instance(config: Optional[Config] = None) -> FileCache:
 
     Uses defaults if no global config is set.
     """
-    config = config or get_global_config(raise_exception=False)
-    kwargs = config.value("file_cache_opts", {}) if config is not None else {}
+    config = config or get_global_config(return_empty_if_none=True)
+    kwargs = config.typed_value("file_cache_opts") or {}
     return FileCache(**kwargs)
 
 

--- a/returnn/util/file_cache.py
+++ b/returnn/util/file_cache.py
@@ -22,56 +22,7 @@ from .basic import expand_env_vars, LockFile, human_bytes_size
 from returnn.config import Config, get_global_config
 
 
-__all__ = ["FileCache", "CachedFile", "get_instance", "init_by_config"]
-
-
-DEFAULT_CACHE_DIR = "$TMPDIR/$USER/returnn/file_cache"
-DEFAULT_CLEANUP_FILES_ALWAYS_OLDER_THAN_DAYS = 31.0
-DEFAULT_CLEANUP_FILES_WANTED_OLDER_THAN_DAYS = 7.0
-DEFAULT_CLEANUP_DISK_USAGE_WANTED_FREE_RATIO = 0.2  # try to free at least 20% disk space
-DEFAULT_NUM_TRIES = 3  # retry twice by default
-
-
-cache_instance: Optional["FileCache"] = None
-
-
-def init_by_config(config: Config):
-    """Initializes the global file cache using values from `config`."""
-    global cache_instance
-    if cache_instance:
-        return
-    # TODO: just pass along all `file_cache_*` config values as kwargs?
-    cache_instance = FileCache(
-        cache_directory=config.value(
-            "file_cache_cache_directory",
-            DEFAULT_CACHE_DIR,
-        ),
-        cleanup_files_always_older_than_days=config.value(
-            "file_cache_cleanup_files_always_older_than_days",
-            DEFAULT_CLEANUP_FILES_ALWAYS_OLDER_THAN_DAYS,
-        ),
-        cleanup_files_wanted_older_than_days=config.value(
-            "file_cache_cleanup_files_wanted_older_than_days",
-            DEFAULT_CLEANUP_FILES_WANTED_OLDER_THAN_DAYS,
-        ),
-        cleanup_disk_usage_wanted_free_ratio=config.value(
-            "file_cache_cleanup_disk_usage_wanted_free_ratio",
-            DEFAULT_CLEANUP_DISK_USAGE_WANTED_FREE_RATIO,
-        ),
-        num_tries=config.value(
-            "file_cache_num_tries",
-            DEFAULT_NUM_TRIES,
-        ),
-    )
-
-
-def get_instance() -> "FileCache":
-    """:return: the global file cache instance. Initializes with defaults if not yet initialized."""
-    global cache_instance
-    if cache_instance is None:
-        print("FileCache: global instance not initialized yet, using default")
-        cache_instance = FileCache()
-    return cache_instance
+__all__ = ["FileCache", "CachedFile", "get_instance"]
 
 
 class FileCache:
@@ -103,11 +54,11 @@ class FileCache:
     def __init__(
         self,
         *,
-        cache_directory: str = DEFAULT_CACHE_DIR,
-        cleanup_files_always_older_than_days: float = DEFAULT_CLEANUP_FILES_ALWAYS_OLDER_THAN_DAYS,
-        cleanup_files_wanted_older_than_days: float = DEFAULT_CLEANUP_FILES_WANTED_OLDER_THAN_DAYS,
-        cleanup_disk_usage_wanted_free_ratio: float = DEFAULT_CLEANUP_DISK_USAGE_WANTED_FREE_RATIO,
-        num_tries: int = DEFAULT_NUM_TRIES,
+        cache_directory: str = "$TMPDIR/$USER/returnn/file_cache",
+        cleanup_files_always_older_than_days: float = 31.0,
+        cleanup_files_wanted_older_than_days: float = 7.0,
+        cleanup_disk_usage_wanted_free_ratio: float = 0.2,  # try to free at least 20% disk space
+        num_tries: int = 3,  # retry twice by default
     ):
         """
         :param cache_directory: directory where to cache files.
@@ -379,6 +330,17 @@ class FileCache:
             os.remove(dst_filename)
             return False
         return True
+
+
+def get_instance(config: Optional[Config] = None) -> FileCache:
+    """
+    Returns a file cache instance potentially initialized by the global config.
+
+    Uses defaults if no global config is set.
+    """
+    config = config or get_global_config(raise_exception=False)
+    kwargs = config.value("file_cache_opts", {}) if config is not None else {}
+    return FileCache(**kwargs)
 
 
 def _copy_with_prealloc(src: str, dst: str):

--- a/returnn/util/file_cache.py
+++ b/returnn/util/file_cache.py
@@ -157,6 +157,7 @@ class FileCache:
         if want_free_space_size <= disk_usage.free and cur_time - last_full_cleanup < 60 * 10:
             return
         # immediately update the file's timestamp to reduce racyness between worker processes
+        # Path().touch() also creates the file if it doesn't exist yet
         pathlib.Path(cleanup_timestamp_file).touch(exist_ok=True)
         # Do a full cleanup, i.e. iterate through all files in cache directory and check their mtime.
         all_files = []  # mtime, neg size (better for sorting), filename


### PR DESCRIPTION
* Fix #1544.
* Fix #1549.
* Closes #1545

Let me know your thoughts about the implementation here. I'm not a big fan yet about having to register "from the outside" the files to be released later, but I'm also not sure if there's a better way to unregister the files when the dataset is deinitialized.

One advantage realising support this way is that cache operations for the preloaded subepoch in `DistributeFilesDataset` are now actually happening asynchronously, because `init_dataset`, which invokes caching, is called in the subprocess. Previously this caching would happen in the parent process, blocking training.
