### PR TITLE
`OggZipDataset`: normalize // to / when reading files from archive

### DIFF
--- a/returnn/datasets/audio.py
+++ b/returnn/datasets/audio.py
@@ -179,7 +179,7 @@ class OggZipDataset(CachedDataset2):
 
                 return gzip.open(self._separate_txt_files[name], "rb").read()
         if self._zip_files is not None:
-            return self._zip_files[zip_index].read(filename)
+            return self._zip_files[zip_index].read(filename.replace("//", "/"))
         return open("%s/%s" % (self.paths[0], filename), "rb").read()
 
     def _collect_data_part(self, zip_index) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:


### PR DESCRIPTION
The dataset implementation joins some (potentially empty) paths, sometimes leading to double slashes in the resulting paths. This can break lookup in the zip file, even though there is a file at that path. By normalizing // to / the file can be read from the archive properly. On normal file systems this usually isn't a problem, because they also do this.