### PR TITLE
`PostprocessingDataset`: pass along `seq_tag`

### DIFF
--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -203,7 +203,7 @@ class PostprocessingDataset(CachedDataset2):
             if loaded_seq_idx != seq_idx:
                 continue
             seq = DatasetSeq(
-                features={k: t.raw_tensor for k, t in tensor_dict.data.items()},
+                features={k: t.raw_tensor for k, t in tensor_dict.data.items() if k != "seq_tag"},
                 seq_idx=seq_idx,
                 seq_tag=str(tensor_dict["seq_tag"].raw_tensor),
             )

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -261,7 +261,7 @@ class PostprocessingDataset(CachedDataset2):
 
                 # Re-adding the seq tag here causes no harm in case it's dropped since we don't
                 # add/drop any segments w/ the non-iterator postprocessing function.
-                if not "seq_tag" in tensor_dict.data:
+                if "seq_tag" not in tensor_dict.data:
                     tensor_dict.data["seq_tag"].raw_tensor = str_to_numpy_array(self._dataset.get_tag(seq_index))
 
             yield tensor_dict

--- a/tests/test_Dataset.py
+++ b/tests/test_Dataset.py
@@ -1086,6 +1086,9 @@ def test_PostprocessingDataset():
         classes = dataset.get_data(0, "classes")
         assert all(c - 1337 >= 0 for c in classes)
 
+        # assert that default seq tags have been replaced w/ ones from oggzip dset
+        assert not dataset.get_tag(0).startswith("seq-")
+
     count = 0
 
     def _repeat2(input_iter: Iterator[TensorDict], **kwargs) -> Iterator[TensorDict]:


### PR DESCRIPTION
Closes #1622

I added an assertion to make sure the seq_tags are not lost. Do we want this, or should we be lenient here? I think the breakage's impact to people from adding this assertion is rather limited.