### PR TITLE
PT: print padding amount per batch and subepoch

### DIFF
--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -386,9 +386,11 @@ class Engine(EngineBase):
                     break
 
                 keys_w_seq_len = [k for k in extern_data_raw if f"{k}:seq_len" in extern_data_raw]
-                total_data_size_packed += NumbersDict({k: sum(extern_data_raw[f"{k}:seq_len"]) for k in keys_w_seq_len})
+                total_data_size_packed += NumbersDict(
+                    {k: sum(extern_data_raw[f"{k}:seq_len"]) for k in keys_w_seq_len},
+                )
                 total_data_size_padded += NumbersDict(
-                    {k: util.prod(extern_data_raw[k].shape[:2]) for k in keys_w_seq_len}
+                    {k: util.prod(extern_data_raw[k].shape[:2]) for k in keys_w_seq_len},
                 )
 
                 num_seqs_ = (

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -396,7 +396,8 @@ class Engine(EngineBase):
                     print(
                         f"WARNING: step {step_idx} has {padding_ratio:.1%} padding in the train data, "
                         "consider reviewing seq ordering settings for better training efficiency "
-                        f"(warning above: {rel_padding_warn_threshold:.1%})",
+                        f"(warning above {rel_padding_warn_threshold:.1%}, "
+                        "configure via `rel_padding_warn_threshold`)",
                         file=log.v3,  # this is not so important as to log it to v2 (where other warnings go)
                     )
                 ep_data_len += data_len

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -1389,7 +1389,7 @@ def _print_process(
         if batch_size_info:
             info += ["%s %s" % (k, _format_score_value(v)) for k, v in batch_size_info.items()]
         if padding_ratio is not None:
-            info += [f"pad {padding_ratio:.1f}"]
+            info += [f"pad {padding_ratio:.1%}"]
         if log_memory_usage_device:
             dev = torch.device(log_memory_usage_device)
             if dev.type == "cuda":

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -367,8 +367,8 @@ class Engine(EngineBase):
         num_seqs = None
         last_seq_idx = 0
 
-        ep_data_size_packed = NumbersDict()
-        ep_data_size_padded = NumbersDict()
+        total_data_size_packed = NumbersDict()
+        total_data_size_padded = NumbersDict()
 
         try:
             while True:
@@ -386,8 +386,8 @@ class Engine(EngineBase):
                     break
 
                 keys_w_seq_len = [k for k in extern_data_raw if f"{k}:seq_len" in extern_data_raw]
-                ep_data_size_packed += NumbersDict({k: sum(extern_data_raw[f"{k}:seq_len"]) for k in keys_w_seq_len})
-                ep_data_size_padded += NumbersDict({k: util.prod(extern_data_raw[k].shape[:2]) for k in keys_w_seq_len})
+                total_data_size_packed += NumbersDict({k: sum(extern_data_raw[f"{k}:seq_len"]) for k in keys_w_seq_len})
+                total_data_size_padded += NumbersDict({k: util.prod(extern_data_raw[k].shape[:2]) for k in keys_w_seq_len})
 
                 num_seqs_ = (
                     int(extern_data_raw["num_seqs"]) if extern_data_raw.get("num_seqs", None) is not None else -1
@@ -508,8 +508,8 @@ class Engine(EngineBase):
 
         elapsed = time.monotonic() - epoch_start_time
         elapsed_computation_percentage = elapsed_computation_time / elapsed
-        total_padding_ratio = NumbersDict.constant_like(1.0, ep_data_size_packed) - (
-            ep_data_size_packed / ep_data_size_padded
+        total_padding_ratio = NumbersDict.constant_like(1.0, total_data_size_packed) - (
+            total_data_size_packed / total_data_size_padded
         )
         pad_str = ", ".join(f"{k}: {v:.1%}" for k, v in total_padding_ratio.items())
         print(

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -477,7 +477,7 @@ class Engine(EngineBase):
                 accumulated_losses_dict += losses_dict
                 accumulated_inv_norm_factors_dict += inv_norm_factors_dict
                 eval_info = self._maybe_extend_losses_info(losses_dict / inv_norm_factors_dict)
-                if self.config.bool("log_stepwise_padding_ratio"):
+                if self.config.bool("log_stepwise_padding_ratio", False):
                     padding_ratio = NumbersDict.constant_like(1.0, data_len) - (data_len / data_space)
                 else:
                     padding_ratio = None

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -387,7 +387,9 @@ class Engine(EngineBase):
 
                 keys_w_seq_len = [k for k in extern_data_raw if f"{k}:seq_len" in extern_data_raw]
                 total_data_size_packed += NumbersDict({k: sum(extern_data_raw[f"{k}:seq_len"]) for k in keys_w_seq_len})
-                total_data_size_padded += NumbersDict({k: util.prod(extern_data_raw[k].shape[:2]) for k in keys_w_seq_len})
+                total_data_size_padded += NumbersDict(
+                    {k: util.prod(extern_data_raw[k].shape[:2]) for k in keys_w_seq_len}
+                )
 
                 num_seqs_ = (
                     int(extern_data_raw["num_seqs"]) if extern_data_raw.get("num_seqs", None) is not None else -1


### PR DESCRIPTION
I first had an impl based on another data pipe, but that was cumbersome to integrate w/ per-step and per-subepoch logging, so the logic resides in the engine now. It's not too much anyway.