### PR TITLE
`PostprocessingDataset`: add laplace ordering `map_seq_stream` iterator

### DIFF
--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -215,7 +215,7 @@ class PostprocessingDataset(CachedDataset2):
 
 class LaplaceOrdering(Callable[[Iterator[TensorDict]], Iterator[TensorDict]]):
     """
-    Iterator compatible with `PostprocessingDataset`'s `map_seq_stream` applying
+    Iterator compatible with :class:`PostprocessingDataset`'s ``map_seq_stream`` applying
     laplace sequence ordering based on the number of segments per bin.
     """
 

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -239,7 +239,7 @@ class LaplaceOrdering(Callable[[Iterator[TensorDict]], Iterator[TensorDict]]):
         assert num_seqs_per_bin > 0
         self.num_seqs_per_bin = num_seqs_per_bin
 
-    def __call__(self, iterator: Iterator[TensorDict]) -> Iterator[TensorDict]:
+    def __call__(self, iterator: Iterator[TensorDict], **kwargs) -> Iterator[TensorDict]:
         """:return: generator applying laplace sequence ordering on the data"""
         iterator = iter(iterator)
         is_down_phase = False


### PR DESCRIPTION
Alternative implementation to #1604 based solely on "RETURNN userland". The iterator can be imported into a RETURNN config like `from returnn.datasets.postprocessing import LaplaceOrdering` and then used.

Closes #1604
