### PR TITLE
Fix _distribute_evenly_by_size for duplicate entries in files_order

### DIFF
--- a/returnn/datasets/distrib_files.py
+++ b/returnn/datasets/distrib_files.py
@@ -364,7 +364,7 @@ class DistributeFilesDataset(CachedDataset2):
         Distributes the files from files_order into ``num_bins`` while attempting
         to make every bin as evenly sized (based on ``file_sizes``) as possible.
         """
-        total_size = sum([file_sizes[_get_key_for_file_tree(f_tree)] for f_tree in files_order])
+        total_size = sum(file_sizes[_get_key_for_file_tree(f_tree)] for f_tree in files_order)
         avg_size_per_sub_epoch = total_size / num_bins
         # Now evenly distribute the files over the bins.
         # Note that many one-pass variants of algorithms to evenly distribute

--- a/returnn/datasets/distrib_files.py
+++ b/returnn/datasets/distrib_files.py
@@ -364,8 +364,7 @@ class DistributeFilesDataset(CachedDataset2):
         Distributes the files from files_order into ``num_bins`` while attempting
         to make every bin as evenly sized (based on ``file_sizes``) as possible.
         """
-
-        total_size = sum(file_sizes.values())
+        total_size = sum([file_sizes[_get_key_for_file_tree(f_tree)] for f_tree in files_order])
         avg_size_per_sub_epoch = total_size / num_bins
         # Now evenly distribute the files over the bins.
         # Note that many one-pass variants of algorithms to evenly distribute

--- a/tests/test_Dataset.py
+++ b/tests/test_Dataset.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterator, List, Dict
+from typing import Any, Iterator, List, Dict, Optional
 import os
 import sys
 import _setup_test_env  # noqa
@@ -905,7 +905,9 @@ def test_MapDatasetWrapper():
 def test_DistributeFilesDataset_distribute_evenly_by_size():
     from returnn.datasets.distrib_files import DistributeFilesDataset
 
-    def _test(sizes: List[int], partition_epoch: int, expected: List[List[int]], files_order=None):
+    def _test(
+        sizes: List[int], partition_epoch: int, expected: List[List[int]], files_order: Optional[List[str]] = None
+    ):
         files = files_order
         if files is None:
             files = [f"file-{i}" for i in range(len(sizes))]

--- a/tests/test_Dataset.py
+++ b/tests/test_Dataset.py
@@ -905,8 +905,10 @@ def test_MapDatasetWrapper():
 def test_DistributeFilesDataset_distribute_evenly_by_size():
     from returnn.datasets.distrib_files import DistributeFilesDataset
 
-    def _test(sizes: List[int], partition_epoch: int, expected: List[List[int]]):
-        files = [f"file-{i}" for i in range(len(sizes))]
+    def _test(sizes: List[int], partition_epoch: int, expected: List[List[int]], files_order=None):
+        files = files_order
+        if files is None:
+            files = [f"file-{i}" for i in range(len(sizes))]
         file_sizes = {f: s for f, s in zip(files, sizes)}
         res = DistributeFilesDataset._distribute_evenly_by_size(
             num_bins=partition_epoch, file_sizes=file_sizes, files_order=files
@@ -926,6 +928,7 @@ def test_DistributeFilesDataset_distribute_evenly_by_size():
         8,
         [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]],
     )
+    _test([1], 5, [[1, 1]] * 5, files_order=["file"] * 10)  # test duplicate files
 
     def _test_stddev(sizes: List[int], partition_epoch: int, max_stddev_percent: float):
         avg_per_bin = sum(sizes) / partition_epoch


### PR DESCRIPTION
I ran into this bug when I added the same file into the "files" list of DistributeFilesDataset multiple times, which messed up the distribution over the subepochs. Subepochs 1-299 contained 1-2 files, and subepoch 300 contained over 50.