### PR TITLE
FileCache: update mtime of lockfile immediately after acquiring it

### DIFF
--- a/returnn/util/file_cache.py
+++ b/returnn/util/file_cache.py
@@ -327,7 +327,7 @@ class FileCache:
         # Copy the file, while holding a lock. See comment on lock_timeout above.
         with LockFile(
             directory=dst_dir, name=os.path.basename(dst_filename) + ".lock", lock_timeout=self._lock_timeout
-        ) as lock:
+        ) as lock, self._touch_files_thread.files_added_context(lock.lockfile):
             # Maybe it was copied in the meantime, while waiting for the lock.
             if self._check_existing_copied_file_maybe_cleanup(src_filename, dst_filename):
                 print(f"FileCache: using existing file {dst_filename}")
@@ -349,7 +349,7 @@ class FileCache:
                     f" to be older than {self._lock_timeout * 0.8:.1f}s but it is {dst_tmp_file_age} seconds old"
                 )
 
-            with self._touch_files_thread.files_added_context([dst_dir, lock.lockfile]):
+            with self._touch_files_thread.files_added_context(dst_dir):
                 # save mtime before the copy process to have it pessimistic
                 orig_mtime_ns = os.stat(src_filename).st_mtime_ns
                 FileInfo(mtime_ns=orig_mtime_ns).save(self._get_info_filename(dst_filename))


### PR DESCRIPTION
After this change there are no more intermediate FS operations after we acquire the lock file and before we start updating its mtime. If the FS is slow this could help the lockfile stay non-stale.