### PR TITLE
`PostprocessingDataset`: implement laplace sequence ordering

### DIFF
--- a/tests/test_Dataset.py
+++ b/tests/test_Dataset.py
@@ -1087,6 +1087,29 @@ def test_PostprocessingDataset():
             assert len(classes) > 0
         assert count == 1
 
+    # test laplace ordering
+    with create_ogg_zip_txt_only_dataset_mult_seqs() as sub_ds_opts:
+        ds_opts = {
+            "class": "PostprocessingDataset",
+            "dataset": sub_ds_opts,
+            "map_seq": _add_1337_to_classes,
+            "seq_ordering": "laplace:.3",
+        }
+        dataset = init_dataset(ds_opts)
+        dataset.init_seq_order(epoch=1)
+        assert dataset.have_seqs()
+        dataset.load_seqs(0, 6)
+
+        prev_len = None
+        for i in range(3):
+            classes = dataset.get_data(i, "classes")
+            assert prev_len is None or classes.shape[0] >= prev_len
+            prev_len = classes.shape[0]
+        for i in range(3, 6):
+            classes = dataset.get_data(i, "classes")
+            assert prev_len is None or classes.shape[0] <= prev_len
+            prev_len = classes.shape[0]
+
 
 if __name__ == "__main__":
     better_exchook.install()


### PR DESCRIPTION
This PR implements laplace sequence ordering based on the number of segments per bin for the `PostprocessingDataset` via a buffer. The implementation is thereby compatible w/ all the different mapping variants and is designed to reduce padding as much as possible by always completing one full up-and-down cycle wrt. the sequence lengths in the resulting stream of segments.

@Stefanwuu Would you like to test this on your CTC model w/o chunking? :) 