### PR TITLE
Fix NumPy array value error in MetaDataset.init_seq_order

### DIFF
--- a/returnn/datasets/meta.py
+++ b/returnn/datasets/meta.py
@@ -406,7 +406,7 @@ class MetaDataset(CachedDataset2):
             self.epoch is None
             or self.epoch != epoch
             or self.seq_list_ordered is None
-            or not self._current_seq_order
+            or (self._current_seq_order is None or len(self._current_seq_order) == 0)
             or seq_list is not None
             or seq_order is not None
             or self.expected_load_seq_start > 0


### PR DESCRIPTION
When configuring a dataset with multiple loading or post-processing workers (`num_data_loading_workers > 1`), `self._current_seq_order` gets distributed as a NumPy array containing sequence indices.

In `MetaDataset.init_seq_order`, evaluating `not self._current_seq_order` attempts to resolve the truth value of a multi-element array, which is ambiguous in NumPy and throws a runtime `ValueError`. This causes the background loader processes to crash.

The current solution is tested.
