### PR TITLE
`MPDataset`: make compatible with being wrapped in `PPDataset`

### DIFF
--- a/returnn/datasets/multi_proc.py
+++ b/returnn/datasets/multi_proc.py
@@ -461,7 +461,7 @@ class MultiProcDataset(CachedDataset2):
         """data keys"""
         if self._data_keys is None:
             self._lazy_init()
-            assert self._data_keys  is not None
+            assert self._data_keys is not None
         return self._data_keys
 
     def get_data_dtype(self, key: str):

--- a/returnn/datasets/multi_proc.py
+++ b/returnn/datasets/multi_proc.py
@@ -464,14 +464,14 @@ class MultiProcDataset(CachedDataset2):
             assert self._data_keys is not None
         return self._data_keys
 
-    def get_data_dtype(self, key: str):
+    def get_data_dtype(self, key: str) -> str:
         """:return: dtype of `key`"""
         if self._data_dtypes is None:
             self._lazy_init()
             assert self._data_dtype is not None
         return self._data_dtypes[key]
 
-    def is_data_sparse(self, key: str):
+    def is_data_sparse(self, key: str) -> bool:
         """:return: whether `key` is sparse"""
         if self.num_outputs is None:
             self._lazy_init()

--- a/returnn/datasets/multi_proc.py
+++ b/returnn/datasets/multi_proc.py
@@ -182,16 +182,23 @@ class MultiProcDataset(CachedDataset2):
         msg, self.labels = self._seq_order_proc_parent_conn.recv()
         assert msg == "labels"
 
-    def _lazy_init_data_keys_and_dtypes(self):
+    def _lazy_init_data_keys(self):
         if self._data_keys is not None:
-            assert self._data_dtypes is not None
             return
 
         self._lazy_init()  # indempotent, will not run twice if not needed
 
-        self._seq_order_proc_parent_conn.send(("get_data_keys_and_dtypes", {}))
+        self._seq_order_proc_parent_conn.send(("get_data_keys", {}))
         msg, self._data_keys = self._seq_order_proc_parent_conn.recv()
         assert msg == "data_keys"
+
+    def _lazy_init_data_dtypes(self):
+        if self._data_dtypes is not None:
+            return
+
+        self._lazy_init()  # indempotent, will not run twice if not needed
+
+        self._seq_order_proc_parent_conn.send(("get_data_dtypes", {}))
         msg, self._data_dtypes = self._seq_order_proc_parent_conn.recv()
         assert msg == "data_dtypes"
 
@@ -316,10 +323,13 @@ class MultiProcDataset(CachedDataset2):
                     except NotImplementedError as exc:
                         all_tags = NotImplementedError(f"{exc} in {dataset}")
                     parent_conn.send(("all_tags", all_tags))
-                elif msg == "get_data_keys_and_dtypes":
+                elif msg == "get_data_keys":
                     assert dataset
                     data_keys = dataset.get_data_keys()
                     parent_conn.send(("data_keys", data_keys))
+                elif msg == "get_data_dtypes":
+                    assert dataset
+                    data_keys = dataset.get_data_keys()
                     parent_conn.send(("data_dtypes", {k: dataset.get_data_dtype(k) for k in data_keys}))
                 elif msg == "init_seq_order":
                     if dataset is None:
@@ -471,14 +481,14 @@ class MultiProcDataset(CachedDataset2):
     def get_data_keys(self) -> List[str]:
         """data keys"""
         if self._data_keys is None:
-            self._lazy_init_data_keys_and_dtypes()
+            self._lazy_init_data_keys()
             assert self._data_keys is not None
         return self._data_keys
 
     def get_data_dtype(self, key: str) -> str:
         """:return: dtype of `key`"""
         if self._data_dtypes is None:
-            self._lazy_init_data_keys_and_dtypes()
+            self._lazy_init_data_dtypes()
             assert self._data_dtypes is not None
         return self._data_dtypes[key]
 

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -155,7 +155,7 @@ class PostprocessingDataset(CachedDataset2):
         for k, t in self._out_tensor_dict_template.data.items():
             if t.vocab:
                 self.labels[k] = t.vocab.labels
-            elif t.sparse_dim:  # sparse_dim but not vocab
+            elif t.sparse_dim and t.sparse_dim.dimension is not None:  # sparse_dim but not vocab
                 self.labels[k] = list(map(str, range(t.sparse_dim.dimension)))  # dummy labels
 
     def init_seq_order(

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -155,7 +155,7 @@ class PostprocessingDataset(CachedDataset2):
         for k, t in self._out_tensor_dict_template.data.items():
             if t.vocab:
                 self.labels[k] = t.vocab.labels
-            elif t.sparse_dim and t.sparse_dim.dimension is not None:  # sparse_dim but not vocab
+            elif t.sparse_dim:  # sparse_dim but not vocab
                 self.labels[k] = list(map(str, range(t.sparse_dim.dimension)))  # dummy labels
 
     def init_seq_order(


### PR DESCRIPTION
This PR makes wrapping a MultiProcDataset into a PPDataset possible

Previously the least you'd get is this crash:

```
EXCEPTION
Traceback (most recent call last):
  File "/[...]/work/i6_core/tools/git/CloneGitRepositoryJob.L2lZBnhLY2SW/output/returnn/rnn.py", line 11, in <module>
    line: main()
    locals:
      main = <local> <function main at 0x7f8117bb7010>
  File "/[...]/recipe/returnn/returnn/__main__.py", line 740, in main
    line: init(command_line_options=argv[1:])
    locals:
      init = <global> <function init at 0x7f8117bb6d40>
      command_line_options = <not found>
      argv = <local> ['/[...]/work/i6_core/tools/git/CloneGitRepositoryJob.L2lZBnhLY2SW/output/returnn/rnn.py', '/[...]/work/i6_core/returnn/training/ReturnnTrainingJob.v52PWHM5t44W/output/returnn.config'], _[0]: {len = 129}
  File "/[...]/recipe/returnn/returnn/__main__.py", line 486, in init
    line: init_data()
    locals:
      init_data = <global> <function init_data at 0x7f8117bb69e0>
  File "/[...]/recipe/returnn/returnn/__main__.py", line 218, in init_data
    line: train_data, extra_train = load_data(config, train_cache_bytes, "train")
    locals:
      train_data = <global> None
      extra_train = <not found>
      load_data = <global> <function load_data at 0x7f8117bb6950>
      config = <global> <returnn.config.Config object at 0x7f8117b8bf10>
      train_cache_bytes = <local> 1513975971841
  File "/[...]/recipe/returnn/returnn/__main__.py", line 190, in load_data
    line: data = init_dataset(kwargs)
    locals:
      data = <not found>
      init_dataset = <global> <function init_dataset at 0x7f8117b7f640>
      kwargs = <local> {'name': 'train', 'class': 'PostprocessingDataset', 'dataset': {'buffer_size': 100, 'class': 'MultiProcDataset', 'dataset': {'class': 'PostprocessingDataset', 'dataset': {'audio': {'features': 'raw', 'peak_normalization': True, 'pre_process': None, 'preemphasis': None, 'sample_rate': 8000}, 'clas..., len = 6
  File "/[...]/recipe/returnn/returnn/datasets/basic.py", line 1496, in init_dataset
    line: obj = clazz(**kwargs)
    locals:
      obj = <not found>
      clazz = <local> <class 'returnn.datasets.postprocessing.PostprocessingDataset'>
      kwargs = <local> {'name': 'train', 'dataset': {'buffer_size': 100, 'class': 'MultiProcDataset', 'dataset': {'class': 'PostprocessingDataset', 'dataset': {'audio': {'features': 'raw', 'peak_normalization': True, 'pre_process': None, 'preemphasis': None, 'sample_rate': 8000}, 'class': 'OggZipDataset', 'epoch_wise_f...
  File "/[...]/recipe/returnn/returnn/datasets/postprocessing.py", line 138, in PostprocessingDataset.__init__
    line: {name: self._make_tensor_template_from_input(name) for name in self._dataset.get_data_keys()}
    locals:
      name = <not found>
      self = <local> <PostprocessingDataset 'train' epoch=None>
      self._make_tensor_template_from_input = <local> <bound method PostprocessingDataset._make_tensor_template_from_input of <PostprocessingDataset 'train' epoch=None>>
      self._dataset = <local> <MultiProcDataset 'dataset_id140187802594336' epoch=None>
      self._dataset.get_data_keys = <local> <bound method CachedDataset2.get_data_keys of <MultiProcDataset 'dataset_id140187802594336' epoch=None>>
  File "/[...]/recipe/returnn/returnn/datasets/cached2.py", line 218, in CachedDataset2.get_data_keys
    line: self._load_something()
    locals:
      self = <local> <MultiProcDataset 'dataset_id140187802594336' epoch=None>
      self._load_something = <local> <bound method CachedDataset2._load_something of <MultiProcDataset 'dataset_id140187802594336' epoch=None>>
  File "/[...]/recipe/returnn/returnn/datasets/cached2.py", line 172, in CachedDataset2._load_something
    line: assert self.added_data, f"{self}: _load_something: could not load anything"
    locals:
      self = <local> <MultiProcDataset 'dataset_id140187802594336' epoch=None>
      self.added_data = <local> []
AssertionError: <MultiProcDataset 'dataset_id140187802594336' epoch=None>: _load_something: could not load anything
```