### PR TITLE
Add option to passthrough num_seqs in PostprocessingDataset

### DIFF
--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -204,10 +204,7 @@ class PostprocessingDataset(CachedDataset2):
             try:
                 self._num_seqs = self._dataset.num_seqs
             except NotImplementedError:
-                # some datasets don't know their num_seqs
-                assert (
-                    not self._map_seq_stream_preserves_num_seqs
-                ), "_map_seq_stream_preserves_num_seqs is True, but wrapped dataset does not know its num_seqs"
+                pass  # some datasets don't know their num_seqs
         return True
 
     def get_current_seq_order(self):

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -235,14 +235,14 @@ class PostprocessingDataset(CachedDataset2):
                 if self._num_seqs is not None:
                     assert self._data_iter_produced_num_seqs <= self._num_seqs, (
                         f"{self}: map_seq_stream yielded more seqs ({self._data_iter_produced_num_seqs}) "
-                        f"than expected ({self._num_seqs}). _map_seq_stream_preserves_num_seqs is set to "
+                        f"than expected ({self._num_seqs}). map_seq_stream_preserves_num_seqs is set to "
                         f"{self._map_seq_stream_preserves_num_seqs}"
                     )
             except StopIteration:
                 if self._num_seqs is not None:
                     assert self._data_iter_produced_num_seqs == self._num_seqs, (
                         f"{self}: map_seq_stream yielded {self._data_iter_produced_num_seqs} seqs, "
-                        f"while {self._num_seqs} were expected. _map_seq_stream_preserves_num_seqs is set to "
+                        f"while {self._num_seqs} were expected. map_seq_stream_preserves_num_seqs is set to "
                         f"{self._map_seq_stream_preserves_num_seqs}"
                     )
                 return None

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -342,6 +342,7 @@ class LaplaceOrdering(Callable[[Iterator[TensorDict]], Iterator[TensorDict]]):
 
     To be composed with any custom data postprocessing logic via :class:`Sequential`.
     """
+
     preserves_num_seqs = True
 
     def __init__(self, num_seqs_per_bin: int, length_key: str = "data"):

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -112,8 +112,8 @@ class PostprocessingDataset(CachedDataset2):
             To simplify the common case when no shapes change, this value can be left unspecified. The dataset then
             assumes the same data layout as returned by the wrapped dataset.
             Example: `map_outputs={"data": {"dim": 42}}`
-        :param map_seq_stream_preserves_num_seqs: whether the function in map_seq_stream preserves the number of sequences,
-            i.e. for every input sequence there is exactly one output sequence.
+        :param map_seq_stream_preserves_num_seqs: whether the function in map_seq_stream preserves the number of
+            sequences, i.e. for every input sequence there is exactly one output sequence.
         :param kwargs: see :class:`CachedDataset2`, :class:`Dataset`
         """
         super().__init__(**kwargs)
@@ -238,9 +238,10 @@ class PostprocessingDataset(CachedDataset2):
                     ), f"_map_seq_stream_preserves_num_seqs is True, but map_seq_stream yielded more seqs than expected"
             except StopIteration:
                 if self._map_seq_stream_preserves_num_seqs and self.num_seqs is not None:
-                    assert (
-                        self._data_iter_produced_num_seqs == self._num_seqs
-                    ), f"_map_seq_stream_preserves_num_seqs is True, but map_seq_stream yielded {self._data_iter_produced_num_seqs} seqs, while {self._num_seqs} were expected"
+                    assert self._data_iter_produced_num_seqs == self._num_seqs, (
+                        f"_map_seq_stream_preserves_num_seqs is True, but map_seq_stream "
+                        f"yielded {self._data_iter_produced_num_seqs} seqs, while {self._num_seqs} were expected"
+                    )
                 return None
             assert loaded_seq_idx <= seq_idx, "_collect_single_seq must be done monotonically"
             if loaded_seq_idx != seq_idx:

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -233,13 +233,14 @@ class PostprocessingDataset(CachedDataset2):
                 loaded_seq_idx, tensor_dict = next(self._data_iter)
                 self._data_iter_produced_num_seqs += 1
                 if self._map_seq_stream_preserves_num_seqs and self.num_seqs is not None:
-                    assert (
-                        self._data_iter_produced_num_seqs <= self._num_seqs
-                    ), f"_map_seq_stream_preserves_num_seqs is True, but map_seq_stream yielded more seqs than expected"
+                    assert self._data_iter_produced_num_seqs <= self._num_seqs, (
+                        f"{self}: _map_seq_stream_preserves_num_seqs is True, but map_seq_stream yielded more seqs "
+                        f" ({self._data_iter_produced_num_seqs}) than expected ({self._num_seqs})"
+                    )
             except StopIteration:
                 if self._map_seq_stream_preserves_num_seqs and self.num_seqs is not None:
                     assert self._data_iter_produced_num_seqs == self._num_seqs, (
-                        f"_map_seq_stream_preserves_num_seqs is True, but map_seq_stream "
+                        f"{self}: _map_seq_stream_preserves_num_seqs is True, but map_seq_stream "
                         f"yielded {self._data_iter_produced_num_seqs} seqs, while {self._num_seqs} were expected"
                     )
                 return None

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -232,16 +232,18 @@ class PostprocessingDataset(CachedDataset2):
             try:
                 loaded_seq_idx, tensor_dict = next(self._data_iter)
                 self._data_iter_produced_num_seqs += 1
-                if self._map_seq_stream_preserves_num_seqs and self.num_seqs is not None:
+                if self._num_seqs is not None:
                     assert self._data_iter_produced_num_seqs <= self._num_seqs, (
-                        f"{self}: _map_seq_stream_preserves_num_seqs is True, but map_seq_stream yielded more seqs "
-                        f" ({self._data_iter_produced_num_seqs}) than expected ({self._num_seqs})"
+                        f"{self}: map_seq_stream yielded more seqs ({self._data_iter_produced_num_seqs}) "
+                        f"than expected ({self._num_seqs}). _map_seq_stream_preserves_num_seqs is set to "
+                        f"{self._map_seq_stream_preserves_num_seqs}"
                     )
             except StopIteration:
-                if self._map_seq_stream_preserves_num_seqs and self.num_seqs is not None:
+                if self._num_seqs is not None:
                     assert self._data_iter_produced_num_seqs == self._num_seqs, (
-                        f"{self}: _map_seq_stream_preserves_num_seqs is True, but map_seq_stream "
-                        f"yielded {self._data_iter_produced_num_seqs} seqs, while {self._num_seqs} were expected"
+                        f"{self}: map_seq_stream yielded {self._data_iter_produced_num_seqs} seqs, "
+                        f"while {self._num_seqs} were expected. _map_seq_stream_preserves_num_seqs is set to "
+                        f"{self._map_seq_stream_preserves_num_seqs}"
                     )
                 return None
             assert loaded_seq_idx <= seq_idx, "_collect_single_seq must be done monotonically"


### PR DESCRIPTION
I'm open to adjusting the name of the variable

My use case for this is to get Laplace Ordering on a Dataset, so map_seq_stream wouldn't drop any sequences.