### PR TITLE
Remove some usages of `num_output`

### DIFF
--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -400,6 +400,21 @@ class OggZipDataset(CachedDataset2):
         self._lazy_init()
         return len(self._data)
 
+    def get_data_dim(self, key: str) -> int:
+        """:return: dim of data entry with `key`"""
+        if key == "data":
+            assert self.feature_extractor is not None
+            return self.feature_extractor.get_feature_dimension()
+        elif key == "classes":
+            assert self.targets is not None
+            return self.targets.num_labels
+        elif key == "raw":
+            return 0
+        elif key == "orth":
+            return 256
+        else:
+            raise ValueError(f"{self}: unknown data key: {key}")
+
     def get_data_dtype(self, key: str) -> str:
         """:return: dtype of data entry with `key`"""
         if key == "data":

--- a/returnn/datasets/lm.py
+++ b/returnn/datasets/lm.py
@@ -7,7 +7,7 @@ and some related helpers.
 
 from __future__ import annotations
 
-from typing import Optional, Union, Callable, List, Tuple, BinaryIO, cast
+from typing import Optional, Union, Callable, Iterator, List, Tuple, BinaryIO, cast
 import typing
 import os
 import sys
@@ -394,7 +394,16 @@ class LmDataset(CachedDataset2):
         """
         :rtype: list[str]
         """
-        return sorted(self.num_outputs.keys())
+
+        def _data_keys() -> Iterator[str]:
+            # return keys in alphabetically sorted
+            if self.add_delayed_seq_data:
+                yield "delayed"
+            yield "data"
+            for i in range(self.add_random_phone_seqs):
+                yield f"random{i}"
+
+        return list(_data_keys())
 
     def get_target_list(self):
         """
@@ -1621,6 +1630,12 @@ class TranslationDataset(CachedDataset2):
         :rtype: bool
         """
         return True  # all is sparse
+
+    def get_data_dim(self, _key: str) -> int:
+        """
+        :return: the data dim of data entry `_key`
+        """
+        return self.num_inputs  # same dim for all keys
 
     def get_data_dtype(self, key):
         """


### PR DESCRIPTION
This PR removes some some usage of `num_outputs` in the dataset implementations. This PR is a collection of works and best reviewed and merged on a commit-by-commit basis.

I'm going to extend this further.

Part of #1302 