### PR TITLE
Check for empty score in cleanup

### DIFF
--- a/returnn/engine/base.py
+++ b/returnn/engine/base.py
@@ -384,7 +384,11 @@ class EngineBase:
                 score_values[key].append(epoch_scores[key])
         for key in list(score_keys):
             scores = score_values[key]
-            if min(scores) == max(scores):
+            if len(scores) == 0:
+                print("Ignoring score key %r because all saved epochs dont have the score." % key, file=log.v3)
+                score_keys.remove(key)
+                score_values.pop(key)
+            elif min(scores) == max(scores):
                 print(
                     "Ignoring score key %r because all epochs have the same value %r." % (key, scores[0]), file=log.v3
                 )


### PR DESCRIPTION
I have a model with 2 losses applied in consecutive epochs. When now a score is not present in the checkpoints anymore the `min==max` check fails because the list is empty. This check fixes it, by checking first if it is empty.