### PR TITLE
CombinedDataset: fix error start < self.num_seqs

### DIFF
--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -1294,10 +1294,10 @@ class CombinedDataset(CachedDataset2):
         # Cur meaning for the next sequence to be added to dataset_sorted_seq_idx_list.
         seq_idx = self.used_num_seqs_per_subset[dataset_idx]
         cur_start, cur_end = self._sub_dataset_cur_loaded_seq_range[dataset_idx]
-        
+
         if not self.datasets[self.dataset_idx2key_map[dataset_idx]].is_less_than_num_seqs(seq_idx):
             return False
-        
+
         if seq_idx >= cur_end:
             self._sub_dataset_load_seqs(dataset_idx, cur_start, seq_idx + 1)
             return True


### PR DESCRIPTION
When I use the CombinedDataset for training, at the last training step of first epoch, I got the assertion error form this line [assert start < self.num_seqs](https://github.com/rwth-i6/returnn/blob/7603e6349f30c098d8cd0674ff76990d0ad49e4f/returnn/datasets/hdf.py#L236).

I found out that even if the dataset exhausted with `complete_fracs_and_ds_idx` [(1.0, 0), (1.0, 1)] , it still try to load the sequence.  It seems to be this [if condition](https://github.com/rwth-i6/returnn/blob/7603e6349f30c098d8cd0674ff76990d0ad49e4f/returnn/datasets/meta.py#L1345) is somehow wrong,  `self.datasets[self.dataset_idx2key_map[j]].num_seqs` seems to be the num_seqs of whole dataset without epoch partition.

Can't we judge if no dataset has remaining data by simply checking if the complete fraction of all dataset is 1?