### PR TITLE
PT preload_from_files ext: random init, external part

### DIFF
--- a/returnn/torch/util/module.py
+++ b/returnn/torch/util/module.py
@@ -1,0 +1,43 @@
+"""
+Utils for modules
+"""
+
+from __future__ import annotations
+from typing import Collection
+import torch
+
+
+def convert_parameters_to_buffers(
+    module: torch.nn.Module, parameter_names: Collection[str], *, deep: bool = True, persistent: bool
+):
+    """
+    :param module:
+    :param parameter_names:
+    :param deep: parameter_name can contain '.' to access submodules
+    :param persistent: whether the buffer is persistent. if True, the buffer will be saved to the state_dict.
+        passed to module.register_buffer.
+    """
+    for parameter_name in parameter_names:
+        convert_parameter_to_buffer(module, parameter_name, deep=deep, persistent=persistent)
+
+
+def convert_parameter_to_buffer(module: torch.nn.Module, parameter_name: str, *, deep: bool = True, persistent: bool):
+    """
+    :param module:
+    :param parameter_name:
+    :param deep: parameter_name can contain '.' to access submodules
+    :param persistent: whether the buffer is persistent. if True, the buffer will be saved to the state_dict.
+        passed to module.register_buffer.
+    """
+    if "." in parameter_name:
+        if not deep:
+            raise ValueError("parameter_name can't contain '.' when deep is False")
+        module_path, _, parameter_name = parameter_name.rpartition(".")
+        module = module.get_submodule(module_path)
+
+    parameter = getattr(module, parameter_name)
+    if not isinstance(parameter, torch.nn.Parameter):
+        raise ValueError(f"{parameter_name} is not a torch.nn.Parameter, got type {type(parameter).__name__}")
+    delattr(module, parameter_name)
+    parameter.requires_grad = False
+    module.register_buffer(parameter_name, parameter, persistent=persistent)


### PR DESCRIPTION
Two features here (maybe we can also leave the individual commits as is):

### 1. `init_for_train=True` and `filename=None` and `pattern`
 
Explicitly specify some parameters which should be randomly initialized (thus `filename=None`) in training.

Note: Currently, if you start training (initial epoch 1), and there is `preload_from_files`, then if that does not cover all model parameters, it will exit with the error: "Missing key(s) in state_dict: ... Any missing key is an error.". I.e. the expectation is, once `preload_from_files` is used, that covers all model parameters.

In further training epochs, when an existing checkpoint is loaded, it will also do the check, but only for those params which are not already in the previous checkpoint. The same logic also applies also for recognition.

So, when you want to use `preload_from_files` for training to preload some of the parameters, and you don't cover all parameters, but you want to leave some parameters randomly initialized, then you need this feature.

### 2. `init_for_train="always"`

Specify some parameters which are always loaded, no matter if it is the initial first training epoch, some later training epoch, or recognition. This also will exclude those parameters from training and exclude those parameters when saving the checkpoint, as it is assumed that they will later again be loaded when they are needed. Or maybe you don't need them anyway for recognition, as they are only used for some auxiliary loss, or for knowledge distillation or so.
