### PR TITLE
PT: pass dist rank/size via env to subprocesses

### DIFF
--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -45,7 +45,7 @@ class DistributedContext:
             dist.init_process_group(backend=self._opts.get("backend", None))
             self._rank = dist.get_rank()
             self._size = dist.get_world_size()
-            os.environ[env_var_name] = str({"rank": self._rank, "size": self._size})
+            os.environ[env_var_name] = repr({"rank": self._rank, "size": self._size})
 
         self._local_rank = int(os.environ["LOCAL_RANK"])
         self._local_size = int(os.environ["LOCAL_WORLD_SIZE"])

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -12,6 +12,7 @@ from typing import Optional, Any, Dict
 import torch
 from torch.nn.parallel import DistributedDataParallel
 
+from returnn.config import Config
 from returnn.util.basic import CollectionReadCheckCovered
 
 _logger = logging.getLogger("returnn.torch.distributed")
@@ -135,9 +136,9 @@ _is_set_up = False
 _ctx = None  # type: Optional[DistributedContext]
 
 
-def get_ctx(config=None) -> Optional[DistributedContext]:
+def get_ctx(config: Optional[Config] = None) -> Optional[DistributedContext]:
     """
-    :param Config|None config:
+    :param config:
     :returns: the global context if Torch distributed is enabled, or None otherwise.
       If we did not setup the context yet, it will automatically create it.
     """

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -3773,9 +3773,9 @@ def should_write_to_disk(config):
     if config.typed_value("torch_distributed") is not None:
         assert BackendEngine.is_torch_selected(), "torch_distributed assumes PyTorch"
 
-        import torch.distributed
+        import returnn.torch.distributed as torch_distributed
 
-        if torch.distributed.get_rank() != 0:
+        if torch_distributed.get_ctx(config).rank() != 0:
             return False
     elif config.is_true("use_horovod"):
         assert BackendEngine.is_tensorflow_selected(), "use_horovod currently assumes TensorFlow"


### PR DESCRIPTION
I checked for imports from `torch.distributed` and all of them that are relevant for this PR point to `returnn.torch.distributed` now.