### PR TITLE
Add warning for not using `num_workers > 0` in torch

### DIFF
--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -307,7 +307,7 @@ def create_data_loader_from_batches(
     if loader_opts is None:
         loader_opts: Dict[str, Any] = {}
 
-    if loader_opts.get("num_workers", 0) > 0:
+    if loader_opts.get("num_workers"):
         loader_opts = loader_opts.copy()
         loader_opts.setdefault("persistent_workers", True)
         loader_opts["worker_init_fn"] = _DataLoaderWorkerInitFunc(

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -332,8 +332,10 @@ def create_data_loader_from_batches(
     else:
         log.print_warning(
             "Not using dedicated worker processes for torch data loading.\n"
-            'It is strongly recommended to set torch_dataloader_opts = {"num_workers": 1}\n'
-            "to improve GPU utilization (and to work around issues wrt. leaking file descriptors)."
+            'It is strongly recommended to set torch_dataloader_opts = {"num_workers": 1} '
+            "to improve GPU utilization and to work around some issues.\n"
+            "See e.g. https://github.com/rwth-i6/returnn/issues/1560 for an issue that is fixed by "
+            "using dedicated worker processes."
         )
 
     return torch.utils.data.DataLoader(


### PR DESCRIPTION
Not sure if I need to mention the specific issue this works around, but I think it's worth having mentioned that this not only improves performance, but also works around bugs.

I made this a PR and not a direct commit to master to bikeshed the text.