### PR TITLE
Add the `custom_missing_load_func` functionality to `preload_from_files` in the torch backend

### DIFF
--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -1073,6 +1073,7 @@ class Engine(EngineBase):
                             name=var_name,
                             shape=var_shape,
                             preload_model_state=preload_model_state,
+                            **util.get_fwd_compat_kwargs(),
                         )
                         if var_val is not None:
                             assert var_val.shape == var_shape


### PR DESCRIPTION
This allows to map params which are missing in the checkpoint to other params which exist.