### PR TITLE
Add option to check for invalid gradient norms and allow skipping updates

### DIFF
--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -270,7 +270,6 @@ class Engine(EngineBase):
         self._updater.set_current_train_step(
             global_train_step=self.global_train_step, epoch=self.epoch, epoch_continuous=self.epoch - 1
         )
-        self._updater._num_consec_invalid_gradients_steps = 0
 
         self.learning_rate_control.epoch_data[self.epoch].meta.update(
             {

--- a/returnn/torch/updater.py
+++ b/returnn/torch/updater.py
@@ -212,6 +212,8 @@ class Updater:
             if the number of steps per epoch is known in advance.
         """
         self._current_train_step = global_train_step
+        if self._current_epoch != epoch:
+            self._num_consec_invalid_gradients_steps = 0
         self._current_epoch = epoch
         self._current_epoch_continuous = epoch_continuous
         self._update_effective_learning_rate()


### PR DESCRIPTION
Adds "gradient_clip_norm_invalid_gradient_threshold" parameter

Defines a threshold count of allowed sequentially occuring nan/inf gradients until the training stops.

Resolves: #1568

@albertz This is code copied from my RETURNN fork as starting point, so it is not tested with the master branch here. I use this to have successful LSTM-LM training. Please suggest how you want to name the parameter or if you want functional changes, then @Atticus1806 will take over. 