### PR TITLE
RF PT conv, fix same padding with striding

### DIFF
--- a/docs/configuration_reference/behavior_version.rst
+++ b/docs/configuration_reference/behavior_version.rst
@@ -22,6 +22,17 @@ and not listing legacy/deprecated parameters.
 Version History
 ---------------
 
+Behavior version 24 (2025-03-02)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RF ``conv`` and ``pool`` ``padding="same"`` with striding:
+Now, will add padding left/right independent of dimension length,
+i.e. also independent of batching.
+
+There is also the global config option ``rf_use_consistent_same_padding: bool`` to overwrite this.
+
+See issue `#1693 <https://github.com/rwth-i6/returnn/issues/1693>`__.
+
 Behavior version 23 (2025-02-25)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/returnn/frontend/_backend.py
+++ b/returnn/frontend/_backend.py
@@ -1223,7 +1223,7 @@ class Backend(Generic[T]):
         out_spatial_dims: Optional[Sequence[Dim]] = None,
         filter: Tensor,
         filter_size: Sequence[Dim],  # to have the order well-defined
-        padding: str,
+        padding: Union[str, int, Sequence[int]],
         strides: Optional[Union[int, Sequence[int]]] = None,
         dilation_rate: Optional[Union[int, Sequence[int]]] = None,
         groups: Optional[int] = None,
@@ -1258,7 +1258,7 @@ class Backend(Generic[T]):
         *,
         mode: str,
         pool_size: Sequence[int],
-        padding: str = "valid",
+        padding: Union[str, int, Sequence[int]] = "valid",
         dilation_rate: Union[Sequence[int], int] = 1,
         strides: Sequence[int],
         in_spatial_dims: Sequence[Dim],

--- a/returnn/tf/frontend_layers/_backend.py
+++ b/returnn/tf/frontend_layers/_backend.py
@@ -998,7 +998,7 @@ class ReturnnLayersBackend(Backend[Layer]):
         out_spatial_dims: Optional[Sequence[Dim]] = None,
         filter: Tensor,
         filter_size: Sequence[Dim],  # to have the order well-defined
-        padding: str,
+        padding: Union[str, int, Sequence[int]],
         strides: Optional[Union[int, Sequence[int]]] = None,
         dilation_rate: Optional[Union[int, Sequence[int]]] = None,
         groups: Optional[int] = None,
@@ -1088,7 +1088,7 @@ class ReturnnLayersBackend(Backend[Layer]):
         *,
         mode: str,
         pool_size: Sequence[int],
-        padding: str = "valid",
+        padding: Union[str, int, Sequence[int]] = "valid",
         dilation_rate: Union[Sequence[int], int] = 1,
         strides: Sequence[int],
         in_spatial_dims: Sequence[Dim],

--- a/returnn/tf/layers/basic.py
+++ b/returnn/tf/layers/basic.py
@@ -4184,7 +4184,9 @@ class PadLayer(_ConcatInputLayer):
         self,
         *,
         axes: Union[Dim, str, Sequence[Union[Dim, str]]],
-        padding: Union[int, Tuple[int, int], Sequence[Tuple[int, int]]],
+        padding: Union[
+            int, Dim, Tuple[Union[int, Dim], Union[int, Dim]], Sequence[Tuple[Union[int, Dim], Union[int, Dim]]]
+        ],
         out_dims: Optional[Union[Dim, Sequence[Dim]]] = None,
         handle_dynamic_dims: Optional[bool] = None,
         value: Union[int, float] = 0,
@@ -4211,7 +4213,10 @@ class PadLayer(_ConcatInputLayer):
         padding = self._transform_padding(padding=padding, axes=axes)
         paddings = [(0, 0)] * len(range(self.input_data.batch_ndim))
         for i, a in enumerate(axes):
-            paddings[a] = padding[i]
+            pad_left, pad_right = padding[i]
+            pad_left = pad_left.dimension if isinstance(pad_left, Dim) else pad_left
+            pad_right = pad_right.dimension if isinstance(pad_right, Dim) else pad_right
+            paddings[a] = (pad_left, pad_right)
         mode = mode.lower()
         if handle_dynamic_dims is None:
             handle_dynamic_dims = self._handle_dynamic_dims_default(
@@ -4219,7 +4224,7 @@ class PadLayer(_ConcatInputLayer):
                 padding=padding,
                 mode=mode,
             )
-        if all(sum(p) == 0 for p in padding):
+        if all(left == right == 0 for left, right in paddings):
             self.output.placeholder = self.input_data.placeholder
         elif mode == "replication":
             self.output.placeholder = tf_util.pad_replicate(self.input_data.placeholder, axes, padding)
@@ -4227,7 +4232,7 @@ class PadLayer(_ConcatInputLayer):
             self.output.placeholder = tf.pad(
                 self.input_data.placeholder, paddings=paddings, mode=mode, constant_values=value
             )
-        if all(right == 0 for left, right in padding) and mode != "circular":
+        if all(right == 0 for left, right in paddings) and mode != "circular":
             pass  # no masking needed
         else:
             import returnn.frontend as rf
@@ -4257,9 +4262,9 @@ class PadLayer(_ConcatInputLayer):
     @classmethod
     def _transform_padding(cls, padding, axes):
         """
-        :param list[(int,int)]|(int,int)|int padding:
+        :param Sequence[(int|Dim,int|Dim)]|(int|Dim,int|Dim)|int|Dim padding:
         :param list[int] axes:
-        :rtype: list[(int,int)]
+        :rtype: Sequence[(int|Dim,int|Dim)]
         """
         if isinstance(padding, (list, tuple)):
             if isinstance(padding[0], (list, tuple)):
@@ -4316,9 +4321,9 @@ class PadLayer(_ConcatInputLayer):
         """
         :param str name:
         :param list[LayerBase] sources:
-        :param Dim|str|list[Dim|str] axes:
-        :param list[(int,int)]|(int,int)|int padding:
-        :param Dim|list[Dim]|None out_dims:
+        :param Dim|str|Sequence[Dim|str] axes:
+        :param Sequence[(int|Dim,int|Dim)]|(int|Dim,int|Dim)|int|Dim padding:
+        :param Dim|Sequence[Dim]|None out_dims:
         :rtype: Data
         """
         from ..util.data import Dim
@@ -6223,7 +6228,7 @@ class ConvLayer(_ConcatInputLayer):
             for 1D/2D/3D conv.
             The input data ndim must match, or you can add dimensions via input_expand_dims or input_add_feature_dim.
             It will automatically swap the batch-dim to the first axis of the input data.
-        :param str padding: "same", "valid" or "same_static".
+        :param str|int|Sequence[int] padding: "same", "valid" or "same_static".
             "same_static" is calculated differently depending on whether an axis is static or dynamic.
             For static axes, "same_static" padding is the same as "same" padding,
             i.e. filter_size - 1 - (T + strides - 1) % strides.
@@ -6261,8 +6266,10 @@ class ConvLayer(_ConcatInputLayer):
         """
         from returnn.util import BehaviorVersion
 
-        padding = padding.upper()
-        assert padding in ["SAME", "VALID", "SAME_STATIC"], "no other padding supported at the moment"
+        padding = padding.upper() if isinstance(padding, str) else padding
+        assert padding in ["SAME", "VALID", "SAME_STATIC"] or isinstance(
+            padding, (int, tuple, list)
+        ), f"{self}: got unsupported padding {padding}"
         assert "out_type" not in kwargs, "don't set out_type explicitly for this layer"
         assert len(filter_size) in (1, 2, 3), "only 1D conv, 2D conv or 3D conv supported"
         super(ConvLayer, self).__init__(in_dim=in_dim, out_dim=out_dim, **kwargs)
@@ -6398,6 +6405,17 @@ class ConvLayer(_ConcatInputLayer):
                 out_batch_feature_major=out_batch_feature_major,
             )
             padding = "VALID"  # input is now already "same" padded, therefore use "valid" padding from here
+        elif isinstance(padding, int) and padding == 0:
+            x = input_data.placeholder
+            padding = "VALID"
+        elif isinstance(padding, (int, list, tuple)):
+            x = self.get_input_placeholder_with_int_padding(
+                input_data=input_data,
+                num_batch_dims=num_batch_dims,
+                out_batch_feature_major=out_batch_feature_major,
+                padding=padding,
+            )
+            padding = "VALID"
         else:
             x = input_data.placeholder
 
@@ -6539,7 +6557,7 @@ class ConvLayer(_ConcatInputLayer):
         :param Sequence[int|Dim] filter_size:
         :param Sequence[int] strides:
         :param Sequence[int] dilation_rate:
-        :param str padding:
+        :param str|int|Sequence[int] padding:
         """
         if output.feature_dim_axis == num_batch_dims:
             out_spatial_dims_ = output.dim_tags[num_batch_dims + 1 :]
@@ -6558,7 +6576,7 @@ class ConvLayer(_ConcatInputLayer):
                 filter_size=filter_size[i],
                 stride=strides[i],
                 dilation_rate=dilation_rate[i],
-                padding=padding,
+                padding=padding if isinstance(padding, (str, int)) else padding[i],
             )
             assert isinstance(out_tag_calc, Dim)
             out_tag_calc.declare_same_as(out_tag)
@@ -6717,7 +6735,7 @@ class ConvLayer(_ConcatInputLayer):
         """
         Returns the placeholder of input_data with same_static padding applied to it.
 
-        :param input_data:
+        :param input_data: [Batch..., Spatial..., Feature] or [Batch..., Feature, Spatial...]
         :param num_batch_dims:
         :param filter_size:
         :param strides:
@@ -6758,13 +6776,51 @@ class ConvLayer(_ConcatInputLayer):
         return x
 
     @classmethod
+    def get_input_placeholder_with_int_padding(
+        cls,
+        input_data: Data,
+        *,
+        num_batch_dims: int,
+        out_batch_feature_major: bool,
+        padding: Union[int, Sequence[int]],
+        pad_value: float = 0.0,
+    ) -> tf.Tensor:
+        """
+        Returns the placeholder of input_data with same_static padding applied to it.
+
+        :param input_data: [Batch..., Spatial..., Feature] or [Batch..., Feature, Spatial...]
+        :param num_batch_dims:
+        :param out_batch_feature_major:
+        :param padding:
+        :param pad_value:
+        """
+        num_spatial_dims = input_data.batch_ndim - num_batch_dims - 1
+        if isinstance(padding, int):
+            padding = [padding] * num_spatial_dims
+        paddings = [[0, 0] for _ in range(input_data.batch_ndim)]
+        for axis, dim in enumerate(input_data.dims):
+            if axis < num_batch_dims:
+                continue
+            if axis == num_batch_dims and out_batch_feature_major:
+                # input_data has dimensions [batch] * num_batch_dims + [channels] + [spatial] * num_spatial_dims
+                continue
+            if axis >= num_batch_dims + num_spatial_dims and not out_batch_feature_major:
+                # input_data has dimensions [batch] * num_batch_dims + [spatial] * num_spatial_dims + [channels]
+                break
+
+            padding_ = padding[axis - num_batch_dims - out_batch_feature_major]
+            paddings[axis] = [padding_, padding_]
+        x = tf.pad(input_data.placeholder, paddings, constant_values=pad_value)
+        return x
+
+    @classmethod
     def calc_out_dim(cls, in_dim, filter_size, stride, padding, dilation_rate=1):
         """
         :param T|int|tf.Tensor|Dim in_dim: dimension in some axis
         :param int|Dim filter_size: e.g. 2, for the corresponding axis
         :param int stride: e.g. 1, for the corresponding axis
         :param int dilation_rate: e.g. 1
-        :param str padding: "valid" or "same"
+        :param str|int padding: "valid" or "same"
         :return: the output dimension
         :rtype: T
         """
@@ -6779,13 +6835,16 @@ class ConvLayer(_ConcatInputLayer):
                 return a
             return -(-a // b)
 
-        padding = padding.upper()
+        padding = padding.upper() if isinstance(padding, str) else padding
         # See tf.compat.v1.nn.convolution() documentation for more.
         if padding == "SAME":
             if isinstance(in_dim, Dim):
                 return in_dim.ceildiv_right(stride)
             return ceildiv(in_dim, stride)
-        elif padding == "VALID":
+        elif padding == "VALID" or isinstance(padding, int):
+            if isinstance(padding, int) and padding != 0:
+                assert padding > 0
+                in_dim = padding + in_dim + padding
             if isinstance(in_dim, Dim):
                 filter_left_dilated = (filter_size - 1) * dilation_rate // 2
                 filter_right_dilated = (filter_size - 1) * dilation_rate - filter_left_dilated
@@ -6826,7 +6885,7 @@ class ConvLayer(_ConcatInputLayer):
         :param Sequence[LayerBase] sources:
         :param returnn.tf.network.TFNetwork network:
         :param Sequence[int|Dim] filter_size:
-        :param str padding:
+        :param str|int|Sequence[int] padding:
         :param int|Sequence[int] strides:
         :param int|Sequence[int] dilation_rate:
         :param int input_expand_dims: number of dynamic dims to add to the input
@@ -6839,6 +6898,7 @@ class ConvLayer(_ConcatInputLayer):
         :param Sequence[Dim]|None out_spatial_dims:
         :param int input_expand_dims: number of spatial dims to add to the input
         :param bool|NotSpecified auto_use_channel_first:
+        :rtype: Data
         """
         from returnn.util import BehaviorVersion
 
@@ -6857,7 +6917,8 @@ class ConvLayer(_ConcatInputLayer):
         assert len(dilation_rate) == len(filter_size)
         if in_spatial_dims:
             assert len(in_spatial_dims) == len(filter_size)
-        padding = padding.upper()
+        if isinstance(padding, str):
+            padding = padding.upper()
         # Be relaxed about incorrect input data. Throw errors later. This can also work during template construction.
         if not input_data.have_batch_axis():
             input_data = input_data.copy_add_batch_dim(batch_dim_axis=0)
@@ -6889,7 +6950,11 @@ class ConvLayer(_ConcatInputLayer):
             for i in range(len(filter_size)):
                 old_tag = old_spatial_dim_tags[i] if i < len(old_spatial_dim_tags) else None
                 filter_size_ = filter_size[i].dimension if isinstance(filter_size[i], Dim) else filter_size[i]
-                if old_tag and (filter_size_ == strides[i] == 1 or (strides[i] == 1 and padding == "SAME")):
+                padding_ = padding if isinstance(padding, (str, int)) else padding[i]
+                if old_tag and (
+                    (filter_size_ == strides[i] == 1 and padding_ in ("SAME", "VALID", 0))
+                    or (strides[i] == 1 and padding_ == "SAME")
+                ):
                     dim_tags.append(old_tag)  # identity in this axis
                     continue
                 new_dim = None
@@ -6899,7 +6964,7 @@ class ConvLayer(_ConcatInputLayer):
                         filter_size=filter_size[i],
                         stride=strides[i],
                         dilation_rate=dilation_rate[i],
-                        padding=padding,
+                        padding=padding_,
                     )
                 dim_tags.append(
                     Dim(
@@ -7009,8 +7074,8 @@ class PoolLayer(_ConcatInputLayer):
     ):
         """
         :param str mode: "max" or "avg"
-        :param tuple[int] pool_size: shape of the window of each reduce
-        :param str padding: "same", "valid" or "same_static".
+        :param Sequence[int] pool_size: shape of the window of each reduce
+        :param str|int|Sequence[int] padding: "same", "valid" or "same_static".
             "same_static" is calculated differently depending on whether an axis is static or dynamic.
             For static axes, "same_static" padding is the same as "same" padding,
             i.e. filter_size - 1 - (T + strides - 1) % strides.
@@ -7018,13 +7083,13 @@ class PoolLayer(_ConcatInputLayer):
             filter_size - 1, i.e. it is independent of the length T of the axis and the striding.
             For dynamic axes, to avoid skipping any frames on the right,
             we set left_padding = (filter_size - strides) // 2.
-        :param tuple[int]|int dilation_rate:
-        :param tuple[int]|int|None strides: in contrast to tf.nn.pool, the default (if it is None)
+        :param Sequence[int]|int dilation_rate:
+        :param Sequence[int]|int|None strides: in contrast to tf.nn.pool, the default (if it is None)
             will be set to pool_size
         :param Dim|None in_dim:
-        :param list[Dim|str]|None in_spatial_dims:
+        :param Sequence[Dim|str]|None in_spatial_dims:
         :param Dim|None out_dim:
-        :param list[Dim]|None out_spatial_dims:
+        :param Sequence[Dim]|None out_spatial_dims:
         :param bool|NotSpecified use_channel_first: if set, will transform input to NCHW format
         :param bool use_time_mask:
         """
@@ -7032,8 +7097,15 @@ class PoolLayer(_ConcatInputLayer):
         assert "out_type" not in kwargs
         mode = mode.upper()
         assert mode in ["MAX", "AVG"]
-        padding = padding.upper()
-        assert padding in ["VALID", "SAME", "SAME_STATIC"]
+        if isinstance(padding, str):
+            padding = padding.upper()
+            assert padding in ["VALID", "SAME", "SAME_STATIC"]
+        elif isinstance(padding, int) or (
+            isinstance(padding, (list, tuple)) and all(isinstance(p, int) for p in padding)
+        ):
+            pass
+        else:
+            raise TypeError(f"invalid type ({type(padding).__name__}) for padding: {padding}")
         if isinstance(dilation_rate, int):
             dilation_rate = [dilation_rate] * len(pool_size)
         assert len(dilation_rate) == len(pool_size)
@@ -7102,6 +7174,18 @@ class PoolLayer(_ConcatInputLayer):
                 out_batch_feature_major=out_batch_feature_major,
             )
             padding = "VALID"  # input is now already "same" padded, therefore use "valid" padding from here
+        elif isinstance(padding, int) and padding == 0:
+            x = input_data.placeholder
+            padding = "VALID"
+        elif isinstance(padding, (int, list, tuple)):
+            x = ConvLayer.get_input_placeholder_with_int_padding(
+                input_data=input_data,
+                num_batch_dims=num_batch_dims,
+                out_batch_feature_major=out_batch_feature_major,
+                padding=padding,
+                pad_value={"MAX": float("-inf"), "AVG": 0}[mode],
+            )
+            padding = "VALID"
         else:
             x = input_data.placeholder
 
@@ -7145,14 +7229,14 @@ class PoolLayer(_ConcatInputLayer):
         :param str name:
         :param list[LayerBase] sources:
         :param returnn.tf.network.TFNetwork network:
-        :param tuple[int]|list[int] pool_size:
-        :param tuple[int]|list[int]|int strides:
-        :param int|tuple[int]|list[int] dilation_rate:
-        :param str padding:
+        :param Sequence[int] pool_size:
+        :param Sequence[int]|int strides:
+        :param int|Sequence[int] dilation_rate:
+        :param str|int|Sequence[int] padding:
         :param Dim|None in_dim:
-        :param list[Dim|str]|None in_spatial_dims:
+        :param Sequence[Dim|str]|None in_spatial_dims:
         :param Dim|None out_dim:
-        :param list[Dim]|None out_spatial_dims:
+        :param Sequence[Dim]|None out_spatial_dims:
         :param bool|NotSpecified use_channel_first:
         :rtype: Data
         """

--- a/returnn/tf/util/basic.py
+++ b/returnn/tf/util/basic.py
@@ -3733,13 +3733,14 @@ def single_strided_slice(x, axis, begin=None, end=None, step=None):
 def pad_replicate(x, axes, padding):
     """
     :param tf.Tensor x:
-    :param list[int] axes:
-    :param list[(int,int)] padding:
+    :param Sequence[int] axes:
+    :param Sequence[(int|Dim,int|Dim)] padding:
     :rtype: tf.Tensor
     """
     with tf.name_scope("pad_replicate"):
         assert len(padding) == 1, "Not implemented otherwise yet"
         assert len(axes) == 1, "Not implemented otherwise yet"
+        assert isinstance(padding[0][0], int) and isinstance(padding[0][1], int)  # not implemented otherwise yet
         pad_left = tf.gather(x, 0, axis=axes[0])
         pad_left = tf.expand_dims(pad_left, axis=axes[0])
         pad_left = tf.repeat(pad_left, padding[0][0], axis=axes[0])

--- a/returnn/torch/frontend/_backend.py
+++ b/returnn/torch/frontend/_backend.py
@@ -1950,9 +1950,15 @@ class TorchBackend(Backend[torch.Tensor]):
                 #                = in_len + s.dimension - 1 - (in_len - 1) % stride
                 # Now, the amount of padding which actually matters is:
                 # pad = in_len_covered - in_len = s.dimension - 1 - (in_len - 1) % stride.
-                pad = s.dimension - 1 - (src_raw.shape[2 + i] - 1) % stride_
+                # pad = s.dimension - 1 - (src_raw.shape[2 + i] - 1) % stride_
+                # pad_left = pad // 2
+                # pad_right = pad - pad_left
+                # TODO configurable.... see https://github.com/rwth-i6/returnn/issues/1693
+                # TODO this seems to fix the test with test_single_batch_entry.
+                #   but why does it not change anything when compared to the TF output?
+                pad = s.dimension - 1
                 pad_left = pad // 2
-                pad_right = pad - pad_left
+                pad_right = pad - pad_left - (src_raw.shape[2 + i] - 1) % stride_
                 pads.extend([pad_left, pad_right])
             src_raw = torch.nn.functional.pad(src_raw, pads)
         if padding == "valid":
@@ -2040,6 +2046,7 @@ class TorchBackend(Backend[torch.Tensor]):
             padding = []
             for i, s in enumerate(pool_size):
                 # See comment in conv.
+                # TODO check this...
                 pad = s - 1 - (src_raw.shape[2 + i] - 1) % strides[i]
                 padding.append(pad // 2)
             ceil_mode = True

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -219,7 +219,7 @@ class BehaviorVersion:
     See :ref:`behavior_version`.
     """
 
-    _latest_behavior_version = 23
+    _latest_behavior_version = 24
     _behavior_version = None  # type: typing.Optional[int]
     _min_behavior_version = 0  # type: int
 

--- a/tests/test_rf_conv.py
+++ b/tests/test_rf_conv.py
@@ -375,3 +375,23 @@ def test_avgpool1d_stride1_padding_same():
         out.mark_as_default_output(shape=[batch_dim, time_dim])
 
     run_model(extern_data, lambda *, epoch, step: _Net(), _forward_step)
+
+
+def test_avgpool1d_stride_padding_same():
+    time_dim = Dim(Tensor("time", [batch_dim], dtype="int32"))
+    extern_data = TensorDict(
+        {
+            "data": Tensor("data", [batch_dim, time_dim], dtype="float32"),
+        }
+    )
+
+    class _Net(rf.Module):
+        def __call__(self, x: rf.Tensor, *, in_spatial_dim: Dim) -> Tuple[Tensor, Dim]:
+            return rf.pool1d(x, mode="avg", pool_size=4, strides=3, padding="same", in_spatial_dim=in_spatial_dim)
+
+    # noinspection PyShadowingNames
+    def _forward_step(*, model: _Net, extern_data: TensorDict):
+        out, out_spatial_dim = model(extern_data["data"], in_spatial_dim=time_dim)
+        out.mark_as_default_output(shape=[batch_dim, out_spatial_dim])
+
+    run_model(extern_data, lambda *, epoch, step: _Net(), _forward_step)

--- a/tests/test_rf_conv.py
+++ b/tests/test_rf_conv.py
@@ -130,8 +130,14 @@ def test_functional_conv1d_stride_same_padding():
         out, dim = model(extern_data["data"])
         out.mark_as_default_output(shape=(batch_dim, dim, out_dim))
 
-    run_model(extern_data, lambda *, epoch, step: _Net(), _forward_step, dyn_dim_max_sizes={time_dim: 7})
-    run_model(extern_data, lambda *, epoch, step: _Net(), _forward_step, dyn_dim_max_sizes={time_dim: 9})
+    for t in [7, 9]:
+        run_model(
+            extern_data,
+            lambda *, epoch, step: _Net(),
+            _forward_step,
+            dyn_dim_max_sizes={time_dim: t},
+            test_single_batch_entry=True,
+        )
 
 
 def test_conv1d_stride_same_padding():
@@ -157,7 +163,14 @@ def test_conv1d_stride_same_padding():
         out, dim = model(extern_data["data"])
         out.mark_as_default_output(shape=(batch_dim, dim, out_dim))
 
-    run_model(extern_data, lambda *, epoch, step: _Net(), _forward_step, test_single_batch_entry=True)
+    for t in [7, 9]:
+        run_model(
+            extern_data,
+            lambda *, epoch, step: _Net(),
+            _forward_step,
+            dyn_dim_max_sizes={time_dim: t},
+            test_single_batch_entry=True,
+        )
 
 
 def test_conv1d_same_out():

--- a/tests/test_rf_conv.py
+++ b/tests/test_rf_conv.py
@@ -157,7 +157,7 @@ def test_conv1d_stride_same_padding():
         out, dim = model(extern_data["data"])
         out.mark_as_default_output(shape=(batch_dim, dim, out_dim))
 
-    run_model(extern_data, lambda *, epoch, step: _Net(), _forward_step)
+    run_model(extern_data, lambda *, epoch, step: _Net(), _forward_step, test_single_batch_entry=True)
 
 
 def test_conv1d_same_out():


### PR DESCRIPTION
Also, new behavior version 24, or config option `rf_use_consistent_same_padding: bool`.

Fix #1693
