### PR TITLE
Torch: unscale gradients before noise and clipping

### DIFF
--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -181,6 +181,9 @@ class Updater(object):
         """
         Perform one step, i.e. update the parameters using the optimizer given the current calculated gradients.
         """
+        if grad_scaler is not None:
+            grad_scaler.unscale_(self.optimizer)
+
         if self._grad_noise:
             gradient_noise_(self.network.parameters(), self._grad_noise)
         if self._grad_clip:


### PR DESCRIPTION
fixes #1590

according to https://pytorch.org/docs/stable/notes/amp_examples.html#working-with-unscaled-gradients gradients should be unscaled before applying gradient clipping.