### PR TITLE
weakref tensor/dim references in extra

### DIFF
--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -160,6 +160,9 @@ class _DimExtra:
             # noinspection PyTypeChecker
             self.kind = {v.name: v for v in DimTypes.Types}[self.kind]
 
+    def _relink_dim(self, dim: Dim):
+        self._dim_ref = weakref.ref(dim)
+
     def __sis_state__(self):
         raise ValueError(f"{self}: currently not expected to be part of the Sisyphus state/hash")
 
@@ -362,6 +365,19 @@ class _DimMixin:
         slots["_dyn_size_max_value"] = None
         # noinspection PyRedundantParentheses
         return (func, args, (vs, slots), *more_args)
+
+    def __setstate__(self: _d.Dim, state):
+        if isinstance(state, tuple) and len(state) == 2:
+            dict_state, slots_state = state
+        else:
+            dict_state, slots_state = None, state
+        for k, v in (dict_state or {}).items():
+            setattr(self, k, v)
+        for k, v in (slots_state or {}).items():
+            setattr(self, k, v)
+        extra = getattr(self, "_extra", None)
+        if extra is not None:
+            extra._relink_dim(self)
 
     def copy(self, same_as_self=True, description=None, kind=None, match_priority=None):
         """

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -85,7 +85,7 @@ class _DimExtra:
         :param src_data:
         :param src_axis:
         """
-        self.dim = dim
+        self._dim_ref = weakref.ref(dim)
         assert kind is None or (isinstance(kind, Entity) and kind in DimTypes.Types)
         self.kind = kind
         if vocab:
@@ -131,6 +131,15 @@ class _DimExtra:
         self.cache_dyn_size_ext_dev: Dict[str, _t.Tensor] = {}  # device -> dyn_size_ext
         self.cache_seq_mask: Dict[Tuple[str, Optional[Tuple[Dim, ...]]], _t.Tensor] = {}  # (dev,dim_order) -> seq_mask
         self.cache_dim_math = _CacheDimMath()  # op (add,sub,...), operand -> Dim
+    
+    @property
+    def dim(self) -> Optional[Dim]:
+        ref = self._dim_ref
+        return ref() if ref is not None else None
+    
+    @dim.setter
+    def dim(self, dim: Optional[Dim]):
+        self._dim_ref = weakref.ref(dim) if dim is not None else None
 
     def __getstate__(self):
         d = vars(self).copy()
@@ -140,10 +149,13 @@ class _DimExtra:
         d["cache_seq_mask"] = {}
         d["cache_dim_math"] = {}
         d["kind"] = self.kind.name if self.kind else None
+        d.pop("_dim_ref", None)
         return d
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        if "_dim_ref" not in self.__dict__:
+            self._dim_ref = None
         if self.kind is not None:
             # noinspection PyTypeChecker
             self.kind = {v.name: v for v in DimTypes.Types}[self.kind]

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -379,6 +379,7 @@ class _DimMixin:
         for k, v in (slots_state or {}).items():
             setattr(self, k, v)
         if self._extra is not None:
+            # noinspection PyProtectedMember
             self._extra._relink_dim(self)
 
     def copy(self, same_as_self=True, description=None, kind=None, match_priority=None):

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -375,9 +375,8 @@ class _DimMixin:
             setattr(self, k, v)
         for k, v in (slots_state or {}).items():
             setattr(self, k, v)
-        extra = getattr(self, "_extra", None)
-        if extra is not None:
-            extra._relink_dim(self)
+        if self._extra is not None:
+            self._extra._relink_dim(self)
 
     def copy(self, same_as_self=True, description=None, kind=None, match_priority=None):
         """

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -155,7 +155,7 @@ class _DimExtra:
         d.pop("_dim_ref", None)
         return d
 
-def __setstate__(self, state):
+    def __setstate__(self, state):
         self.__dict__.update(state)
         # Backwards compat: older pickles had a strong "dim" attribute.
         dim = self.__dict__.pop("dim", None)
@@ -163,6 +163,7 @@ def __setstate__(self, state):
             self._dim_ref = weakref.ref(dim)
         elif "_dim_ref" not in self.__dict__:
             self._dim_ref = None
+
         if self.kind is not None:
             # noinspection PyTypeChecker
             self.kind = {v.name: v for v in DimTypes.Types}[self.kind]

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -155,14 +155,17 @@ class _DimExtra:
         d.pop("_dim_ref", None)
         return d
 
-    def __setstate__(self, state):
+def __setstate__(self, state):
         self.__dict__.update(state)
-        if "_dim_ref" not in self.__dict__:
+        # Backwards compat: older pickles had a strong "dim" attribute.
+        dim = self.__dict__.pop("dim", None)
+        if dim is not None:
+            self._dim_ref = weakref.ref(dim)
+        elif "_dim_ref" not in self.__dict__:
             self._dim_ref = None
         if self.kind is not None:
             # noinspection PyTypeChecker
             self.kind = {v.name: v for v in DimTypes.Types}[self.kind]
-
     def _relink_dim(self, dim: Dim):
         self._dim_ref = weakref.ref(dim)
 

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -134,6 +134,9 @@ class _DimExtra:
 
     @property
     def dim(self) -> Optional[Dim]:
+        """
+        :return: the parent Dim (weakref deref), or None if it was collected
+        """
         ref = self._dim_ref
         return ref() if ref is not None else None
 
@@ -377,6 +380,7 @@ class _DimMixin:
             setattr(self, k, v)
         extra = getattr(self, "_extra", None)
         if extra is not None:
+            # noinspection PyProtectedMember
             extra._relink_dim(self)
 
     def copy(self, same_as_self=True, description=None, kind=None, match_priority=None):

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -131,12 +131,12 @@ class _DimExtra:
         self.cache_dyn_size_ext_dev: Dict[str, _t.Tensor] = {}  # device -> dyn_size_ext
         self.cache_seq_mask: Dict[Tuple[str, Optional[Tuple[Dim, ...]]], _t.Tensor] = {}  # (dev,dim_order) -> seq_mask
         self.cache_dim_math = _CacheDimMath()  # op (add,sub,...), operand -> Dim
-    
+
     @property
     def dim(self) -> Optional[Dim]:
         ref = self._dim_ref
         return ref() if ref is not None else None
-    
+
     @dim.setter
     def dim(self, dim: Optional[Dim]):
         self._dim_ref = weakref.ref(dim) if dim is not None else None

--- a/returnn/tensor/_dim_extra.py
+++ b/returnn/tensor/_dim_extra.py
@@ -167,6 +167,7 @@ class _DimExtra:
         if self.kind is not None:
             # noinspection PyTypeChecker
             self.kind = {v.name: v for v in DimTypes.Types}[self.kind]
+
     def _relink_dim(self, dim: Dim):
         self._dim_ref = weakref.ref(dim)
 

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -91,7 +91,7 @@ class _TensorExtra:
         d.pop("_tensor_ref", None)
         return d
 
-def __setstate__(self, state):
+    def __setstate__(self, state):
         self.__dict__.update(state)
         # Backwards compat: older pickles had a strong "tensor" attribute.
         tensor = self.__dict__.pop("tensor", None)
@@ -99,6 +99,7 @@ def __setstate__(self, state):
             self._tensor_ref = weakref.ref(tensor)
         elif "_tensor_ref" not in self.__dict__:
             self._tensor_ref = None
+
     def _relink_tensor(self, tensor: Tensor):
         self._tensor_ref = weakref.ref(tensor)
 

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -6,6 +6,7 @@ or just rarely used attribs, such that we can save memory for the common case.
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Union, Type, Sequence, Tuple, List, Dict, Set
 import os
+import weakref
 
 if TYPE_CHECKING:
     # Those are only used for TensorFlow, or they are deprecated.
@@ -46,7 +47,7 @@ class _TensorExtra:
             such that it represents the merged dims [batch, beam_size].
         :param ControlFlowContext|None control_flow_ctx:
         """
-        self.tensor = tensor
+        self._tensor_ref = weakref.ref(tensor)
         if beam and batch:
             assert batch.beam == beam
         self.batch = batch
@@ -69,10 +70,34 @@ class _TensorExtra:
             raise TypeError(f"unexpected time_dim_axis type {type(time_dim_axis)}")
         self.time_dim_axis = time_dim_axis
 
+    @property
+    def tensor(self) -> Optional[Tensor]:
+        """
+        :return: the parent :class:`Tensor` this ``_extra`` belongs to, or None if it was already collected.
+            In normal operation the parent is always alive (the ``_extra`` is only reachable via
+            ``Tensor._extra``), so this returns a valid tensor. It can be None only on an ``_extra``
+            instance that was just unpickled/deepcopied and not yet re-linked to its parent.
+        """
+        ref = self._tensor_ref
+        return ref() if ref is not None else None
+
+    @tensor.setter
+    def tensor(self, tensor: Optional[Tensor]):
+        self._tensor_ref = weakref.ref(tensor) if tensor is not None else None
+
     def __getstate__(self):
-        d = vars(self)
-        d["batch"] = None  # BatchInfo pickling not supported
+        d = vars(self).copy()
+        d["batch"] = None
+        d.pop("_tensor_ref", None)
         return d
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if "_tensor_ref" not in self.__dict__:
+            self._tensor_ref = None
+
+    def _relink_tensor(self, tensor: Tensor):
+        self._tensor_ref = weakref.ref(tensor)
 
 
 class _TensorMixin(_TensorMixinBase):
@@ -599,6 +624,9 @@ class _TensorMixin(_TensorMixinBase):
     def __setstate__(self, state):
         for k, v in state.items():
             setattr(self, k, v)
+
+        if self._extra is not None:
+            self._extra._relink_tensor(self)
 
     def reset(self: Tensor):
         """

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -626,6 +626,7 @@ class _TensorMixin(_TensorMixinBase):
             setattr(self, k, v)
 
         if self._extra is not None:
+            # noinspection PyProtectedMember
             self._extra._relink_tensor(self)
 
     def reset(self: Tensor):

--- a/returnn/tensor/_tensor_extra.py
+++ b/returnn/tensor/_tensor_extra.py
@@ -91,11 +91,14 @@ class _TensorExtra:
         d.pop("_tensor_ref", None)
         return d
 
-    def __setstate__(self, state):
+def __setstate__(self, state):
         self.__dict__.update(state)
-        if "_tensor_ref" not in self.__dict__:
+        # Backwards compat: older pickles had a strong "tensor" attribute.
+        tensor = self.__dict__.pop("tensor", None)
+        if tensor is not None:
+            self._tensor_ref = weakref.ref(tensor)
+        elif "_tensor_ref" not in self.__dict__:
             self._tensor_ref = None
-
     def _relink_tensor(self, tensor: Tensor):
         self._tensor_ref = weakref.ref(tensor)
 


### PR DESCRIPTION
## Summary
### weakref the `_extra` -> parent ref to break `Tensor`/`_TensorExtra` and `Dim`/`_DimExtra` cycles

`_TensorExtra`/`_DimExtra` held a strong back-ref to their parent (`_extra.tensor` / `_extra.dim`), forming a `parent <-> _extra` cycle. Cyclic objects can't be refcount-freed, so the wrapped CUDA tensors lived until the next GC pass. This makes the ref a weakref-backed property (`_tensor_ref` / `_dim_ref`), so the parent frees immediately when its last external strong ref drops.

Any RETURNN-frontend-based training that allocates enough cycle-trapped CUDA tensors per step, over a long enough run, may hit it (the more `Tensor`s per step, the faster). An `rf` model (12-layer Conformer encoder, causal Transformer decoder) on H100 allocated CUDA memory up without bound and OOM-killed at 91 GB allocated after about 18.5k steps. Runs of the same model with fewer sequences per step or with the per-step `gc.collect()` workaround stay flat. Particularly, during A/B tests I found out that memory usage scaled polynomially with decoder sequence length. The encoder didn't cause memory leaks.

`Dim` has the same structural cycle, however, it pins no large tensors, so it never drove the OOM but is fixed for consistency.

## Safety
An `_extra` is only reachable via its own parent (`parent._extra`). So any reader of `_extra.tensor`/`_extra.dim` already holds the parent alive -> the weakref is always live at read sites. It can only return `None` in the post-unpickle window.

## Pickling asymmetry (deliberate)
Weakrefs aren't picklable. Tensor re-links: `_TensorMixin.__setstate__` calls `_extra._relink_tensor(self)` once the parent exists (child `__setstate__` runs first, so a dead ref is installed meanwhile). Dim does not re-link: `_DimExtra.dim` stays `None` after a round-trip, justified by having no readers after construction.

## Testing
RF-based end-to-end speech LLM training run:
- before: 91 GB by ~18k steps then OOM
- after: flat across 1630 steps (gc totals bounded at 1.45 / 1.94 GB; RETURNN alloc 1.9 GB / reserved peak 5.1 GB). `gc.get_referrers()` shows live `Dim`/`Tensor` held only by ordinary caches.
