### PR TITLE
fix build, publish wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,11 +31,11 @@ jobs:
     - name: Install Python deps
       run: |
         echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV
-        pip3 install --user --upgrade pip setuptools wheel twine
+        pip3 install --user --upgrade pip build twine
         pip3 install --user typing  # needed for Python 2 in some cases
         pip3 install --user -r requirements.txt
 
-    - run: python3 setup.py sdist
+    - run: python3 -m build
 
     # https://github.com/marketplace/actions/pypi-publish
     - name: Publish to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,4 @@ extend-exclude = '''
 '''
 
 [build-system]
-requires = ["setuptools", "numpy", "h5py"]
+requires = ["setuptools"]

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,10 @@ def main():
         packages=["returnn"],
         include_package_data=True,
         package_data={"returnn": package_data},  # filtered via MANIFEST.in
+        install_requires=[
+            "numpy",
+            "h5py",
+        ],
         description="The RWTH extensible training framework for universal recurrent neural networks",
         author="Albert Zeyer",
         author_email="albzey@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ def main():
         package_data={"returnn": package_data},  # filtered via MANIFEST.in
         install_requires=[
             "numpy",
-            "h5py",
         ],
         description="The RWTH extensible training framework for universal recurrent neural networks",
         author="Albert Zeyer",


### PR DESCRIPTION
You have mixed up build-time and run-time requirements.  Direct invocation of setup.py is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  Build and publish wheels.