### PR TITLE
OggZipDataset various fixes

### DIFF
--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -422,23 +422,25 @@ class OggZipDataset(CachedDataset2):
             keys.append("classes")
         return [*keys, "orth", "raw"]
 
-    def get_data_shape(self, key):
+    def get_data_shape(self, key: str):
         """
         :returns get_data(*, key).shape[1:], i.e. num-frames excluded
         :rtype: list[int]
         """
+        assert key in self.get_data_keys()
         if key == "data" and self.feature_extractor is not None:
-            if self.feature_extractor.num_channels is not None:
-                return [self.feature_extractor.num_channels, self.feature_extractor.get_feature_dimension()]
-        if key == "raw":
+            assert self.feature_extractor is not None
+            assert self.feature_extractor.num_channels is not None
+            return [self.feature_extractor.num_channels, self.feature_extractor.get_feature_dimension()]
+        elif key in ["classes", "orth", "raw"]:
             return []
-        return super(OggZipDataset, self).get_data_shape(key)
+        else:
+            raise ValueError(f"{self}: unknown data key {key}")
 
-    def is_data_sparse(self, key) -> bool:
+    def is_data_sparse(self, key: str) -> bool:
         """:return: whether data entry with `key` is sparse"""
-        if key == "raw":
-            return False
-        return super().is_data_sparse(key)
+        assert key in self.get_data_keys()
+        return key == "classes"
 
     def _get_transcription(self, corpus_seq_idx: int):
         """

--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -151,8 +151,6 @@ class OggZipDataset(CachedDataset2):
             self.num_outputs["classes"] = [self.targets.num_labels, 1]
         if self.feature_extractor:
             self.num_outputs["data"] = [self.num_inputs, 2]
-        else:
-            self.num_outputs["data"] = [0, 2]
         self._data: Optional[List[Dict[str, Any]]] = None  # lazily loaded
         self._fixed_random_subset = fixed_random_subset
         self._fixed_random_subset_seed = fixed_random_subset_seed

--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -427,8 +427,7 @@ class OggZipDataset(CachedDataset2):
         :returns get_data(*, key).shape[1:], i.e. num-frames excluded
         :rtype: list[int]
         """
-        assert key in self.get_data_keys()
-        if key == "data" and self.feature_extractor is not None:
+        if key == "data":
             assert self.feature_extractor is not None
             assert self.feature_extractor.num_channels is not None
             return [self.feature_extractor.num_channels, self.feature_extractor.get_feature_dimension()]
@@ -439,7 +438,6 @@ class OggZipDataset(CachedDataset2):
 
     def is_data_sparse(self, key: str) -> bool:
         """:return: whether data entry with `key` is sparse"""
-        assert key in self.get_data_keys()
         return key == "classes"
 
     def _get_transcription(self, corpus_seq_idx: int):

--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -490,11 +490,11 @@ class OggZipDataset(CachedDataset2):
         """
         self._lazy_init()
         seq_tag = self._get_tag_from_info_dict(self._data[corpus_seq_idx])
+        data_features = {}
         if self.feature_extractor:
             with self._open_audio_file(corpus_seq_idx) as audio_file:
-                features = self.feature_extractor.get_audio_features_from_raw_bytes(audio_file, seq_name=seq_tag)
-        else:
-            features = numpy.zeros((), dtype=numpy.float32)  # currently the API requires some dummy values...
+                data = self.feature_extractor.get_audio_features_from_raw_bytes(audio_file, seq_name=seq_tag)
+            data_features = {"data": data}
         targets, txt = self._get_transcription(corpus_seq_idx)
         targets = numpy.array(targets, dtype="int32")
         raw_txt = str_to_numpy_array(txt)
@@ -506,8 +506,7 @@ class OggZipDataset(CachedDataset2):
             orth = list(map(ord, orth))
         orth = numpy.array(orth, dtype="uint8")
         return DatasetSeq(
-            features=features,
-            targets={"classes": targets, "raw": raw_txt, "orth": orth},
+            features={**data_features, "classes": targets, "raw": raw_txt, "orth": orth},
             seq_idx=corpus_seq_idx,
             seq_tag=seq_tag,
         )

--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -429,8 +429,9 @@ class OggZipDataset(CachedDataset2):
         """
         if key == "data":
             assert self.feature_extractor is not None
-            assert self.feature_extractor.num_channels is not None
-            return [self.feature_extractor.num_channels, self.feature_extractor.get_feature_dimension()]
+            if self.feature_extractor.num_channels is not None:
+                return [self.feature_extractor.num_channels, self.feature_extractor.get_feature_dimension()]
+            return [self.feature_extractor.get_feature_dimension()]
         elif key in ["classes", "orth", "raw"]:
             return []
         else:

--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -400,7 +400,8 @@ class OggZipDataset(CachedDataset2):
         self._lazy_init()
         return len(self._data)
 
-    def get_data_dtype(self, key):
+    def get_data_dtype(self, key: str) -> str:
+        """:return: dtype of data entry with `key`"""
         if key == "data":
             return "float32"
         elif key == "classes":
@@ -412,7 +413,8 @@ class OggZipDataset(CachedDataset2):
         else:
             raise ValueError(f"{self}: unknown data key: {key}")
 
-    def get_data_keys(self):
+    def get_data_keys(self) -> List[str]:
+        """:return: available data keys"""
         keys = ["classes", "orth", "raw"]
         if self.feature_extractor is not None:
             keys.append("data")
@@ -430,7 +432,8 @@ class OggZipDataset(CachedDataset2):
             return []
         return super(OggZipDataset, self).get_data_shape(key)
 
-    def is_data_sparse(self, key):
+    def is_data_sparse(self, key) -> bool:
+        """:return: whether data entry with `key` is sparse"""
         if key == "raw":
             return False
         return super().is_data_sparse(key)

--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -400,6 +400,24 @@ class OggZipDataset(CachedDataset2):
         self._lazy_init()
         return len(self._data)
 
+    def get_data_dtype(self, key):
+        if key == "data":
+            return "float32"
+        elif key == "classes":
+            return "int32"
+        elif key == "raw":
+            return "string"
+        elif key == "orth":
+            return "uint8"
+        else:
+            raise ValueError(f"{self}: unknown data key: {key}")
+
+    def get_data_keys(self):
+        keys = ["classes", "orth", "raw"]
+        if self.feature_extractor is not None:
+            keys.append("data")
+        return keys
+
     def get_data_shape(self, key):
         """
         :returns get_data(*, key).shape[1:], i.e. num-frames excluded
@@ -408,7 +426,14 @@ class OggZipDataset(CachedDataset2):
         if key == "data" and self.feature_extractor is not None:
             if self.feature_extractor.num_channels is not None:
                 return [self.feature_extractor.num_channels, self.feature_extractor.get_feature_dimension()]
+        if key == "raw":
+            return []
         return super(OggZipDataset, self).get_data_shape(key)
+
+    def is_data_sparse(self, key):
+        if key == "raw":
+            return False
+        return super().is_data_sparse(key)
 
     def _get_transcription(self, corpus_seq_idx: int):
         """


### PR DESCRIPTION
- No longer relies on `init_seq_order` for data shape/type accessors to be callable
- No longer output dummy data w/ wrong shape
- No longer define `num_outputs["data"]` when no features are extracted.

Pulled out from #1596 