### PR TITLE
Allow some attention matrices to be garbage collected

### DIFF
--- a/returnn/frontend/attention.py
+++ b/returnn/frontend/attention.py
@@ -483,7 +483,7 @@ class RelPosSelfAttention(SelfAttentionBase):
         matrix_bd = _rel_pos_enc_shift(matrix_bd, axis, pos_emb_spatial_dim, hist_dim)
 
         scores = matrix_ac + matrix_bd  # (batch, head, time1, time2)
-        matrix_ac = matrix_bd = None  # possibly free memory
+        del matrix_ac, matrix_bd
         scores *= self.key_dim_per_head.dimension**-0.5
         att_weights = rf.softmax(scores, axis=hist_dim)
         att_weights = rf.dropout(att_weights, self.att_dropout, axis=self.att_dropout_broadcast and hist_dim)

--- a/returnn/frontend/encoder/conformer.py
+++ b/returnn/frontend/encoder/conformer.py
@@ -273,7 +273,7 @@ class ConformerEncoderLayer(rf.Module):
         x_mhsa = self.self_att(x_mhsa_ln, axis=spatial_dim)
         x_mhsa = rf.dropout(x_mhsa, self.dropout, axis=self.dropout_broadcast and self.out_dim)
         x_mhsa_out = x_mhsa + x_ffn1_out
-        x_mhsa = None  # possibly free memory
+        del x_mhsa
 
         # Conv
         x_conv_ln = self.conv_layer_norm(x_mhsa_out)


### PR DESCRIPTION
Somewhat related to issue #1730

Explicitly setting these variables to `None` allows the python garbage collector to free the them and thus decreases memory consumption, otherwise the memory would be (unnecessarily) held until the function returns.

Of course this only works when the matrices don't require grad, during training this PR doesn't do anything.

Theoretically this change could be applied to almost all intermediate result variables, but it would also make the code really ugly. Maybe there should be a different, more general fix? Here I only picked those matrices that had by far the biggest memory footprint in my use case