### PR TITLE
Fix assert in LaplaceOrdering

### DIFF
--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -382,7 +382,7 @@ class LaplaceOrdering(Callable[[Iterator[TensorDict]], Iterator[TensorDict]]):
                     has_ended = True
 
             if len(seq_buffer) < self.num_seqs_per_bin:
-                assert has_ended and not next_seq_buffer
+                assert (len(seq_buffer) == 0 or has_ended) and not next_seq_buffer
                 break
 
             is_down_phase = not is_down_phase

--- a/returnn/datasets/postprocessing.py
+++ b/returnn/datasets/postprocessing.py
@@ -364,11 +364,11 @@ class LaplaceOrdering(Callable[[Iterator[TensorDict]], Iterator[TensorDict]]):
         is_down_phase = False
 
         seq_buffer = list(islice(iterator, self.num_seqs_per_bin))
+        has_ended = False
         while True:
             seq_buffer.sort(key=self._get_seq_len, reverse=is_down_phase)
 
             next_seq_buffer = []
-            has_ended = False
 
             # Yield items to trainer while gradually pulling more data from PP function.
             # This optimizes CPU load when multiple workers are used.
@@ -382,7 +382,7 @@ class LaplaceOrdering(Callable[[Iterator[TensorDict]], Iterator[TensorDict]]):
                     has_ended = True
 
             if len(seq_buffer) < self.num_seqs_per_bin:
-                assert (len(seq_buffer) == 0 or has_ended) and not next_seq_buffer
+                assert has_ended and not next_seq_buffer
                 break
 
             is_down_phase = not is_down_phase


### PR DESCRIPTION
This assert wrongfully throws in an edge case: When the datasets' `num_seqs` is a multiple of `self.num_seqs_per_bin`, then the `seq_buffer` is replaced with an empty list in line 389, and on the next iteration `has_ended` will thus not be set because the for-loop is never entered, and this assert is triggered