### PR TITLE
ConcatSeqsDataset pad_narrow_data_to_multiple_of_target_len

### DIFF
--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -1536,10 +1536,18 @@ class ConcatSeqsDataset(CachedDataset2):
                     key,
                     sub_dataset_keys,
                 )
-            for key in self.force_align:
+            for key in self.repeat_in_between_last_frame_up_to_multiple_of:
                 assert (
                     key in sub_dataset_keys
-                ), "%s: force_align key %r not in sub dataset data-keys %r" % (
+                ), "%s: repeat_in_between_last_frame_up_to_multiple_of key %r not in sub dataset data-keys %r" % (
+                    self,
+                    key,
+                    sub_dataset_keys,
+                )
+            for key in self.pad_truncate_data_to_multiple_of:
+                assert (
+                    key in sub_dataset_keys
+                ), "%s: pad_truncate_data_to_multiple_of key %r not in sub dataset data-keys %r" % (
                     self,
                     key,
                     sub_dataset_keys,

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -1580,7 +1580,7 @@ class ConcatSeqsDataset(CachedDataset2):
                     len_diff = data.shape[0] - target_data.shape[0] * multiple
                     if len_diff > 0:
                         # if data longer than ref_data * frame_rate, truncate
-                        data = data[:-len_diff,]
+                        data = data[:-len_diff]
                     elif len_diff < 0:
                         # if data shorter than ref_data * frame_rate, pad by repeating last frame
                         data = numpy.concatenate([data] + [data[-1:]] * -len_diff, axis=0)

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -1417,7 +1417,7 @@ class ConcatSeqsDataset(CachedDataset2):
         self.seq_tag_delim = seq_tag_delim
         self.remove_in_between_postfix = remove_in_between_postfix or {}
         self.repeat_in_between_last_frame_up_to_multiple_of = repeat_in_between_last_frame_up_to_multiple_of or {}
-        self.pad_truncate_data_to_multiple_of = pad_truncate_data_to_target_length or {}
+        self.pad_truncate_data_to_multiple_of = pad_truncate_data_to_multiple_of or {}
         self.epoch_wise_filter = EpochWiseFilter(epoch_wise_filter) if epoch_wise_filter else None
         if isinstance(dataset, dict):
             dataset = dataset.copy()
@@ -1633,7 +1633,7 @@ class ConcatSeqsDataset(CachedDataset2):
     def get_total_num_seqs(self):
         """
         :rtype: int
-        """ 
+        """
         return len(self.full_seq_list)
 
 

--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -1391,7 +1391,7 @@ class ConcatSeqsDataset(CachedDataset2):
         seq_tag_delim=";",
         remove_in_between_postfix=None,
         repeat_in_between_last_frame_up_to_multiple_of=None,
-        pad_truncate_data_to_multiple_of_target_len=None,
+        pad_narrow_data_to_multiple_of_target_len=None,
         use_cache_manager=False,
         epoch_wise_filter=None,
         **kwargs,
@@ -1407,11 +1407,12 @@ class ConcatSeqsDataset(CachedDataset2):
           Now it could happen that ceildiv(data_len1 + data_len2, 6) < align_len1 + align_len2.
           This option would repeat intermediate ending frames such that data_len1 % 6 == 0,
           by setting it to {"data": 6}.
-        :param dict[str,(str,int)]|None pad_truncate_data_to_multiple_of_target_len: data_key -> (target_key, multiple).
-            Force data_len == target_len * multiple for specified data and target.
-            Similar to repeat_in_between_last_frame_up_to_multiple_of but also truncates the data.
-            Mainly for raw wav alignment, where data_len could be slightly longer than target_len * multiple
-            due to mismatch in feature extraction.
+        :param dict[str,(str,int)]|None pad_narrow_data_to_multiple_of_target_len: data_key -> (target_key, multiple).
+            Similar as repeat_in_between_last_frame_up_to_multiple_of, but works for more padding/alignment schemes.
+            Example: align_len == ceildiv(data_len - P, F) for all your sub-sequences, where P is a custom number,
+            repeat_in_between_last_frame_up_to_multiple_of would not work because align_len != ceildiv(data_len, F)
+            This option would pad/narrow so that align_len * F == data_len for all but the last sub-sequences
+            by setting it to {"data": ("classes", F)} to ensure concat_align_len == ceildiv(concat_data_len - P, F)
         :param bool use_cache_manager:
         :param dict[(int,int),dict] epoch_wise_filter: see :class:`EpochWiseFilter`
         """
@@ -1419,7 +1420,7 @@ class ConcatSeqsDataset(CachedDataset2):
         self.seq_tag_delim = seq_tag_delim
         self.remove_in_between_postfix = remove_in_between_postfix or {}
         self.repeat_in_between_last_frame_up_to_multiple_of = repeat_in_between_last_frame_up_to_multiple_of or {}
-        self.pad_truncate_data_to_multiple_of_target_len = pad_truncate_data_to_multiple_of_target_len or {}
+        self.pad_narrow_data_to_multiple_of_target_len = pad_narrow_data_to_multiple_of_target_len or {}
         self.epoch_wise_filter = EpochWiseFilter(epoch_wise_filter) if epoch_wise_filter else None
         if isinstance(dataset, dict):
             dataset = dataset.copy()
@@ -1546,9 +1547,9 @@ class ConcatSeqsDataset(CachedDataset2):
                     key,
                     sub_dataset_keys,
                 )
-            for key in self.pad_truncate_data_to_multiple_of_target_len:
+            for key in self.pad_narrow_data_to_multiple_of_target_len:
                 assert key in sub_dataset_keys, (
-                    f"{self}: pad_truncate_data_to_multiple_of_target_len key {key}"
+                    f"{self}: pad_narrow_data_to_multiple_of_target_len key {key}"
                     f" not in sub dataset data-keys {sub_dataset_keys}"
                 )
         for sub_seq_idx, sub_seq_tag in zip(sub_seq_idxs, sub_seq_tags):
@@ -1574,12 +1575,12 @@ class ConcatSeqsDataset(CachedDataset2):
                     if data.shape[0] % multiple != 0:
                         data = numpy.concatenate([data] + [data[-1:]] * (multiple - data.shape[0] % multiple), axis=0)
                         assert data.shape[0] % multiple == 0
-                if key in self.pad_truncate_data_to_multiple_of_target_len and sub_seq_idx != sub_seq_idxs[-1]:
-                    target_key, multiple = self.pad_truncate_data_to_multiple_of_target_len[key]
+                if key in self.pad_narrow_data_to_multiple_of_target_len and sub_seq_idx != sub_seq_idxs[-1]:
+                    target_key, multiple = self.pad_narrow_data_to_multiple_of_target_len[key]
                     target_data = self.sub_dataset.get_data(sub_seq_idx, target_key)
                     len_diff = data.shape[0] - target_data.shape[0] * multiple
                     if len_diff > 0:
-                        # if data longer than ref_data * frame_rate, truncate
+                        # if data longer than ref_data * frame_rate, narrow the data
                         data = data[:-len_diff]
                     elif len_diff < 0:
                         # if data shorter than ref_data * frame_rate, pad by repeating last frame


### PR DESCRIPTION
To allow training with alignments of raw wav data, we make sure every concatenated sequence has strictly aligned length