### PR TITLE
`PPDataset`: be strict about `seq_order` and `seq_list` in `init_seq_order`

### DIFF
--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from itertools import islice
 from numpy.random import RandomState
-from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, TypeVar
 
 from returnn.datasets.basic import DatasetSeq
 from returnn.datasets.util.strings import str_to_numpy_array
@@ -127,7 +127,7 @@ class PostprocessingDataset(CachedDataset2):
         self._map_seq_stream = map_seq_stream
         self._map_outputs = map_outputs
         self._rng = RandomState(self._get_random_seed_for_epoch(0))
-        self._seq_list_for_validation: Optional[Set[str]] = None
+        self._seq_list_for_validation: Optional[List[str]] = None
 
         self._dataset = init_dataset(self._dataset_def, parent_dataset=self)
         if self._map_seq_stream is None:

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -184,7 +184,7 @@ class PostprocessingDataset(CachedDataset2):
         assert self._dataset is not None
         self._dataset.init_seq_order(epoch=epoch, seq_list=seq_list, seq_order=seq_order)
         self._data_iter = enumerate(self._build_mapping_iter())
-        self._seq_list_for_validation = set(seq_list) if seq_list else None
+        self._seq_list_for_validation = seq_list
         if self._map_seq_stream is None:
             # If we don't have an iterable mapper we know the number of segments exactly
             # equals the number of segments in the wrapped dataset
@@ -283,10 +283,11 @@ class PostprocessingDataset(CachedDataset2):
                     tensor_dict.data["seq_tag"].raw_tensor = seq_tag_tensor
 
                 if self._seq_list_for_validation is not None:
-                    seq_tag = tensor_dict.data["seq_tag"].raw_tensor.item()
+                    seq_tag = self._seq_list_for_validation[seq_index]
+                    tag_of_seq = tensor_dict.data["seq_tag"].raw_tensor.item()
                     assert (
-                        seq_tag in self._seq_list_for_validation
-                    ), f"seq tag {seq_tag} not in seq_list given in init_seq_order"
+                        tag_of_seq == seq_tag
+                    ), f"seq tag mismath: {tag_of_seq} != {seq_tag} for seq index {seq_index} when seq list is given"
 
             yield tensor_dict
             seq_index += 1

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -176,7 +176,7 @@ class PostprocessingDataset(CachedDataset2):
             if seq_order is not None:
                 raise ValueError("map_seq_stream is set, cannot specify custom seq_order")
 
-        if epoch is None:
+        if epoch is None and seq_list is None and seq_order is None:
             self._num_seqs = 0
             return True
 


### PR DESCRIPTION
Closes #1651 by disallowing `seq_order` and` seq_list` when`map_set_stream` is set, and otherwise validating the `seq_list`. Not sure if the set inclusivity test is not too expensive after all.