### PR TITLE
FileCache: also trigger cleanup when file exists on disk

### DIFF
--- a/returnn/util/file_cache.py
+++ b/returnn/util/file_cache.py
@@ -390,6 +390,7 @@ class FileCache:
                 #   - https://github.com/rwth-i6/returnn/pull/1709
                 os.utime(dst_filename, None)
                 os.utime(info_file_name, None)
+                self.cleanup(need_at_least_free_space_size=0)
                 return
 
             print(f"FileCache: Copy file {src_filename} to cache")


### PR DESCRIPTION
This prevents excessive disk usage when the `FileCache` has all the files it ever needs, plus additional ones, readily on disk. In that case we would never trigger proactive cleanup (based on `want_free_space_size`), and can end up consuming a large share of the local disk.