### PR TITLE
Add new default for torch distributed backend

### DIFF
--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -39,10 +39,9 @@ class DistributedContext:
         else:
             import torch.distributed as dist
 
-            # when no backend is specified, both gloo and nccl backends will be created
-            # the gloo backend will be used for collectives with CPU tensors and
-            # the nccl backend will be used for collectives with CUDA tensors
-            dist.init_process_group(backend=self._opts.get("backend", None))
+            # when no backend is specified, we set gloo for CPU tensors and nccl for CUDA tensors as backend
+            # by explicitly setting dispatching instruction, we avoid bug in newer pytorch version
+            dist.init_process_group(backend=self._opts.get("backend", "cpu:gloo,cuda:nccl"))
             self._rank = dist.get_rank()
             self._size = dist.get_world_size()
             os.environ[env_var_name] = repr({"rank": self._rank, "size": self._size})

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -41,6 +41,7 @@ class DistributedContext:
 
             # When no backend is specified, we set gloo for CPU tensors and nccl for CUDA tensors as backend.
             # torch 2.6.0 and onwards require explicitly setting the backends.
+            # See https://github.com/rwth-i6/returnn/issues/1724 for discussion.
             dist.init_process_group(backend=self._opts.get("backend", "cpu:gloo,cuda:nccl"))
             self._rank = dist.get_rank()
             self._size = dist.get_world_size()

--- a/returnn/torch/distributed.py
+++ b/returnn/torch/distributed.py
@@ -39,8 +39,8 @@ class DistributedContext:
         else:
             import torch.distributed as dist
 
-            # when no backend is specified, we set gloo for CPU tensors and nccl for CUDA tensors as backend
-            # by explicitly setting dispatching instruction, we avoid bug in newer pytorch version
+            # When no backend is specified, we set gloo for CPU tensors and nccl for CUDA tensors as backend.
+            # torch 2.6.0 and onwards require explicitly setting the backends.
             dist.init_process_group(backend=self._opts.get("backend", "cpu:gloo,cuda:nccl"))
             self._rank = dist.get_rank()
             self._size = dist.get_world_size()


### PR DESCRIPTION
In newer Pytorch versions, the default distributed backend dispatching seems to fail on some operations and cause a RuntimeError: No backend type associated with device type cpu (see #1724). We therefore decide to update the default backend value to "cpu:gloo,cuda:nccl" to explicitly force CPU tensors to use gloo and CUDA tensors to use nccl. 

Fix #1724.
