### PR TITLE
Update get_tensorflow_version_tuple

### DIFF
--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -557,7 +557,9 @@ def get_tensorflow_version_tuple() -> Tuple[int, ...]:
     import tensorflow as tf  # noqa
     import re
 
-    return tuple([int(re.sub("(-rc[0-9]|-dev[0-9]*)(\\+selfbuilt)?", "", s)) for s in tf.__version__.split(".")])
+    # Remove unwanted suffixes from the TF version string (e.g. "2.20.0-dev0+selfbuilt")
+    filtered_version = [re.sub("(-rc[0-9]|-dev[0-9]*)(\\+selfbuilt)?", "", s) for s in tf.__version__.split(".")]
+    return tuple(int(v) for v in filtered_version)
 
 
 class ReportImportedDevModules:


### PR DESCRIPTION
It seems that if you self-compile TF it will add a `+selfbuilt` string to the version. It should also be filtered out when getting the version tuple.