### PR TITLE
`DFDataset`: do not pickle sharding info

### DIFF
--- a/returnn/datasets/distrib_files.py
+++ b/returnn/datasets/distrib_files.py
@@ -130,6 +130,8 @@ class DistributeFilesDataset(CachedDataset2):
     https://github.com/rwth-i6/returnn/issues/1524.
     """
 
+    _getnewargs_exclude_attrs = CachedDataset2._getnewargs_exclude_attrs.union(("_num_shards", "_shard_index"))
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
... but rely on `_distrib_info` instead.

Fixes #1678

@Judyxujj feel free to give this PR a test run.