### PR TITLE
RF conv/pool/etc, stft, window, use_mask, new behavior version 23

### DIFF
--- a/docs/configuration_reference/behavior_version.rst
+++ b/docs/configuration_reference/behavior_version.rst
@@ -22,6 +22,21 @@ and not listing legacy/deprecated parameters.
 Version History
 ---------------
 
+Behavior version 23 (2025-02-25)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RF ``Conv1d.__init__`` and co, ``conv``,
+``TransposedConv1d.__init__`` an co, ``transposed_conv``,
+``pool``, ``max_pool``, ``pool1d`` and co,
+``stft``, ``window`` default changed:
+
+* ``use_mask``: False → True
+
+There is also the global config option ``rf_use_mask: bool`` to overwrite the global default
+for these and also additionally for ``BatchNorm.__init__``.
+
+See issue `#1691 <https://github.com/rwth-i6/returnn/issues/1691>`__.
+
 Behavior version 22 (2025-01-22)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/returnn/frontend/array_.py
+++ b/returnn/frontend/array_.py
@@ -791,6 +791,7 @@ def scatter(
     mode: str = "sum",
     fill_value: Optional[Union[int, float]] = None,
     out_dim: Optional[Union[Dim, Sequence[Dim]]] = None,
+    use_mask: Optional[bool] = None,
 ) -> Tensor:
     """
     Scatters into new zero-tensor.
@@ -813,6 +814,7 @@ def scatter(
         If not given, will be automatically determined as the sparse_dim from indices.
         If multiple out dims, use indices into the merged out dims,
         and then we use :func:`rf.split_dims` afterwards.
+    :param use_mask:
     :return: [batch_dims..., out_dim(s)..., feature_dims...]
     """
     if mode == "logsumexp":
@@ -847,6 +849,12 @@ def scatter(
                 fill_value = float("inf")
         else:
             raise ValueError(f"scatter: invalid mode {mode!r}")
+    indices_dim = indices_dim if isinstance(indices_dim, (list, tuple)) else [indices_dim]
+    if any(dim.need_masking() for dim in indices_dim):
+        if use_mask is None:
+            use_mask = rf.use_mask_default(default=True, default_false_for_behavior_version_up_to=22)
+        if use_mask:
+            source = source.copy_masked(fill_value, dims=indices_dim)
     # noinspection PyProtectedMember
     return source._raw_backend.scatter(
         source, indices=indices, indices_dim=indices_dim, mode=mode, fill_value=fill_value, out_dim=out_dim

--- a/returnn/frontend/array_.py
+++ b/returnn/frontend/array_.py
@@ -325,6 +325,7 @@ def window(
     padding: str = "same",
     pad_value: Optional[Union[int, float]] = None,
     stride: int = 1,
+    use_mask: Optional[bool] = None,
 ) -> Tuple[Tensor, Dim]:
     """
     Follows the same idea as RETURNN tf_util.windowed,
@@ -338,8 +339,14 @@ def window(
     :param padding: "same" or "valid"
     :param pad_value:
     :param stride:
+    :param use_mask: whether we should mask to make sure the zero padding is correct
     :return: out, out_spatial_dim
     """
+    if spatial_dim.need_masking():
+        if use_mask is None:
+            use_mask = rf.use_mask_default(default=True, default_false_for_behavior_version_up_to=22)
+        if use_mask:
+            source = source.copy_masked(0, dims=[spatial_dim])
     assert window_dim.dimension is not None
     if padding == "same":
         out_spatial_dim = spatial_dim

--- a/returnn/frontend/conv.py
+++ b/returnn/frontend/conv.py
@@ -458,7 +458,7 @@ def pool(
         if use_mask is None:
             use_mask = rf.use_mask_default(default=True, default_false_for_behavior_version_up_to=22)
         if use_mask:
-            source = source.copy_masked(0, dims=in_spatial_dims)
+            source = source.copy_masked({"max": float("-inf"), "avg": 0}[mode], dims=in_spatial_dims)
 
     # noinspection PyProtectedMember
     out, out_spatial_dims = source._raw_backend.pool(

--- a/returnn/frontend/conv.py
+++ b/returnn/frontend/conv.py
@@ -34,8 +34,8 @@ class _ConvOrTransposedConv(rf.Module):
     Base class for both convolution and transposed convolution.
     """
 
-    nd: Optional[int] = None
-    _transposed: bool
+    nd: Optional[int] = None  # set in the subclasses, e.g. 1 for Conv1d, etc
+    _transposed: bool  # set in the subclasses _Conv or _TransposedConv
     groups: Optional[int] = None
 
     def __init__(
@@ -187,8 +187,14 @@ def conv(
     dilation_rate: Optional[Union[int, Sequence[int]]] = None,
     groups: Optional[int] = None,
     bias: Optional[Tensor] = None,
+    use_mask: Optional[bool] = None,
 ) -> Tuple[Tensor, Sequence[Dim]]:
     """convolution"""
+    if any(in_spatial_dim.need_masking() for in_spatial_dim in in_spatial_dims):
+        if use_mask is None:
+            use_mask = rf.use_mask_default(default=True, default_false_for_behavior_version_up_to=22)
+        if use_mask:
+            source = source.copy_masked(0, dims=in_spatial_dims)
     for in_spatial_dim in in_spatial_dims:
         if in_spatial_dim not in source.dims:
             raise ValueError(f"conv: source {source} does not have spatial dim {in_spatial_dim}")
@@ -345,8 +351,14 @@ def transposed_conv(
     output_padding: Optional[Union[Sequence[Optional[int]], int]] = None,
     strides: Optional[Sequence[int]] = None,
     bias: Optional[Tensor] = None,
+    use_mask: Optional[bool] = None,
 ) -> Tuple[Tensor, Sequence[Dim]]:
     """transposed conv"""
+    if any(in_spatial_dim.need_masking() for in_spatial_dim in in_spatial_dims):
+        if use_mask is None:
+            use_mask = rf.use_mask_default(default=True, default_false_for_behavior_version_up_to=22)
+        if use_mask:
+            source = source.copy_masked(0, dims=in_spatial_dims)
     # noinspection PyProtectedMember
     out, out_spatial_dims = source._raw_backend.transposed_conv(
         source=source,
@@ -394,6 +406,7 @@ class TransposedConv3d(_TransposedConv):
 def pool(
     source: Tensor,
     *,
+    nd: Optional[int] = None,
     mode: str,
     pool_size: Union[Sequence[int], int],
     padding: str = "valid",
@@ -401,22 +414,23 @@ def pool(
     strides: Optional[Union[Sequence[int], int]] = None,
     in_spatial_dims: Union[Sequence[Dim], Dim],
     out_spatial_dims: Optional[Union[Sequence[Dim], Dim]] = None,
-    nd: Optional[int] = None,
+    use_mask: Optional[bool] = None,
 ) -> Tuple[Tensor, Sequence[Dim]]:
     """
     A generic N-D pooling layer.
     This would usually be done after a convolution for down-sampling.
 
-    :param Tensor source:
+    :param source:
     :param nd:
-    :param str mode: "max" or "avg"
-    :param tuple[int] pool_size: shape of the window of each reduce
-    :param str padding: "valid" or "same"
-    :param tuple[int]|int dilation_rate:
-    :param tuple[int]|int|None strides: in contrast to tf.nn.pool, the default (if it is None) will be set to pool_size
-    :param Sequence[Dim] in_spatial_dims:
-    :param Sequence[Dim]|None out_spatial_dims:
-    :return: layer, out_spatial_dims
+    :param mode: "max" or "avg"
+    :param pool_size: shape of the window of each reduce
+    :param padding: "valid" or "same"
+    :param dilation_rate:
+    :param strides: in contrast to tf.nn.pool, the default (if it is None) will be set to pool_size
+    :param in_spatial_dims:
+    :param out_spatial_dims:
+    :param use_mask:
+    :return: out, out_spatial_dims
     """
     if isinstance(in_spatial_dims, Dim):
         in_spatial_dims = [in_spatial_dims]
@@ -439,6 +453,12 @@ def pool(
         strides = [strides] * nd
     assert isinstance(strides, (list, tuple))
     assert len(strides) == nd
+
+    if any(in_spatial_dim.need_masking() for in_spatial_dim in in_spatial_dims):
+        if use_mask is None:
+            use_mask = rf.use_mask_default(default=True, default_false_for_behavior_version_up_to=22)
+        if use_mask:
+            source = source.copy_masked(0, dims=in_spatial_dims)
 
     # noinspection PyProtectedMember
     out, out_spatial_dims = source._raw_backend.pool(

--- a/returnn/frontend/conv.py
+++ b/returnn/frontend/conv.py
@@ -459,6 +459,8 @@ def pool(
             use_mask = rf.use_mask_default(default=True, default_false_for_behavior_version_up_to=22)
         if use_mask:
             source = source.copy_masked({"max": float("-inf"), "avg": 0}[mode], dims=in_spatial_dims)
+    else:
+        use_mask = False
 
     # noinspection PyProtectedMember
     out, out_spatial_dims = source._raw_backend.pool(
@@ -471,6 +473,10 @@ def pool(
         in_spatial_dims=in_spatial_dims,
         out_spatial_dims=out_spatial_dims,
     )
+    if use_mask and mode == "max":
+        # We masked with -inf for max-pooling to get correct pooling at the boundaries.
+        # However, the resulting tensor might have -inf in it, and it is better to mask it out.
+        out = out.copy_masked(0, dims=out_spatial_dims)
     return out, out_spatial_dims
 
 

--- a/returnn/frontend/normalization.py
+++ b/returnn/frontend/normalization.py
@@ -218,10 +218,9 @@ class BatchNorm(rf.Module):
 
         if any(d.need_masking() for d in source.dims if d != self.in_dim):
             if self.use_mask is None:
-                raise ValueError(
-                    f"{self}: use_mask must be specified if the input {source} has any dynamic spatial dims"
-                )
-            use_mask = self.use_mask
+                use_mask = rf.use_mask_default(default=True)
+            else:
+                use_mask = self.use_mask
         else:
             use_mask = False  # not needed. False because this potentially enables an efficient fused op.
 

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -219,7 +219,7 @@ class BehaviorVersion:
     See :ref:`behavior_version`.
     """
 
-    _latest_behavior_version = 22
+    _latest_behavior_version = 23
     _behavior_version = None  # type: typing.Optional[int]
     _min_behavior_version = 0  # type: int
 

--- a/tests/test_rf_array.py
+++ b/tests/test_rf_array.py
@@ -193,9 +193,16 @@ def test_pad_packed_batched():
     in_ = out_dict["in"]
     flat = out_dict["flat"]
     out = out_dict["out"]
-    print(in_.raw_tensor.shape, flat.raw_tensor.shape, out.raw_tensor.shape)
+    print("in:", in_, in_.raw_tensor.shape)
+    print("in time1:", in_.dims[1].dyn_size)
+    print("in time2:", in_.dims[2].dyn_size)
+    print("flat:", flat, flat.raw_tensor.shape)
+    print("out:", out, out.raw_tensor.shape)
+    print("in raw:")
     print(in_.raw_tensor)
+    print("flat raw:")
     print(flat.raw_tensor)
+    print("out raw:")
     print(out.raw_tensor)
     np.testing.assert_array_equal(in_.raw_tensor, out.raw_tensor)
 

--- a/tests/test_rf_encoder_conformer.py
+++ b/tests/test_rf_encoder_conformer.py
@@ -78,6 +78,7 @@ def test_e_branchformer():
     import torch
     import returnn.frontend as rf
     from returnn.util.debug import PyTracer, check_py_traces_rf_to_pt_equal
+    from returnn.config import global_config_ctx, Config
 
     rf.select_backend_torch()
     rf.set_random_seed(42)
@@ -300,7 +301,9 @@ def test_e_branchformer():
         ],
         Tensor,
     ) as trace_rf, torch.no_grad():
-        enc_out, _ = model_rf(enc_in, in_spatial_dim=enc_spatial_dim)
+        # ESPnet E-Branchformer does not use masking properly. Keep it disabled here as well.
+        with global_config_ctx(Config({"rf_use_mask": False})):
+            enc_out, _ = model_rf(enc_in, in_spatial_dim=enc_spatial_dim)
     enc_out = enc_out.copy_transpose((batch_dim, enc_spatial_dim, model_dim))
     enc_out = enc_out.copy_masked(0.0)
 


### PR DESCRIPTION
`use_mask` option implemented for:

* `Conv1d.__init__` and co, `conv`
* `TransposedConv1d.__init__` an co, `transposed_conv`
* `pool`, `max_pool`, `pool1d` and co
* `stft`
* `window`
* `scatter`

`rf_use_mask: bool` config option to explicitly specify the default for `use_mask`.

If `rf_use_mask` is not specified, for older behavior versions (<=22), we use `use_mask=False` by default, with behavior version >=23, we use `use_mask=True` by default. Thus this introduces the new behavior version 23.

`BatchNorm` `use_mask` is not required to be set now. If it is not explicitly set, it is True by default. (Previously, it was required to set this when there were dynamic dims, so this change does not change the behavior of any existing setup.)

Fix #1691
