### PR TITLE
PT: allow custom batching, add bucket batching

### DIFF
--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -341,7 +341,7 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
         assert buckets, "empty bucket batching configuration"
         if not all(size > 0 and max_seqs > 0 for size, max_seqs in buckets):
             raise ValueError(f"bucket sizes and max seqs in bucket must be positive")
-        self._max_seq_lens, self._max_bucket_sizes = zip(*sorted(buckets, key=lambda b: b[0]))
+        self._max_seq_lens, self._max_bucket_sizes = zip(*sorted(buckets))
         assert len(set(self._max_seq_lens)) == len(self._max_seq_lens), "seq len boundaries must all be unique"
 
     def __iter__(self):

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -372,6 +372,13 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
 def init_batching(
     dataset: torch.utils.data.IterableDataset, config: Config, train: bool
 ) -> torch.utils.data.IterableDataset:
+    """
+    Batches the segments in the given dataset given the config settings.
+
+    :param dataset: dataset whose segments to group into batches
+    :param config: RETURNN config
+    :param train: whether we are in training or in inference mode
+    """
     custom_batching = config.typed_value("custom_batching", None)
     if custom_batching is None:
         batch_size = config.typed_value("batch_size", -1)

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -311,6 +311,7 @@ class BatchingIterDataPipe(torch.utils.data.IterDataPipe):
             yield current_batch
 
 
+# noinspection PyAbstractClass
 class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
     """
     Converts a dataset yielding sequences (dict data_key -> array per sequence) into

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -325,7 +325,12 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
     """
 
     def __init__(
-        self, dataset: torch.utils.data.IterableDataset, *, buckets: Sequence[Tuple[int, int]], length_key: str
+        self,
+        dataset: torch.utils.data.IterableDataset,
+        *,
+        buckets: Sequence[Tuple[int, int]],
+        length_key: str,
+        **kwargs,
     ):
         """
         :param dataset: dataset to apply bucket batching to
@@ -333,6 +338,7 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
             Segments longer than the largest size limit configured in the buckets are dropped. To avoid dropping
             any segments make sure your largest bucket allows segments larger than your longest training segment.
         :param length_key: data key to take as length measure
+        :param kwargs: unused args
         """
         self._dataset = dataset
         self._length_key = length_key

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -359,7 +359,8 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
                 yield buckets[bucket_idx]
                 buckets[bucket_idx] = []
 
-        yield from buckets
+        non_empty_buckets = [b for b in buckets if b]
+        yield from non_empty_buckets
 
 
 def init_batching(

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -374,8 +374,8 @@ def get_batching_iterable_dataset_from_config(
     :param config: RETURNN config
     :param train: whether we are in training or in inference mode
     """
-    custom_batching = config.typed_value("custom_batching", None)
-    if custom_batching is None:
+    torch_batching = config.typed_value("torch_batching", None)
+    if torch_batching is None:
         batch_size = config.typed_value("batch_size", -1)
         batch_size = config.typed_value(f"batch_size_{'train' if train else 'dev'}", batch_size)
         assert batch_size != -1, f"batch_size or batch_size_{'train' if train else 'dev'} not defined in config"
@@ -383,17 +383,17 @@ def get_batching_iterable_dataset_from_config(
         batches_dataset = BatchingIterDataPipe(dataset, batch_size=batch_size, max_seqs=max_seqs)
         return batches_dataset
 
-    if isinstance(custom_batching, dict):
-        assert "class" in custom_batching
-        batching_args = custom_batching.copy()
+    if isinstance(torch_batching, dict):
+        assert "class" in torch_batching
+        batching_args = torch_batching.copy()
         type_name = batching_args.pop("class")
         assert isinstance(type_name, str)
         cls = globals()[type_name]
-    elif isinstance(custom_batching, (type, Callable)):
+    elif callable(torch_batching):
         # callables need to be forward compatible
         batching_args = get_fwd_compat_kwargs()
         batching_args["train"] = train
-        cls = custom_batching
+        cls = torch_batching
     else:
         raise ValueError(
             f"custom_batching must either be a dict containing a `class` key naming a type, a type or a callable."

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -311,7 +311,6 @@ class BatchingIterDataPipe(torch.utils.data.IterDataPipe):
             yield current_batch
 
 
-# noinspection PyAbstractClass
 class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
     """
     Converts a dataset yielding sequences (dict data_key -> array per sequence) into
@@ -362,6 +361,11 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
 
         non_empty_buckets = [b for b in buckets if b]
         yield from non_empty_buckets
+
+    def __getitem__(self, index):
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.__getitem__ is not supported"
+        )
 
 
 def get_batching_iterable_dataset_from_config(

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -331,7 +331,7 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
         *,
         buckets: Sequence[Tuple[int, int]],
         length_key: str,
-        **kwargs,
+        **_kwargs,
     ):
         """
         :param dataset: dataset to apply bucket batching to
@@ -339,7 +339,7 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
             Segments longer than the largest size limit configured in the buckets are dropped. To avoid dropping
             any segments make sure your largest bucket allows segments larger than your longest training segment.
         :param length_key: data key to take as length measure
-        :param kwargs: unused args
+        :param _kwargs: unused args
         """
         self._dataset = dataset
         self._length_key = length_key

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -405,7 +405,7 @@ def get_batching_iterable_dataset_from_config(
         raise ValueError(
             f"custom_batching must either be a dict containing a `class` key naming a type, a type or a callable."
         )
-    batches_dataset = cls(dataset, train=train, **batching_args)
+    batches_dataset = cls(dataset, **batching_args)
     assert isinstance(batches_dataset, torch.utils.data.IterableDataset)
     return batches_dataset
 

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -386,17 +386,10 @@ def get_batching_iterable_dataset_from_config(
     if isinstance(custom_batching, dict):
         assert "class" in custom_batching
         batching_args = custom_batching.copy()
-        type_or_name = batching_args.pop("class")
-        if isinstance(type_or_name, str):
-            cls = globals()[type_or_name]
-        elif isinstance(type_or_name, (type, Callable)):
-            # custom types need to be forward compatible
-            batching_args.update(get_fwd_compat_kwargs())
-            batching_args["train"] = train
-            cls = type_or_name
-        else:
-            raise ValueError(f"Custom batching class key must either be a string naming a type or a class.")
-    elif isinstance(custom_batching, (type, Callable)):  # short form w/o a dict
+        type_name = batching_args.pop("class")
+        assert isinstance(type_name, str)
+        cls = globals()[type_name]
+    elif isinstance(custom_batching, (type, Callable)):
         # callables need to be forward compatible
         batching_args = get_fwd_compat_kwargs()
         batching_args["train"] = train

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -399,7 +399,7 @@ def init_batching(
         make_batcher = clazz
     else:
         raise ValueError(f"Custom batching class must either be a string or a type.")
-    batches_dataset = make_batcher(dataset, **custom_batching)
+    batches_dataset = make_batcher(dataset, train=train, **custom_batching)
     return batches_dataset
 
 

--- a/returnn/torch/data/pipeline.py
+++ b/returnn/torch/data/pipeline.py
@@ -363,9 +363,7 @@ class BucketOrderingIterDataPipe(torch.utils.data.IterDataPipe):
         yield from non_empty_buckets
 
     def __getitem__(self, index):
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.__getitem__ is not supported"
-        )
+        raise Exception(f"{self.__class__.__name__}.__getitem__ is not supported")
 
 
 def get_batching_iterable_dataset_from_config(

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -386,13 +386,12 @@ class Engine(EngineBase):
                 if not _has_data[0]:
                     break
 
-                # convert values from torch int32 to Python ints to prevent overflow
                 keys_w_seq_len = [k for k in extern_data_raw if f"{k}:seq_len" in extern_data_raw]
                 total_data_size_packed += NumbersDict(
-                    {k: int(sum(extern_data_raw[f"{k}:seq_len"])) for k in keys_w_seq_len},
+                    {k: sum(extern_data_raw[f"{k}:seq_len"]) for k in keys_w_seq_len},
                 )
                 total_data_size_padded += NumbersDict(
-                    {k: int(util.prod(extern_data_raw[k].shape[:2])) for k in keys_w_seq_len},
+                    {k: util.prod(extern_data_raw[k].shape[:2]) for k in keys_w_seq_len},
                 )
 
                 num_seqs_ = (
@@ -524,7 +523,6 @@ class Engine(EngineBase):
         total_padding_ratio = NumbersDict.constant_like(1.0, total_data_size_packed) - (
             total_data_size_packed / total_data_size_padded
         )
-        assert 0.0 <= total_padding_ratio.min_value() <= total_padding_ratio.max_value() <= 1.0
         pad_str = ", ".join(f"{k}: {v:.1%}" for k, v in total_padding_ratio.items())
         print(
             f"Epoch {self.epoch}: Trained {step_idx} steps, {hms(elapsed)} elapsed "

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -730,7 +730,9 @@ class Engine(EngineBase):
                 wrapped_dataset, chunking, min_chunk_size=min_chunk_size
             )
 
-        batches_dataset = data_pipeline.init_batching(wrapped_dataset, self.config, train)
+        batches_dataset = data_pipeline.get_batching_iterable_dataset_from_config(
+            dataset=wrapped_dataset, config=self.config, train=train
+        )
 
         online_shuffle_batches = self.config.typed_value("online_shuffle_batches", None)
         if train and online_shuffle_batches:

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -386,12 +386,13 @@ class Engine(EngineBase):
                 if not _has_data[0]:
                     break
 
+                # convert values from torch int32 to Python ints to prevent overflow
                 keys_w_seq_len = [k for k in extern_data_raw if f"{k}:seq_len" in extern_data_raw]
                 total_data_size_packed += NumbersDict(
-                    {k: sum(extern_data_raw[f"{k}:seq_len"]) for k in keys_w_seq_len},
+                    {k: int(sum(extern_data_raw[f"{k}:seq_len"])) for k in keys_w_seq_len},
                 )
                 total_data_size_padded += NumbersDict(
-                    {k: util.prod(extern_data_raw[k].shape[:2]) for k in keys_w_seq_len},
+                    {k: int(util.prod(extern_data_raw[k].shape[:2])) for k in keys_w_seq_len},
                 )
 
                 num_seqs_ = (
@@ -523,6 +524,7 @@ class Engine(EngineBase):
         total_padding_ratio = NumbersDict.constant_like(1.0, total_data_size_packed) - (
             total_data_size_packed / total_data_size_padded
         )
+        assert 0.0 <= total_padding_ratio.min_value() <= total_padding_ratio.max_value() <= 1.0
         pad_str = ", ".join(f"{k}: {v:.1%}" for k, v in total_padding_ratio.items())
         print(
             f"Epoch {self.epoch}: Trained {step_idx} steps, {hms(elapsed)} elapsed "

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -728,11 +728,7 @@ class Engine(EngineBase):
                 wrapped_dataset, chunking, min_chunk_size=min_chunk_size
             )
 
-        batch_size = self.config.typed_value("batch_size", -1)
-        batch_size = self.config.typed_value(f"batch_size_{'train' if train else 'dev'}", batch_size)
-        assert batch_size != -1, f"batch_size or batch_size_{'train' if train else 'dev'} not defined in config"
-        max_seqs = self.config.typed_value("max_seqs", -1)
-        batches_dataset = data_pipeline.BatchingIterDataPipe(wrapped_dataset, batch_size=batch_size, max_seqs=max_seqs)
+        batches_dataset = data_pipeline.init_batching(wrapped_dataset, self.config, train)
 
         online_shuffle_batches = self.config.typed_value("online_shuffle_batches", None)
         if train and online_shuffle_batches:


### PR DESCRIPTION
Support bucket batching, and other custom batching schemes, via the config option `torch_batching`.

E.g. put this into the config for bucket batching:
```python
torch_batching = {
    "class": "BucketOrderingIterDataPipe",
    "buckets": [(1000, 100), (2000, 50), (4000, 25), (10_000, 10), (100_000, 1)],
    "length_key": "data"
}
```
This will have 5 buckets (specified as (max_seq_len, num_seqs) tuples), using seq length from "data" key.
